### PR TITLE
[rosidl_gen]Assign the property of string type when being deserialized

### DIFF
--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -214,6 +214,8 @@ class {{=objectWrapper}} {
       wrapper._refObject = this._wrapperFields.{{=field.name}}._refArray[index];
       wrapper.deserialize();
     });
+    {{?? !field.type.isArray && field.type.type === 'string' && it.spec.msgName !== 'String'}}
+    this._wrapperFields.{{=field.name}}.data = this._refObject.{{=field.name}}.data;
     {{?}}
     {{~}}
   }


### PR DESCRIPTION
When we recive a raw memory buffer and deserialize it back to a JavaScript
object, if the message has a property of string type, then we have to
assiagn the value to it when it's being deserialized.

Fix