### PR TITLE
[ut]Avoid calling method done() multi-times

### DIFF
--- a/test/test-message-type.js
+++ b/test/test-message-type.js
@@ -35,12 +35,12 @@ const rclnodejs = require('../index.js');
 // }
 
 describe('Rclnodejs message type testing', function() {
-  before(function() {
+  beforeEach(function() {
     this.timeout(60 * 1000);
     return rclnodejs.init();
   });
 
-  after(function() {
+  afterEach(function() {
     rclnodejs.shutdown();
   });
 


### PR DESCRIPTION
When running test, test-message-type.js, sometimes the call() method
were called several times, which caused the mocha reported an error.

So we'd better call rclnodejs.shutdown() immediately after the call() is
executed to stop reveiving the subscribed message any longer.