### PR TITLE
Make it able to build on Mac

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -62,7 +62,7 @@
           {
             "xcode_settings": {
               "OTHER_CPLUSPLUSFLAGS": [
-                "-std=c++11",
+                "-std=c++14",
                 "-stdlib=libc++"
               ],
               "OTHER_LDFLAGS": [


### PR DESCRIPTION
Make it be able to build, but with execution exception at some cases.
At least timer is able to run on macOS 10.12.6