### PR TITLE
[subscription]Ensure to pass the correct variable when receiving messages

### DIFF
--- a/example/subscription-example.js
+++ b/example/subscription-example.js
@@ -23,10 +23,11 @@ const {message} = rclnodejs;
 rclnodejs.init().then(() => {
   let node = rclnodejs.createNode('subscription_example_node');
 
-  let messageType = message.getMessageType('std_msgs', 'msg', 'Int32');
+  let messageType = message.getMessageType('std_msgs', 'msg', 'String');
   let Message = message.getMessageClass(messageType);
+  messageType.Message = Message;
 
-  node.createSubscription(messageType, Message, 'topic', (msg) => {
+  node.createSubscription(messageType, 'topic', (msg) => {
     console.log(`Receive message: ${msg.data}`);
   });
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -39,7 +39,7 @@ class Node {
     });
 
     this._subscriptions.forEach((subscription) => {
-      let success = rclnodejs.rclTake(subscription.handle, subscription.rosMsg);
+      let success = rclnodejs.rclTake(subscription.handle, subscription.takenMsg);
       if (success) {
         subscription.processResponse(subscription.rosMsg);
       }

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -18,31 +18,34 @@ const rclnodejs = require('bindings')('rclnodejs');
 const generator = require('../rosidl_gen/generator.js');
 
 class Subscription {
-  constructor(handle, messageType, message, topic, callback) {
+  constructor(handle, messageType, topic, callback) {
     this._handle = handle;
-    this._messageType = messageType,
     this._topic = topic;
     this._callback = callback;
-    this._Message = message;
-    this._rosMsg = new message();
+    this._Message = messageType.Message;
+    this._rosMsg = new messageType.Message();
   }
 
   get handle() {
     return this._handle;
   }
 
-  get rosMsg() {
+  get takenMsg() {
     return this._Message.getRefBuffer(this._rosMsg);
+  }
+
+  get rosMsg() {
+    return this._rosMsg;
   }
 
   processResponse(response) {
     this._callback(response);
   }
 
-  static createSubscription(node, messageType, message, topic, callback) {
+  static createSubscription(node, messageType, topic, callback) {
     let handle = rclnodejs.createSubscription(node._handle, messageType.pkgName,
         messageType.msgSubfolder, messageType.msgName, topic);
-    return new Subscription(handle, messageType, message, topic, callback);
+    return new Subscription(handle, messageType, topic, callback);
   }
 };
 

--- a/src/handle_manager.cpp
+++ b/src/handle_manager.cpp
@@ -73,6 +73,10 @@ bool HandleManager::AddHandlesToWaitSet(rcl_wait_set_t* wait_set) {
     if (rcl_wait_set_add_timer(wait_set, timer) != RCL_RET_OK)
       return false;
   }
+  for (auto& subscription : subscriptions_) {
+    if (rcl_wait_set_add_subscription(wait_set, subscription) != RCL_RET_OK)
+      return false;
+  }
   return true;
 }
 


### PR DESCRIPTION
The current implementation used wrong variable to pass, when it called the
callback function.

This patch fixed the problem and made other small changes to make the
code reasonable.