### PR TITLE
Throw an error when double init/shutdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,8 +74,7 @@ let rcl = {
           reject(e);
         });
       } else {
-        console.log('Warning - rclnodejs is already initialized. These arguments will be ignored:', args);
-        resolve();
+        throw new Error('The module rclnodejs has been initialized.');
       }
     });
   },
@@ -102,6 +101,10 @@ let rcl = {
    * @return {undefined}
    */
   shutdown() {
+    if (!this._initialized) {
+      throw new Error('The module rclnodejs has been shut.');
+    }
+
     this._nodes.forEach((node) => {
       node.destroy();
     });


### PR DESCRIPTION
Currently, the rclnodejs doesn't reject the promise when it's initialized
two times, and does throw an error when it was shut twice.

To make these two behaviors consistently, this patch implements a strategy,
which will throw an error when init/shutdown are called continuously.

Fix #66