### PR TITLE
[example]Require the desired messages after the rclnodejs has been

### DIFF
--- a/example/publisher-message-example.js
+++ b/example/publisher-message-example.js
@@ -15,11 +15,12 @@
 'use strict';
 
 const rclnodejs = require('../index.js');
-let Header = rclnodejs.require('std_msgs').msg.Header;
-let Time = rclnodejs.require('builtin_interfaces').msg.Time;
-let JointState = rclnodejs.require('sensor_msgs').msg.JointState;
 
 rclnodejs.init().then(() => {
+  let Header = rclnodejs.require('std_msgs').msg.Header;
+  let Time = rclnodejs.require('builtin_interfaces').msg.Time;
+  let JointState = rclnodejs.require('sensor_msgs').msg.JointState;
+
   const node = rclnodejs.createNode('publisher_example_node');
   const publisher = node.createPublisher(JointState, 'JointState');
   let count = 0;

--- a/example/subscription-message-example.js
+++ b/example/subscription-message-example.js
@@ -15,9 +15,9 @@
 'use strict';
 
 const rclnodejs = require('../index.js');
-let JointState = rclnodejs.require('sensor_msgs').msg.JointState;
 
 rclnodejs.init().then(() => {
+  let JointState = rclnodejs.require('sensor_msgs').msg.JointState;
   let node = rclnodejs.createNode('subscription_example_node');
   let count = 0;
 


### PR DESCRIPTION
initialized.

Fix #98