### PR TITLE
Guarantee the destruction sequence of rcl resource handles

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ let rcl = {
     let node =  new rclnodejs.ShadowNode();
 
     node.init();
-    node._handle = handle;
+    node.handle = handle;
     this._nodes.push(node);
     return node;
   },
@@ -91,9 +91,7 @@ let rcl = {
     if (node.spinning) {
       throw new Error('The node is already spinning.');
     }
-
-    rclnodejs.spin(node);
-    node.spinning = true;
+    node.startSpinning();
   },
 
   /**
@@ -106,6 +104,7 @@ let rcl = {
     }
 
     this._nodes.forEach((node) => {
+      node.stopSpinning();
       node.destroy();
     });
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -24,7 +24,6 @@ const Service = require('./service.js');
 /** Class representing a Node in ROS */
 class Node {
   init() {
-    this._handle = {};
     this._publishers = [];
     this._subscriptions = [];
     this._clients = [];
@@ -56,19 +55,21 @@ class Node {
     });
 
     this._services.forEach((service) => {
-      let header = rclnodejs.rclTakeRequest(service.handle, this._handle, service.takenRequest);
+      let header = rclnodejs.rclTakeRequest(service.handle, this.handle, service.takenRequest);
       if (header) {
         service.processRequest(header);
       }
     });
   }
 
-  handle() {
-    return this._handle;
+  startSpinning() {
+    this.start();
+    this.spinning = true;
   }
 
-  setHandle(handle) {
-    this._handle = handle;
+  stopSpinning() {
+    this.stop();
+    this.spinning = false;
   }
 
   /**
@@ -100,7 +101,7 @@ class Node {
       throw new TypeError('Invalid argument');
     }
 
-    let publisher = Publisher.createPublisher(this._handle, typeClass, topic);
+    let publisher = Publisher.createPublisher(this.handle, typeClass, topic);
     this._publishers.push(publisher);
     return publisher;
   }
@@ -128,7 +129,7 @@ class Node {
       throw new TypeError('Invalid argument');
     }
 
-    let subscription = Subscription.createSubscription(this._handle, typeClass, topic, callback);
+    let subscription = Subscription.createSubscription(this.handle, typeClass, topic, callback);
     this._subscriptions.push(subscription);
     return subscription;
   }
@@ -144,7 +145,7 @@ class Node {
       throw new TypeError('Invalid argument');
     }
 
-    let client = Client.createClient(this._handle, serviceName, typeClass);
+    let client = Client.createClient(this.handle, serviceName, typeClass);
     this._clients.push(client);
     return client;
   }
@@ -172,7 +173,7 @@ class Node {
       throw new TypeError('Invalid argument');
     }
 
-    let service = Service.createService(this._handle, serviceName, typeClass, callback);
+    let service = Service.createService(this.handle, serviceName, typeClass, callback);
     this._services.push(service);
     return service;
   }
@@ -184,34 +185,16 @@ class Node {
    * @return {undefined}
    */
   destroy() {
-    this.stopSpin();
+    if (this.spinning) {
+      this.stopSpinning();
+    }
 
-    this._timers.forEach(function(timer) {
-      timer._handle.destroy();
-    });
+    this.handle.release();
     this._timers = [];
-
-    this._publishers.forEach(function(publisher) {
-      publisher._handle.destroy();
-    });
     this._publishers = [];
-
-    this._subscriptions.forEach(function(subscription) {
-      subscription._handle.destroy();
-    });
     this._subscriptions = [];
-
-    this._clients.forEach(function(client) {
-      client._handle.destroy();
-    });
     this._clients = [];
-
-    this._services.forEach(function(service) {
-      service._handle.destroy();
-    });
     this._services = [];
-
-    this._handle.destroy();
   }
 
   destroyPublisher(publisher) {

--- a/src/handle_manager.cpp
+++ b/src/handle_manager.cpp
@@ -122,7 +122,7 @@ void HandleManager::CollectHandlesByType(
       rclnodejs::RclHandle* rcl_handle =
           rclnodejs::RclHandle::Unwrap<rclnodejs::RclHandle>(
               handle.ToLocalChecked()->ToObject());
-      vec->push_back(reinterpret_cast<T*>(rcl_handle->GetPtr()));
+      vec->push_back(reinterpret_cast<T*>(rcl_handle->ptr()));
     }
   }
 }

--- a/src/shadow_node.hpp
+++ b/src/shadow_node.hpp
@@ -31,8 +31,10 @@ class ShadowNode : public Nan::ObjectWrap,
                    public Executor::Delegate {
  public:
   static void Init(v8::Local<v8::Object> exports);
-  void Spin();
-  void Shutdown();
+  void StartRunning();
+  void StopRunning();
+
+  Nan::Persistent<v8::Object>* rcl_handle() { return rcl_handle_.get(); }
 
   // Executor::Delegate overrides:
   void Execute() override;
@@ -44,10 +46,14 @@ class ShadowNode : public Nan::ObjectWrap,
 
   static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
   static Nan::Persistent<v8::Function> constructor;
-  static NAN_METHOD(StopSpin);
+  static NAN_METHOD(Stop);
+  static NAN_METHOD(Start);
+  static NAN_GETTER(HandleGetter);
+  static NAN_SETTER(HandleSetter);
 
   std::unique_ptr<HandleManager> handle_manager_;
   std::unique_ptr<Executor> executor_;
+  std::unique_ptr<Nan::Persistent<v8::Object>> rcl_handle_;
 };
 
 }  // namespace rclnodejs

