### PR TITLE
Support to pass primitive type directly to publisher/client

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ After building this module, you just need to follow the normal way to use it as 
 
 ```javascript
 const rclnodejs = require('../index.js');
-let String = rclnodejs.require('std_msgs').msg.String;
 
 rclnodejs.init().then(() => {
+  let String = rclnodejs.require('std_msgs').msg.String;
   const node = rclnodejs.createNode('publisher_example_node');
   const publisher = node.createPublisher(String, 'topic');
   let msg = new String();

--- a/example/publisher-qos-example.js
+++ b/example/publisher-qos-example.js
@@ -30,17 +30,13 @@ rclnodejs.init().then(() => {
 
   let String = rclnodejs.require('std_msgs').msg.String;
   const publisher = node.createPublisher(String, 'topic', qos);
-  let msg = new String();
   /* eslint-enable */
 
   let counter = 0;
   setInterval(function() {
-    const str = 'Hello ROS ' + counter++;
-    console.log('Publishing message:', str);
-
-    msg.data = str;
-    publisher.publish(msg);
-  }, 10);
+    console.log(`Publishing message: Hello ROS ${counter}`);
+    publisher.publish(`Hello ROS ${counter++}`);
+  }, 1000);
 
   rclnodejs.spin(node);
 });

--- a/lib/client.js
+++ b/lib/client.js
@@ -48,11 +48,17 @@ class Client extends Entity {
    * @see {@link ResponseCallback}
    */
   sendRequest(request, callback) {
-    if (typeof (request) !== 'object' || typeof (callback) !== 'function') {
+    let rclRequest = request;
+    if (typeof request !== 'object') {
+      rclRequest = new this._typeClass();
+      rclRequest.data = request;
+    }
+    if (typeof (callback) !== 'function') {
       throw new TypeError('Invalid argument');
     }
-    request.serialize();
-    let rawROSRequest = request.toRawROS();
+
+    rclRequest.serialize();
+    let rawROSRequest = rclRequest.toRawROS();
     this._sequenceNumber = rclnodejs.sendRequest(this._handle, rawROSRequest);
     this._callback = callback;
   }

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -44,12 +44,18 @@ class Publisher extends Entity {
   publish(message) {
     // TODO(minggang): Support to convert a plain JavaScript value/object to a ROS message,
     // thus we can invoke this function like: publisher.publish('hello world').
-    message.serialize();
-    let rawRosMessage = message.toRawROS();
+    let rclMessage = message;
+    if (typeof message !== 'object') {
+      rclMessage = new this._typeClass();
+      rclMessage.data = message;
+    }
+
+    rclMessage.serialize();
+    let rawRosMessage = rclMessage.toRawROS();
     if (rawRosMessage) {
       rclnodejs.publish(this._handle, rawRosMessage);
     } else {
-      debug('Message was not published:', message);
+      debug('Message was not published:', rclMessage);
     }
   }
 

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -224,6 +224,10 @@ class {{=objectWrapper}} {
     return {pkgName: '{{=it.messageInfo.pkgName}}', subFolder: '{{=it.messageInfo.subFolder}}', interfaceName: '{{=it.messageInfo.interfaceName}}'};
   }
 
+  isPrimitive() {
+    return {{=isPrimitivePackage(it.spec.baseType)}};
+  }
+
   get refObject() {
     this.serialize();
     return this._refObject;


### PR DESCRIPTION
Currently, when we want to pass a primitive type of message to publisher
or client, we have to create a new class object of that type and assign
the value to its 'data' property, which makes the whole process redundant.

This patch lets user publish primitive message directly, the transition
from primitive message to the corresponding object will occur
implicitly. So you can write code like below:

  const publisher = node.createPublisher(String, 'topic');
  publisher.publish('hello world');

Besides, we also update the example to demonstrate the new usage for
this change.

Fix #50