### PR TITLE
[rosidlparser]Wrap the rosidl_parser into JavaScript

### DIFF
--- a/example/rosidl-parse-msg-example.js
+++ b/example/rosidl-parse-msg-example.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const parser = require('../rosidl_parser/rosidl_parser.js');
+
+const rosInstallPath = process.env.AMENT_PREFIX_PATH;
+const packageName = 'std_msgs';
+const packagePath = rosInstallPath + '/share/std_msgs/msg/ColorRGBA.msg';
+
+parser.parseMessageFile(packageName, packagePath).then((spec) => {
+  console.log(`msg name: ${spec.msgName}`);
+
+  console.log('fields includes:');
+  spec.fields.forEach((field) => {
+    console.log(field);
+  });
+}).catch((e) => {
+  console.log(e);
+});

--- a/example/rosidl-parse-srv-example.js
+++ b/example/rosidl-parse-srv-example.js
@@ -1,0 +1,38 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const parser = require('../rosidl_parser/rosidl_parser.js');
+
+const rosInstallPath = process.env.AMENT_PREFIX_PATH;
+const packageName = 'std_srvs';
+const packagePath = rosInstallPath + '/share/std_srvs/srv/SetBool.srv';
+
+parser.parseServiceFile(packageName, packagePath).then((spec) => {
+  console.log(`srv name: ${spec.srvName}`);
+  console.log(`pkg name: ${spec.pkgName}`);
+
+  console.log('srv request fields includes:');
+  spec.request.fields.forEach((field) => {
+    console.log(field);
+  });
+
+  console.log('srv response fields includes:');
+  spec.response.fields.forEach((field) => {
+    console.log(field);
+  });
+}).catch((e) => {
+  console.log(e);
+});

--- a/rosidl_parser/parser.py
+++ b/rosidl_parser/parser.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2017 Intel Corporation. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import json
+
+import rosidl_parser
+
+def get_json_object_from_base_type_object(base_type_obj):
+     return {'pkgName': base_type_obj.pkg_name, 'type': base_type_obj.type,
+         'stringUpperBound': base_type_obj.string_upper_bound, 'isPrimitiveType': base_type_obj.is_primitive_type()}
+
+def get_json_object_from_type_object(type_obj):
+    json_obj = {'isArray': type_obj.is_array,
+        'arraySize': type_obj.array_size, 'isUpperBound': type_obj.is_upper_bound,
+        'isDynamicArray': type_obj.is_dynamic_array(), 'isFixedSizeArray': type_obj.is_fixed_size_array()}
+    json_obj.update(get_json_object_from_base_type_object(type_obj))
+    return json_obj
+
+def get_json_object_from_msg_spec_object(msg_spec_object):
+    fields = []
+    for field in msg_spec_object.fields:
+        dict_field = {'name': field.name}
+        dict_field['type'] = get_json_object_from_type_object(field.type)
+        fields.append(dict_field)
+
+    constants = []
+    for constant in msg_spec_object.constants:
+        constants.append({'type': constant.type, 'name': constant.type, 'value': constant.value})
+
+    msg_name = {'msgName': msg_spec_object.msg_name}
+    json_obj = {'constants': constants, 'fields': fields, 'baseType': get_json_object_from_base_type_object(msg_spec_object.base_type),
+        'msgName': msg_spec_object.msg_name}
+
+    return json_obj
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print ('Wrong number of argments')
+        sys.exit(1)
+    try:
+        parser_method = getattr(rosidl_parser, sys.argv[1])
+        spec = parser_method(sys.argv[2], sys.argv[3])
+
+        if sys.argv[1] == 'parse_message_file':
+            json_obj = get_json_object_from_msg_spec_object(spec)
+        elif sys.argv[1] == 'parse_service_file':
+            json_obj = {'pkgName': spec.pkg_name, 'srvName': spec.srv_name,
+                'request': get_json_object_from_msg_spec_object(spec.request),
+                'response': get_json_object_from_msg_spec_object(spec.response)}
+        else:
+            assert False, "unknown method '%s'" % sys.argv[1]
+
+        print (json.dumps(json_obj))
+        sys.exit(0)
+
+    except Exception as e:
+        print (str(e), file=sys.stderr)
+        sys.exit(1)

--- a/rosidl_parser/rosidl_parser.js
+++ b/rosidl_parser/rosidl_parser.js
@@ -1,0 +1,49 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const exec = require('child_process').exec;
+
+let rosidlParser = {
+  parseMessageFile(packageName, filePath) {
+    return this._parseFile('parse_message_file', packageName, filePath);
+  },
+
+  parseServiceFile(packageName, filePath) {
+    return this._parseFile('parse_service_file', packageName, filePath);
+  },
+
+  _parseFile(...args) {
+    return new Promise((resolve, reject) => {
+      exec(this._assembleCommand(args), (err, stdout, stderr) => {
+        if (err) {
+          reject(new Error(stderr));
+        } else {
+          resolve(JSON.parse(stdout));
+        }
+      });
+    });
+  },
+
+  _assembleCommand(args) {
+    let command = `python3 ${__dirname}/parser.py`;
+    args.forEach((arg) => {
+      command += ' ' + arg;
+    });
+    return command;
+  }
+};
+
+module.exports = rosidlParser;


### PR DESCRIPTION
This patch simply realized to wrap the rosidl_parser and exposed the
final result as JavaScript object.

Calling the rosidl_parser in node.js to get the python object
as result, then wrapped the result to a JSON object and serialized it
to a string. The string will be deserialized to JSON object in
the JavaScript at least.

There are two examples to illustrate the usage. One shows how to parse
the message file (.msg), the other shows how to parse the service file
(.srv).