### PR TITLE
Add function to create rosidl_service_type_support_t*

### DIFF
--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -177,8 +177,8 @@ NAN_METHOD(CreateSubscription) {
 
   rcl_subscription_options_t subscription_ops =
       rcl_subscription_get_default_options();
-  const rosidl_message_type_support_t* ts = GetMessageTypeSupportByMessageType(
-      package_name, message_sub_folder, message_name);
+  const rosidl_message_type_support_t* ts =
+      GetMessageTypeSupport(package_name, message_sub_folder, message_name);
 
   THROW_ERROR_IF_NOT_EQUAL(
       RCL_RET_OK,
@@ -234,8 +234,8 @@ NAN_METHOD(CreatePublisher) {
   *publisher = rcl_get_zero_initialized_publisher();
 
   // Get type support object dynamically
-  const rosidl_message_type_support_t* ts = GetMessageTypeSupportByMessageType(
-      package_name, message_sub_folder, message_name);
+  const rosidl_message_type_support_t* ts =
+      GetMessageTypeSupport(package_name, message_sub_folder, message_name);
 
   // Using default options
   rcl_publisher_options_t publisher_ops = rcl_publisher_get_default_options();

--- a/src/rcl_utilities.hpp
+++ b/src/rcl_utilities.hpp
@@ -18,13 +18,18 @@
 #define RCLNODEJS_RCL_UTILITIES_HPP_
 
 class rosidl_message_type_support_t;
+class rosidl_service_type_support_t;
 
 namespace rclnodejs {
 
-const rosidl_message_type_support_t* GetMessageTypeSupportByMessageType(
+const rosidl_message_type_support_t* GetMessageTypeSupport(
     const std::string& package_name,
     const std::string& sub_folder,
     const std::string& msg_name);
+
+const rosidl_service_type_support_t* GetServiceTypeSupport(
+    const std::string& package_name,
+    const std::string& service_name);
 
 }  // namespace rclnodejs
 


### PR DESCRIPTION
When we are creating client/service in ROS2 through rcl library, we must
get variable of type rosidl_service_type_support_t* to initialize them. This
patch adds the interface, which can get rosidl_service_type_support_t* by
the service package name and service name.