### PR TITLE
Reset the error state after error happened

### DIFF
--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -19,6 +19,7 @@
   { \
     if (lhs op rhs) { \
       Nan::ThrowError(message); \
+      rcl_reset_error(); \
       info.GetReturnValue().Set(Nan::Undefined()); \
       return; \
     } \

--- a/src/rcl_handle.cpp
+++ b/src/rcl_handle.cpp
@@ -102,9 +102,10 @@ void RclHandle::Reset() {
     child->Reset();
   }
 
-  if (deleter_() != RCL_RET_OK)
+  if (deleter_() != RCL_RET_OK) {
     Nan::ThrowError(rcl_get_error_string_safe());
-
+    rcl_reset_error();
+  }
   free(pointer_);
   pointer_ = nullptr;
   children_.clear();


### PR DESCRIPTION
After we call the function rcl_get_error_string_safe(), we have to call
the rcl_reset_error() to clear the state.

Fix #60