### PR TITLE
[rosidl_gen]Use ref to generate and initialize the string message

### DIFF
--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -42,7 +42,7 @@ class Publisher extends Entity {
     // thus we can invoke this function like: publisher.publish('hello world').
     let rawRosMessage = message.toRawROS();
     if (rawRosMessage) {
-      rclnodejs.publishMessage(this._handle, rawRosMessage);
+      rclnodejs.publish(this._handle, rawRosMessage);
     } else {
       debug('Message was not published:', message);
     }

--- a/rosidl_gen/generator_primitive.js
+++ b/rosidl_gen/generator_primitive.js
@@ -26,22 +26,14 @@ const rosidl_generator_nodejs__String = StructType({
   capacity: ref.types.size_t,
 });
 
-function bindingsStringInit(buf) {
-  if (! buf instanceof Buffer) {
-    throw new TypeError('Invalid argument: should provide a Node Buffer to bindingsStringInit()');
+function initString(str) {
+  if (! str instanceof rosidl_generator_nodejs__String) {
+    throw new TypeError('Invalid argument: should provide a type of rosidl_generator_nodejs__String');
   }
 
-  return rclnodejs.rosIDLStringInit(buf);
-}
-
-function bindingsStringAssign(buf, text) {
-  if (! buf instanceof Buffer) {
-    throw new TypeError('Invalid argument: should provide a Node Buffer to bindingsStringInit()');
-  }
-
-  let strPtr = new Buffer(text + '\0');
-  strPtr.type = ref.types.CString;
-  return rclnodejs.rosIDLStringAssign(buf, strPtr);
+  str.data = Buffer.alloc(1).fill('\u0000');
+  str.size = 0;
+  str.capacity = 1;
 }
 
 module.exports = {
@@ -60,8 +52,7 @@ module.exports = {
   byte: ref.types.byte,
 
   string: rosidl_generator_nodejs__String,
-  stringInit: bindingsStringInit,
-  stringAssignFunc: bindingsStringAssign,
+  initString: initString
 };
 
 /* eslint-enable camelcase */

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -127,7 +127,7 @@ class {{=className}} {
 
 {{~ it.spec.fields :field}}
   {{? isString(field.type)}}
-    primitiveTypes.stringInit(this.__ref_message.{{=field.name}}.ref());
+    primitiveTypes.initString(this.__ref_message.{{=field.name}});
   {{?}}
 {{~}}
   }
@@ -157,11 +157,9 @@ class {{=className}} {
 
   set {{=field.name}}(value) {
   {{? isString(field.type)}}
-    {{var handleName = '__handle_' + field.name;}}
-    if (this.__ref_message.{{=handleName}}) {
-      this.__ref_message.{{=handleName}}.dismiss();
-    }
-    this.__ref_message.{{=handleName}} = primitiveTypes.stringAssignFunc(this.__ref_message.{{=field.name}}.ref(), value);
+    this.__ref_message.data.size = value.length;
+    this.__ref_message.data.capacity = value.length + 1;
+    this.__ref_message.data.data = value;
   {{?? isStruct(field.type)}}
     if (!this.__ref_object['{{=field.name}}']) {
       this.__ref_object['{{=field.name}}'] = new {{=calcStructTypeName(field.type)}}();

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -204,33 +204,6 @@ NAN_METHOD(CreateSubscription) {
   info.GetReturnValue().Set(js_obj);
 }
 
-NAN_METHOD(ROSIDLStringInit) {
-  void* buffer = node::Buffer::Data(info[0]->ToObject());
-  rosidl_generator_c__String* ptr =
-      reinterpret_cast<rosidl_generator_c__String*>(buffer);
-
-  rosidl_generator_c__String__init(ptr);
-  info.GetReturnValue().Set(Nan::Undefined());
-}
-
-NAN_METHOD(ROSIDLStringAssign) {
-  void* buffer = node::Buffer::Data(info[0]->ToObject());
-  std::string value(*v8::String::Utf8Value(info[1]));
-  rosidl_generator_c__String* ptr =
-      reinterpret_cast<rosidl_generator_c__String*>(buffer);
-
-  // This call will free the previous allocated C-string
-  bool ret = rosidl_generator_c__String__assign(ptr, value.c_str());
-
-  if (ret) {
-    // We only book the clean-up call, a.k.a. free(),
-    // of the mallocated C-string itself
-    info.GetReturnValue().Set(RclHandle::NewInstance(ptr->data));
-  } else {
-    info.GetReturnValue().Set(Nan::Undefined());
-  }
-}
-
 NAN_METHOD(CreatePublisher) {
   // Extract arguments
   RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(info[0]->ToObject());
@@ -273,7 +246,7 @@ NAN_METHOD(CreatePublisher) {
   info.GetReturnValue().Set(js_obj);
 }
 
-NAN_METHOD(PublishMessage) {
+NAN_METHOD(Publish) {
   rcl_publisher_t* publisher = reinterpret_cast<rcl_publisher_t*>(
       RclHandle::Unwrap<RclHandle>(info[0]->ToObject())->ptr());
 
@@ -484,11 +457,8 @@ BindingMethod binding_methods[] = {
     {"timerGetTimeUntilNextCall", TimerGetTimeUntilNextCall},
     {"rclTake", RclTake},
     {"createSubscription", CreateSubscription},
-    {"rosIDLStringAssign", ROSIDLStringAssign},
-    {"rosIDLStringInit", ROSIDLStringInit},
-
     {"createPublisher", CreatePublisher},
-    {"publishMessage", PublishMessage},
+    {"publish", Publish},
     {"createClient", CreateClient},
     {"rclTakeResponse", RclTakeResponse},
     {"sendRequest", SendRequest},


### PR DESCRIPTION
Before this patch, we bound the JS method to the native method to
initialize and assign the message of a string type. So the overhead
increased.

This patch is using the unicode of '\0' to initialize an empty string
and set the corresponding values of size/capacity, which will also
simplify the case when the message is a string array.

Fix #47