### PR TITLE
[macos]Enable macos build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,75 +1,69 @@
 {
-  "targets": [
+  'targets': [
     {
-      "target_name": "rclnodejs",
-      "variables": {
-        "ROS2_INSTALL_PATH": "<!(echo $AMENT_PREFIX_PATH)",
+      'target_name': 'rclnodejs',
+      'variables': {
+        'ROS2_INSTALL_PATH': '<!(echo $AMENT_PREFIX_PATH)',
       },
-      "sources": [
-        "./src/addon.cpp",
-        "./src/executor.cpp",
-        "./src/handle_manager.cpp",
-        "./src/rcl_bindings.cpp",
-        "./src/rcl_handle.cpp",
-        "./src/rcl_utilities.cpp",
-        "./src/shadow_node.cpp",
+      'sources': [
+        './src/addon.cpp',
+        './src/executor.cpp',
+        './src/handle_manager.cpp',
+        './src/rcl_bindings.cpp',
+        './src/rcl_handle.cpp',
+        './src/rcl_utilities.cpp',
+        './src/shadow_node.cpp',
       ],
-      "include_dirs": [
-        ".",
-        "<!(node -e \"require('nan')\")",
-        "<(ROS2_INSTALL_PATH)/include/",
+      'include_dirs': [
+        '.',
+        '<!(node -e \'require("nan")\')',
+        '<(ROS2_INSTALL_PATH)/include/',
       ],
-      "cflags!": [
-        "-fno-exceptions"
+      'cflags!': [
+        '-fno-exceptions'
       ],
-      "cflags": [
-        "-std=c++11",
-        "-fstack-protector-strong",
-        "-fPIE -fPIC",
-        "-O2 -D_FORTIFY_SOURCE=2",
-        "-Wformat -Wformat-security"
+      'cflags': [
+        '-fstack-protector-strong',
+        '-fPIE -fPIC',
+        '-O2 -D_FORTIFY_SOURCE=2',
+        '-Wformat -Wformat-security'
       ],
-      "cflags_cc!": [
-        "-fno-exceptions"
+      'cflags_cc!': [
+        '-fno-exceptions'
       ],
-      "libraries": [
-        "-lrcl",
-        "-lrcutils",
-        "-L<(ROS2_INSTALL_PATH)/lib"
+      'libraries': [
+        '-lrcl',
+        '-lrcutils',
+        '-L<(ROS2_INSTALL_PATH)/lib'
       ],
-      "xcode_settings": {
-        "OTHER_CFLAGS": [
-          "-std=c++11"
-        ]
-      },
-      "conditions": [
+      'conditions': [
         [
-          "OS!=\"win\"",
-          {
-            "cflags+": [
-              "-std=c++14"
+          'OS=="linux"', {
+            'defines': [
+              'OS_LINUX'
             ],
-            "cflags_c+": [
-              "-std=c++14"
-            ],
-            "cflags_cc+": [
-              "-std=c++14"
+            'cflags_cc': [
+              '-std=c++14'
             ]
           }
         ],
         [
-          "OS==\"mac\"",
+          'OS=="win"',
           {
-            "xcode_settings": {
-              "OTHER_CPLUSPLUSFLAGS": [
-                "-std=c++14",
-                "-stdlib=libc++"
+          }
+        ],
+        [
+          'OS=="mac"',
+          {
+            'defines': [
+              'OS_MACOS'
+            ],
+            'xcode_settings': {
+              'OTHER_CPLUSPLUSFLAGS': [
+                '-std=c++14',
+                '-stdlib=libc++'
               ],
-              "OTHER_LDFLAGS": [
-                "-stdlib=libc++"
-              ],
-              "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-              "MACOSX_DEPLOYMENT_TARGET": "10.8"
+              'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
             }
           }
         ]

--- a/src/rcl_utilities.cpp
+++ b/src/rcl_utilities.cpp
@@ -23,6 +23,12 @@ namespace rclnodejs {
 typedef const rosidl_message_type_support_t* (*GetMessageTypeSupportFunction)();
 typedef const rosidl_service_type_support_t* (*GetServiceTypeSupportFunction)();
 
+#if defined(OS_MACOS)
+const char* lib_ext = ".dylib";
+#elif defined(OS_LINUX)
+const char* lib_ext = ".so";
+#endif
+
 void* GetTypeSupportFunctionByInterfaceSymbolName(
     const std::string& symbol_name,
     const std::string& lib_name) {
@@ -42,7 +48,7 @@ const rosidl_message_type_support_t* GetMessageTypeSupport(
   void* function = GetTypeSupportFunctionByInterfaceSymbolName(
       "rosidl_typesupport_c__get_message_type_support_handle__" + package_name +
           "__" + sub_folder + "__" + msg_name,
-      "lib" + package_name + "__rosidl_typesupport_c.so");
+      "lib" + package_name + "__rosidl_typesupport_c" + lib_ext);
   if (function)
     return reinterpret_cast<GetMessageTypeSupportFunction>(function)();
   else
@@ -55,7 +61,7 @@ const rosidl_service_type_support_t* GetServiceTypeSupport(
   void* function = GetTypeSupportFunctionByInterfaceSymbolName(
       "rosidl_typesupport_c__get_service_type_support_handle__" + package_name +
           "__srv__" + service_name,
-      "lib" + package_name + "__rosidl_typesupport_c.so");
+      "lib" + package_name + "__rosidl_typesupport_c" + lib_ext);
   if (function)
     return reinterpret_cast<GetServiceTypeSupportFunction>(function)();
   else

--- a/src/rcl_utilities.hpp
+++ b/src/rcl_utilities.hpp
@@ -17,8 +17,8 @@
 #ifndef RCLNODEJS_RCL_UTILITIES_HPP_
 #define RCLNODEJS_RCL_UTILITIES_HPP_
 
-class rosidl_message_type_support_t;
-class rosidl_service_type_support_t;
+struct rosidl_message_type_support_t;
+struct rosidl_service_type_support_t;
 
 namespace rclnodejs {
 


### PR DESCRIPTION
This patch enables the node-gyp build on macos platform. The platform
has been tested on:
  macos version 10.11.6
  Xcode version 7.3

Please notice that if you want to run unit test, execute
'node node_modules/.bin/mocha test/test-*.js' instead of 'npm test'.
There is a unit test, test-interactive.js, which will fail, and it will be
resolved in the following patches.

Fix #46