### PR TITLE
Add property to indicate the type in the required package

### DIFF
--- a/example/client-example.js
+++ b/example/client-example.js
@@ -20,9 +20,9 @@ rclnodejs.init().then(() => {
   let node = rclnodejs.createNode('client_example_node');
 
   /* eslint-disable */
-  let example_interfaces = rclnodejs.require('example_interfaces');
-  let client = node.createClient(example_interfaces.AddTwoInts, 'add_two_ints');
-  let request = new example_interfaces.AddTwoInts.Request();
+  let AddTwoInts = rclnodejs.require('example_interfaces').srv.AddTwoInts;
+  let client = node.createClient(AddTwoInts, 'add_two_ints');
+  let request = new AddTwoInts.Request();
   /* eslint-enable */
 
   request.a = 1;

--- a/example/publisher-example.js
+++ b/example/publisher-example.js
@@ -23,9 +23,9 @@ rclnodejs.init().then(() => {
   const node = rclnodejs.createNode('publisher_example_node');
 
   /* eslint-disable */
-  let std_msgs = rclnodejs.require('std_msgs');
-  const publisher = node.createPublisher(std_msgs.String, 'topic');
-  let msg = new std_msgs.String();
+  let String = rclnodejs.require('std_msgs').msg.String;
+  const publisher = node.createPublisher(String, 'topic');
+  let msg = new String();
   /* eslint-enable */
 
   let counter = 0;

--- a/example/service-example.js
+++ b/example/service-example.js
@@ -20,8 +20,8 @@ rclnodejs.init().then(() => {
   let node = rclnodejs.createNode('service_example_node');
 
   /* eslint-disable */
-  let example_interfaces = rclnodejs.require('example_interfaces');
-  let service = node.createService(example_interfaces.AddTwoInts, 'add_two_ints', (request, response) => {
+  let AddTwoInts = rclnodejs.require('example_interfaces').srv.AddTwoInts;
+  let service = node.createService(AddTwoInts, 'add_two_ints', (request, response) => {
     console.log(`Incoming request: requst.a = ${request.a}; request.b = ${request.b}`);
     response.sum = request.a + request.b;
     return response;

--- a/example/subscription-example.js
+++ b/example/subscription-example.js
@@ -23,9 +23,9 @@ rclnodejs.init().then(() => {
   let node = rclnodejs.createNode('subscription_example_node');
 
   /* eslint-disable */
-  let std_msgs = rclnodejs.require('std_msgs');
+  let String = rclnodejs.require('std_msgs').msg.String;
 
-  node.createSubscription(std_msgs.String, 'topic', (msg) => {
+  node.createSubscription(String, 'topic', (msg) => {
     console.log(`Receive message: ${msg.data}`);
   });
   /* eslint-enable */

--- a/index.js
+++ b/index.js
@@ -121,10 +121,10 @@ let rcl = {
     // TODO(minggang): Can require by a single interface name instead of the
     // whole package.
     let interfaceInfos = loader.loadInterfaceInfos(packageName);
-    let pkg = {};
+    let pkg = {srv: {}, msg: {}};
 
     interfaceInfos.forEach((info) => {
-      Object.defineProperty(pkg, info.name, {value: require(info.filePath)});
+      Object.defineProperty(pkg[info.type], info.name, {value: require(info.filePath)});
     });
     return pkg;
   },

--- a/lib/interface_loader.js
+++ b/lib/interface_loader.js
@@ -28,9 +28,11 @@ let interfaceLoader = {
     let interfaceInfos = [];
 
     files.forEach((file) => {
-      let name = file.match(/\w+__(\w+)?.js$/)[1];
+      let results = file.match(/\w+__(\w+)__(\w+).js$/);
+      let type = results[1];
+      let name = results[2];
       let filePath = path.join(packagePath, file).normalize();
-      interfaceInfos.push({name, filePath});
+      interfaceInfos.push({name, type, filePath});
     });
     return interfaceInfos;
   },


### PR DESCRIPTION
In some package, a message(.msg) has the same name with the service(.srv).
e.g. The package 'test_communication', there is a message named 'Empty',
also another 'Empty' in the srv folder.

So, when requiring the interface, we must indicate explicitly which type
is needed, like: rclnodejs.require('test_communication').msg or
rclnodejs.require('test_communication').srv