--- a/test/test-destruction.js
+++ b/test/test-destruction.js
@@ -45,13 +45,13 @@ describe('Node destroy testing', function() {
     var node = rclnodejs.createNode('my_node3');
     node.destroy();
 
-    var org_handle = node._handle;
-    node._handle = 'garbage'; 
-    try {               
+    var org_handle = node.handle;
+    node.handle = 'garbage';
+    try {
       node.destroy();
     } catch (TypeError) {
       assert.ok(true);
-      node._handle = org_handle;
+      node.handle = org_handle;
       node.destroy();
     }
   });
@@ -104,7 +104,7 @@ describe('Node destroy testing', function() {
       node.handle = 'gargage';
     } catch (Error) {
       assert.ok(true);
-      node.destroy();            
+      node.destroy();
     }
   });
 });

--- a/test/test-init-shutdown.js
+++ b/test/test-init-shutdown.js
@@ -30,7 +30,7 @@ describe('Node destroy testing', function() {
     }).catch(function(err) {
       assert.ok(false);
       done(err);
-    });        
+    });
   });
 
   it('rclnodejs.init() & rclnodejs.shutdown()', function(done) {
@@ -48,7 +48,7 @@ describe('Node destroy testing', function() {
     rclnodejs.init().then(function() {
       rclnodejs.shutdown();
       assert.ok(true);
-    }).then(function() {     
+    }).then(function() {
       assert.ok(true);
       return rclnodejs.init();
     }).then(function() {
@@ -60,12 +60,12 @@ describe('Node destroy testing', function() {
     }).catch(function(err) {
       assert.ok(false);
       done(err);
-    });        
+    });
   });
 
   it('rclnodejs double init', function(done) {
     rclnodejs.init().then(function() {
-      assert.ok(true);    
+      assert.ok(true);
     }).then(function() {
       return rclnodejs.init();
     }).catch(function(err) {

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -34,7 +34,7 @@ describe('rclnodejs node test suite', function() {
       node.destroy();
     });
 
-/* Todo: 
+/* Todo:
 **     need the get_name() and get_namespace() interface.
     it('Try creating a node with a namespace', function() {
       let nodeName = 'example_node_with_ns',

--- a/test/test-rosidl-message-generator.js
+++ b/test/test-rosidl-message-generator.js
@@ -16,7 +16,6 @@
 
 const assert = require('assert');
 const rclnodejs = require('../index.js');
-const {message} = rclnodejs;
 
 describe('ROSIDL Node.js message generator test suite', function() {
   before(function() {


### PR DESCRIPTION
When we terminate the node instance intentionally or any type of the
handle is recycled, we have to ensure that the destruction sequence
of these handles. Handles, which include
publisher/subscription/client/service, must be freed before the node
it attached.

This patch designed a mechanism that each handle has a parent and some
children, and when the handle itself is going to be destructed, it will
notify its parent the event, then free its children. According the ROS
system, usually the parent handle is a node, the children are
publisher/subscription/client/service.

In conclusion, either we released the handle of the node explicitly
or the GC of v8 recycled any kind of the handle, the handle of the node
will always the last one to be destructed, which lets the whole process
quit correctly.

Fix #33