### PR TITLE
[eslint]Ignore the length of comment line

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@ rules:
   indent: [2, 2]
   key-spacing: [2, { beforeColon: false, afterColon: true }]
   max-depth: [1, 3]
-  max-len: [1, 80, 4]
+  max-len: ["error", {"code": 80, "tabWidth": 4, "ignoreComments": true}]
   max-nested-callbacks: [1, 3]
   no-cond-assign: 2
   no-constant-condition: 2
@@ -32,7 +32,7 @@ rules:
   no-throw-literal: 2
   no-underscore-dangle: 0
   quote-props: [2, "as-needed"]
-  quotes: [2, "single", "avoid-escape"]
+  quotes: [2, "single", {"avoidEscape": true}]
   radix: 2
   semi-spacing: [2, {before: false, after: true}]
   semi: [2, "always"]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "install": "node-gyp rebuild",
-    "lint": "eslint index.js cpplint.js lib example && node cpplint.js"
+    "lint": "eslint --max-warnings=0 index.js cpplint.js lib example rosidl_parser && node cpplint.js"
   },
   "author": [
     "Minggang Wang <minggang.wang@intel.com>",


### PR DESCRIPTION
Configure the eslint to ignore all trailing comments and comments on
their own line, and treate all warnings as errors.