### PR TITLE
[ut]Customize the test set on different platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "install": "node-gyp rebuild",
     "docs": "cd docs && make",
-    "test": "mocha test/test-*.js",
+    "test": "node ./scripts/run_test.js",
     "lint": "eslint --max-warnings=0 index.js scripts lib example rosidl_gen rosidl_parser test && node ./scripts/cpplint.js"
   },
   "authors": [

--- a/scripts/run_test.js
+++ b/scripts/run_test.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const fs = require('fs');
+const Mocha = require('mocha');
+const os = require('os');
+const path = require('path');
+
+let mocha = new Mocha();
+const testDir = path.join(__dirname, '../test/');
+// eslint-disable-next-line
+const tests = fs.readdirSync(testDir).filter(file => {
+  return file.substr(0, 5) === 'test-';});
+
+const blacklistWindows = ['test-array.js', 'test-cross-lang.js', 'test-msg-type-py-node.js', 'test-message-type.js'];
+const blacklistMac = [];
+const blacklistLinux = [];
+let blacklist = [];
+
+if (os.type() === 'Windows_NT') {
+  blacklist = blacklistWindows;
+} else if (os.type() === 'Darwin') {
+  blacklist = blacklistMac;
+} else {
+  blacklist = blacklistLinux;
+}
+
+tests.forEach(test => {
+  if (blacklist.indexOf(test) === -1) {
+    mocha.addFile(path.join(testDir, test));
+  }
+});
+
+mocha.run(function(failures) {
+  process.on('exit', () => {
+    process.exit(failures);
+  });
+});


### PR DESCRIPTION
Currently we will run all tests when executing 'npm test', but on some
platform we may want to disable part of the test cases. This patch gives
an opportunity to assign different test set for specific platform.