### PR TITLE
[rosidl_gen]Change the interface of generator

### DIFF
--- a/example/publisher-example.js
+++ b/example/publisher-example.js
@@ -18,16 +18,15 @@
 'use strict';
 
 const rclnodejs = require('../index.js');
-const {message} = rclnodejs;
 
 rclnodejs.init().then(() => {
   const node = rclnodejs.createNode('publisher_example_node');
 
-  const messageType = message.getMessageType('std_msgs', 'msg', 'String');
-  const publisher = node.createPublisher(messageType, 'topic');
-
-  const StringMessage = message.getMessageClass(messageType);
-  var msg = new StringMessage();
+  /* eslint-disable */
+  let std_msgs = rclnodejs.require('std_msgs');
+  const publisher = node.createPublisher(std_msgs.String, 'topic');
+  let msg = new std_msgs.String();
+  /* eslint-enable */
 
   let counter = 0;
   setInterval(function() {
@@ -35,7 +34,7 @@ rclnodejs.init().then(() => {
     console.log('Publishing message:', str);
 
     msg.data = str;
-    publisher.publish(StringMessage.getRefBuffer(msg));
+    publisher.publish(msg);
   }, 10);
 
   rclnodejs.spin(node);

--- a/example/subscription-example.js
+++ b/example/subscription-example.js
@@ -18,18 +18,17 @@
 'use strict';
 
 const rclnodejs = require('../index.js');
-const {message} = rclnodejs;
 
 rclnodejs.init().then(() => {
   let node = rclnodejs.createNode('subscription_example_node');
 
-  let messageType = message.getMessageType('std_msgs', 'msg', 'String');
-  let Message = message.getMessageClass(messageType);
-  messageType.Message = Message;
+  /* eslint-disable */
+  let std_msgs = rclnodejs.require('std_msgs');
 
-  node.createSubscription(messageType, 'topic', (msg) => {
+  node.createSubscription(std_msgs.String, 'topic', (msg) => {
     console.log(`Receive message: ${msg.data}`);
   });
+  /* eslint-enable */
 
   rclnodejs.spin(node);
 });

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@
 const rclnodejs = require('bindings')('rclnodejs');
 const Node = require('./lib/node.js');
 const generator = require('./rosidl_gen/generator.js');
+const packages = require('./rosidl_gen/packages.js');
 
 function inherits(target, source) {
   let properties = Object.getOwnPropertyNames(source.prototype);
@@ -66,7 +67,7 @@ let rcl = {
         return;
       }
 
-      this.message.generateAll().then((all) => {
+      generator.generateAll().then((all) => {
         this._allMessageType = all;
         this._messageGenerated = true;
         resolve();
@@ -98,7 +99,17 @@ let rcl = {
     this._initialized = false;
   },
 
-  message: generator,
+  require(packageName, interfaceName) {
+    // TODO(minggang): Can require by a single interface name instead of the
+    // whole package.
+    let interfaceInfos = packages.loadInterfaceInfos(packageName);
+    let pkg = {};
+
+    interfaceInfos.forEach((info) => {
+      Object.defineProperty(pkg, info.name, {value: require(info.filePath)});
+    });
+    return pkg;
+  }
 };
 
 module.exports = rcl;

--- a/lib/node.js
+++ b/lib/node.js
@@ -66,16 +66,14 @@ class Node {
     return timer;
   }
 
-  createPublisher(messageType, topicName) {
-    let publisher = Publisher.createPublisher(this._handle,
-        messageType, topicName);
+  createPublisher(typeClass, topic) {
+    let publisher = Publisher.createPublisher(this._handle, typeClass, topic);
     this._publishers.push(publisher);
     return publisher;
   }
 
-  createSubscription(messageType, message, topic, callback) {
-    let subscription = Subscription.createSubscription(this, messageType, message, topic,
-                                                       callback);
+  createSubscription(typeClass, topic, callback) {
+    let subscription = Subscription.createSubscription(this._handle, typeClass, topic, callback);
     this._subscriptions.push(subscription);
     return subscription;
   }

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -21,13 +21,15 @@ class Publisher {
   /**
    * Represents a ROS Publisher
    * @constructor
-   * @param {RclHandle} handle - A RclHandle object created by createPublisher
-   * @param {Object} messageType - the type of the topic, {pkgName: ..., msgSubfolder: ..., msgName: ...}
-   * @param {string} topic - the name of the topic
+   * @param {RclHandle} publisherHandle - A RclHandle object of publisher.
+   * @param {RclHandle} nodeHandle - A RclHandle object of node.
+   * @param {Object} typeClass - The class of the topic message.
+   * @param {string} topic - The name of the topic.
    */
-  constructor(handle, messageType, topic) {
-    this._handle = handle;
-    this._messageType = messageType;
+  constructor(publisherHandle, nodeHandle, typeClass, topic) {
+    this._handle = publisherHandle;
+    this._nodeHandle = nodeHandle;
+    this._typeClass = typeClass;
     this._topic = topic;
   }
 
@@ -45,31 +47,24 @@ class Publisher {
 
   /**
    * Publish a message
-   * @param {Buffer} message - A Node.js buffer object, representing the message to be published.
-   * @return {undefined}
+   * @param {Object} message - An object of the topic message.
+   * @return {void}
    */
   publish(message) {
-    let msg;
-    if (message instanceof Buffer) {
-      msg = message;
-    } else if (typeof message.getBuffer === 'function') {
-      msg = message.getBuffer();
-    }  // TODO(kenny): check messageType and convert raw values to a ros message
-
-    if (msg) {
-      rclnodejs.publishMessage(this._handle, msg);
+    // TODO(minggang): Support to convert a plain JavaScript value/object to a ROS message,
+    // thus we can invoke this function like: publisher.publish('hello world').
+    let rawRosMessage = this._typeClass.getRefBuffer(message);
+    if (rawRosMessage) {
+      rclnodejs.publishMessage(this._handle, rawRosMessage);
     } else {
       debug('Message was not published:', message);
     }
   }
 
-  static createPublisher(node, messageType, topicName) {
-    let handle = rclnodejs.createPublisher(node,
-        messageType.pkgName,
-        messageType.msgSubfolder,
-        messageType.msgName,
-        topicName);
-    return new Publisher(handle, messageType, topicName);
+  static createPublisher(nodeHandle, typeClass, topicName) {
+    let type = typeClass.type();
+    let handle = rclnodejs.createPublisher(nodeHandle, type.pkgName, type.msgSubfolder, type.msgName, topicName);
+    return new Publisher(handle, nodeHandle, typeClass, topicName);
   }
 };
 

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -15,15 +15,15 @@
 'use strict';
 
 const rclnodejs = require('bindings')('rclnodejs');
-const generator = require('../rosidl_gen/generator.js');
 
 class Subscription {
-  constructor(handle, messageType, topic, callback) {
-    this._handle = handle;
+  constructor(subscriptionHandle, nodeHandle, typeClass, topic, callback) {
+    this._handle = subscriptionHandle;
+    this._nodeHandle = nodeHandle;
     this._topic = topic;
     this._callback = callback;
-    this._Message = messageType.Message;
-    this._rosMsg = new messageType.Message();
+    this._typeClass = typeClass;
+    this._rosMsg = new typeClass();
   }
 
   get handle() {
@@ -31,7 +31,7 @@ class Subscription {
   }
 
   get takenMsg() {
-    return this._Message.getRefBuffer(this._rosMsg);
+    return this._typeClass.getRefBuffer(this._rosMsg);
   }
 
   get rosMsg() {
@@ -42,10 +42,11 @@ class Subscription {
     this._callback(response);
   }
 
-  static createSubscription(node, messageType, topic, callback) {
-    let handle = rclnodejs.createSubscription(node._handle, messageType.pkgName,
-        messageType.msgSubfolder, messageType.msgName, topic);
-    return new Subscription(handle, messageType, topic, callback);
+  static createSubscription(nodeHandle, typeClass, topic, callback) {
+    let type = typeClass.type();
+    let handle = rclnodejs.createSubscription(nodeHandle, type.pkgName,
+        type.msgSubfolder, type.msgName, topic);
+    return new Subscription(handle, nodeHandle, typeClass, topic, callback);
   }
 };
 

--- a/rosidl_gen/generator.js
+++ b/rosidl_gen/generator.js
@@ -98,7 +98,8 @@ const generator = {
     } else if (isString([arguments[0], arguments[1], arguments[2]])) {
       file = arguments[0] + '__' + arguments[1] + '__' + arguments[2] + '.js';
     }
-    return require(this.genPath + file);
+    this.genPath = path.join(this.genPath, msgType.pkgName);
+    return require(this.genPath + '/' + file);
   },
 
   generateAll: function() {
@@ -111,10 +112,6 @@ const generator = {
       this.genPath = path.join(__dirname, '../generated/');
     }
 
-    // return removeAllIntermediateMessages(this.genPath).then(() => {
-    //   mkdirp.sync(this.genPath);
-    //   return generateAllMessages(this.scanPath);
-    // });
     mkdirp.sync(this.genPath);
     return generateAllMessages(this.scanPath);
   },

--- a/rosidl_gen/message.js
+++ b/rosidl_gen/message.js
@@ -56,7 +56,7 @@ function __discardGenerateMessageStructure(messageType, spec) {
     types: primitiveTypes,
     json: JSON.stringify(spec, null, '  '),
   }));
-  const fileFolder = path.join(__dirname, '../generated/');
+  const fileFolder = path.join(__dirname, `../generated/${spec.baseType.pkgName}`);
   mkdirp.sync(fileFolder);
   const fileName = fileFolder + className + '.js';
   fs.writeFile(fileName, generated);  // Write to file for reference
@@ -100,6 +100,8 @@ const message = {
       parser.parseMessageFile(messageType.pkgName, packagePath).then((spec) => {
         const code = generateMessageSourceCode(messageType, spec);
         const className = getClassName(messageType, spec);
+        let  generatedFilesDir = path.join(__dirname, `../generated/${spec.baseType.pkgName}/`);
+        mkdirp.sync(generatedFilesDir);
         const fileName = generatedFilesDir + className + '.js';
         return fs.writeFile(fileName, code);
       }).then(() => {

--- a/rosidl_gen/packages.js
+++ b/rosidl_gen/packages.js
@@ -1,0 +1,40 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+const generatedRoot = path.join(__dirname, '../generated/');
+
+let packages = {
+  loadInterfaceInfos(packageName) {
+    let packagePath = path.join(generatedRoot, packageName);
+    // The files under the package folder are limited, so it will not cost too
+    // much time and result in blocking the main thread.
+    // eslint-disable-next-line
+    let files = fs.readdirSync(packagePath);
+    let interfaceInfos = [];
+
+    files.forEach((file) => {
+      let name = file.match(/\w+__(\w+)?.js$/)[1];
+      let filePath = path.join(packagePath, file).normalize();
+      interfaceInfos.push({name, filePath});
+    });
+    return interfaceInfos;
+  }
+};
+
+module.exports = packages;

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -8,7 +8,7 @@
 const StructType = require('ref-struct');
 const ref = require('ref');
 const ArrayType = require('ref-array');
-const primitiveTypes = require('../rosidl_gen/generator_primitive.js');
+const primitiveTypes = require('../../rosidl_gen/generator_primitive.js');
 
 {{
 var className = it.className;
@@ -75,7 +75,7 @@ var calcGeneratorTypeNameFromType = function(type) {
 // TODO: remove duplicated (if any)
 {{~ it.spec.fields :field}}
 {{? shouldRequireType(field.type)}}
-var {{=calcStructTypeName(field.type)}} = require('../generated/{{=calcFileNameFromType(field.type)}}');
+var {{=calcStructTypeName(field.type)}} = require('../../generated/{{=field.type.pkgName}}/{{=calcFileNameFromType(field.type)}}');
 {{?}}
 {{~}}
 
@@ -130,6 +130,10 @@ class {{=className}} {
     primitiveTypes.stringInit(this.__ref_message.{{=field.name}}.ref());
   {{?}}
 {{~}}
+  }
+
+  static type() {
+    return {pkgName: '{{=it.msgType.pkgName}}', msgSubfolder: '{{=it.msgType.msgSubfolder}}', msgName: '{{=it.msgType.msgName}}'};
   }
 
 {{~ it.spec.fields :field}}


### PR DESCRIPTION
This patch made the following changes:
1. Change the path of the .js files generated from the .msg/.srv files,
the location is ./generated/[packageName]
2. Refactor the way of getting the interface class and passing it to the
subscription/publisher.

Fix issue #27