### PR TITLE
[windows]Enable windows build of rclnodejs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "spdlog"]
 	path = src/third_party/spdlog
 	url = https://github.com/gabime/spdlog.git
+[submodule "src/third_party/dlfcn-win32"]
+	path = src/third_party/dlfcn-win32
+	url = https://github.com/dlfcn-win32/dlfcn-win32.git

--- a/binding.gyp
+++ b/binding.gyp
@@ -16,8 +16,7 @@
       ],
       'include_dirs': [
         '.',
-        '<!(node -e \'require("nan")\')',
-        '<(ROS2_INSTALL_PATH)/include/',
+        "<!(node -e \"require('nan')\")",
       ],
       'cflags!': [
         '-fno-exceptions'
@@ -34,7 +33,6 @@
       'libraries': [
         '-lrcl',
         '-lrcutils',
-        '-L<(ROS2_INSTALL_PATH)/lib'
       ],
       'conditions': [
         [
@@ -42,14 +40,45 @@
             'defines': [
               'OS_LINUX'
             ],
+            'include_dirs': [
+              "<(ROS2_INSTALL_PATH)/include/",
+            ],
             'cflags_cc': [
               '-std=c++14'
-            ]
+            ],
+            'libraries': [
+              '-L<(ROS2_INSTALL_PATH)/lib'
+            ],
           }
         ],
         [
           'OS=="win"',
           {
+            'defines': [
+              'OS_WINDOWS'
+            ],
+            'variables': {
+              "ROS2_INSTALL_PATH_WINDOWS": "<!(echo %AMENT_PREFIX_PATH%)",
+            },
+            'cflags_cc': [
+              '-std=c++14'
+            ],
+            'include_dirs': [
+              './src/third_party/dlfcn-win32/',
+              '<(ROS2_INSTALL_PATH_WINDOWS)/include/',
+            ],
+            'sources': [
+              './src/third_party/dlfcn-win32/dlfcn.c',
+            ],
+            'msvs_settings': {
+              'VCCLCompilerTool': {
+                'ExceptionHandling': '2', # /EHsc
+              },
+              'VCLinkerTool': {
+                'AdditionalDependencies': ['psapi.lib'],
+                'AdditionalLibraryDirectories': ['<(ROS2_INSTALL_PATH_WINDOWS)/lib/'],
+              }
+            }
           }
         ],
         [
@@ -57,6 +86,12 @@
           {
             'defines': [
               'OS_MACOS'
+            ],
+            'include_dirs': [
+              "<(ROS2_INSTALL_PATH)/include/",
+            ],
+            'libraries': [
+              '-L<(ROS2_INSTALL_PATH)/lib'
             ],
             'xcode_settings': {
               'OTHER_CPLUSPLUSFLAGS': [

--- a/rosidl_gen/generator.js
+++ b/rosidl_gen/generator.js
@@ -21,16 +21,19 @@ const path = require('path');
 const parser = require('../rosidl_parser/rosidl_parser.js');
 const packages = require('./packages.js');
 const dot = require('dot');
+const os = require('os');
 
 dot.templateSettings.strip = false;
 dot.log = process.env.RCLNODEJS_LOG_VERBOSE || false;
 const dots = dot.process({path: path.join(__dirname, '../rosidl_gen/templates')});
 
 const generatedRoot = path.join(__dirname, '../generated/');
-const installedPackagesRoot = process.env.AMENT_PREFIX_PATH.split(':');
+const installedPackagesRoot = (os.type() === 'Windows_NT')
+                              ? process.env.AMENT_PREFIX_PATH.split(';')
+                              : process.env.AMENT_PREFIX_PATH.split(':');
 
 function removeExtraSpaceLines(str) {
-  return str.replace(/([ \t]*\n){2,}/g, '\n');
+  return str.replace(/^\s*\n/gm, '');
 }
 
 function removeAllIntermediateFiles(path) {

--- a/rosidl_gen/packages.js
+++ b/rosidl_gen/packages.js
@@ -16,15 +16,22 @@
 
 const path = require('path');
 const walk = require('walk');
+const os = require('os');
 
 const generatedRoot = path.join(__dirname, '../generated/');
 let pkgMap = new Map();
 
 function getPackageName(filePath) {
+  if (os.type() === 'Windows_NT') {
+    filePath = filePath.replace(/\\/g, '/');
+  }
   return filePath.match(/\w+\/share\/(\w+)\//)[1];
 };
 
 function getSubFolder(filePath) {
+  if (os.type() === 'Windows_NT') {
+    filePath = filePath.replace(/\\/g, '/');
+  }
   return filePath.match(/\w+\/share\/\w+\/(\w+)\//)[1];
 }
 

--- a/rosidl_parser/rosidl_parser.js
+++ b/rosidl_parser/rosidl_parser.js
@@ -14,7 +14,10 @@
 
 'use strict';
 
+const os = require('os');
 const exec = require('child_process').exec;
+
+const pythonExe = (os.type() === 'Windows_NT') ? 'python' : 'python3';
 
 let rosidlParser = {
   parseMessageFile(packageName, filePath) {
@@ -38,7 +41,7 @@ let rosidlParser = {
   },
 
   _assembleCommand(args) {
-    let command = `python3 ${__dirname}/parser.py`;
+    let command = `${pythonExe} ${__dirname}/parser.py`;
     args.forEach((arg) => {
       command += ' ' + arg;
     });

--- a/src/rcl_utilities.cpp
+++ b/src/rcl_utilities.cpp
@@ -14,9 +14,15 @@
 
 #include "rcl_utilities.hpp"
 
+#if defined(OS_MACOS) || defined(OS_LINUX)
 #include <dlfcn.h>
+#endif
 #include <rcl/rcl.h>
 #include <string>
+
+#if defined(OS_WINDOWS)
+#include "third_party/dlfcn-win32/dlfcn.h"
+#endif
 
 namespace rclnodejs {
 
@@ -24,9 +30,14 @@ typedef const rosidl_message_type_support_t* (*GetMessageTypeSupportFunction)();
 typedef const rosidl_service_type_support_t* (*GetServiceTypeSupportFunction)();
 
 #if defined(OS_MACOS)
+const char* lib_prefix = "lib";
 const char* lib_ext = ".dylib";
 #elif defined(OS_LINUX)
+const char* lib_prefix = "lib";
 const char* lib_ext = ".so";
+#elif defined(OS_WINDOWS)
+const char* lib_prefix = "";
+const char* lib_ext = ".dll";
 #endif
 
 void* GetTypeSupportFunctionByInterfaceSymbolName(
@@ -48,7 +59,7 @@ const rosidl_message_type_support_t* GetMessageTypeSupport(
   void* function = GetTypeSupportFunctionByInterfaceSymbolName(
       "rosidl_typesupport_c__get_message_type_support_handle__" + package_name +
           "__" + sub_folder + "__" + msg_name,
-      "lib" + package_name + "__rosidl_typesupport_c" + lib_ext);
+      lib_prefix + package_name + "__rosidl_typesupport_c" + lib_ext);
   if (function)
     return reinterpret_cast<GetMessageTypeSupportFunction>(function)();
   else
@@ -61,7 +72,7 @@ const rosidl_service_type_support_t* GetServiceTypeSupport(
   void* function = GetTypeSupportFunctionByInterfaceSymbolName(
       "rosidl_typesupport_c__get_service_type_support_handle__" + package_name +
           "__srv__" + service_name,
-      "lib" + package_name + "__rosidl_typesupport_c" + lib_ext);
+      lib_prefix + package_name + "__rosidl_typesupport_c" + lib_ext);
   if (function)
     return reinterpret_cast<GetServiceTypeSupportFunction>(function)();
   else

--- a/src/shadow_node.cpp
+++ b/src/shadow_node.cpp
@@ -100,7 +100,7 @@ NAN_METHOD(ShadowNode::Stop) {
 
 void ShadowNode::Execute() {
   Nan::HandleScope scope;
-  v8::Local<v8::Value> argv[0];
+  v8::Local<v8::Value> argv[1];
   Nan::MakeCallback(Nan::New(this->persistent()), "execute", 0, argv);
 }
 


### PR DESCRIPTION
This patch enables the node-gyp build on windows platform. The tested
platform is:

    Windows8.1 + VS2015 with Update3

Please reference https://github.com/ros2/ros2/wiki/Windows-Development-Setup
to build ROS2 from source, and you have to checkout master branch of it.

Some kind of interactive unit tests will fail at this stage.

Fix #49