### PR TITLE
Add debug log for the JavaScript code

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const packages = require('./rosidl_gen/packages.js');
 const loader = require('./lib/interface_loader.js');
 const QoS = require('./lib/qos.js');
 const validator = require('./lib/validator.js');
+const debug = require('debug')('rclnodejs');
 
 function inherits(target, source) {
   let properties = Object.getOwnPropertyNames(source.prototype);
@@ -59,6 +60,7 @@ let rcl = {
     let node =  new rclnodejs.ShadowNode();
 
     node.init(nodeName, namespace);
+    debug('Finish initializing node, name = %s and namespace = %s.', nodeName, namespace);
     node.handle = handle;
     this._nodes.push(node);
     return node;
@@ -72,9 +74,12 @@ let rcl = {
   init(...args) {
     return new Promise((resolve, reject) => {
       if (!this._initialized) {
+        debug('Begin to generate JavaScript code from ROS IDL files.');
         // TODO(Kenny): introduce other policy to save the amout of time of doing message generation
         generator.generateAll(false).then(() => {
+          debug('Finish generating.');
           rclnodejs.init(args);
+          debug('Finish initializing rcl with args = %o.', args);
           this._initialized = true;
           resolve();
         }).catch((e) => {
@@ -147,8 +152,10 @@ let rcl = {
   regenerateAll() {
     // This will trigger to regererate all the JS structs used for messages and services,
     // to overwrite the existing ones although they have been created.
+    debug('Begin to regenerate JavaScript code from ROS IDL files.');
     return new Promise((resolve, reject) => {
       generator.generateAll(true).then(() => {
+        debug('Finish regenerating.');
         resolve();
       }).catch((e) => {
         reject(e);

--- a/lib/client.js
+++ b/lib/client.js
@@ -16,6 +16,7 @@
 
 const rclnodejs = require('bindings')('rclnodejs');
 const Entity = require('./entity.js');
+const debug = require('debug')('rclnodejs:client');
 
 /**
  * @class - Class representing a Client in ROS
@@ -59,6 +60,7 @@ class Client extends Entity {
 
     let rawROSRequest = rclRequest.serialize();
     this._sequenceNumber = rclnodejs.sendRequest(this._handle, rawROSRequest);
+    debug('Client has sent a request.');
     this._callback = callback;
   }
 
@@ -68,6 +70,7 @@ class Client extends Entity {
 
   processResponse(response) {
     this._response.deserialize(response);
+    debug('Client has received response from service.');
     this._callback(this._response);
   }
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -21,6 +21,7 @@ const Subscription = require('./subscription.js');
 const Client = require('./client.js');
 const Service = require('./service.js');
 const QoS = require('./qos.js');
+const debug = require('debug')('rclnodejs:node');
 
 /**
  * @class - Class representing a Node in ROS
@@ -115,8 +116,8 @@ class Node {
 
     let timerHandle = rclnodejs.createTimer(period);
     let timer = new Timer(timerHandle, period, callback);
+    debug('Finish creating timer, period = %d.', period);
     this._timers.push(timer);
-
     return timer;
   }
 
@@ -134,6 +135,7 @@ class Node {
     }
 
     let publisher = Publisher.createPublisher(this.handle, typeClass, topic, qos);
+    debug('Finish creating publisher, topic = %s.', topic);
     this._publishers.push(publisher);
     return publisher;
   }
@@ -164,6 +166,7 @@ class Node {
     }
 
     let subscription = Subscription.createSubscription(this.handle, typeClass, topic, callback, qos);
+    debug('Finish creating subscription, topic = %s.', topic);
     this._subscriptions.push(subscription);
     return subscription;
   }
@@ -182,6 +185,7 @@ class Node {
     }
 
     let client = Client.createClient(this.handle, serviceName, typeClass, qos);
+    debug('Finish creating client, service = %s.', serviceName);
     this._clients.push(client);
     return client;
   }
@@ -212,6 +216,7 @@ class Node {
     }
 
     let service = Service.createService(this.handle, serviceName, typeClass, callback, qos);
+    debug('Finish creating service, service = %s.', serviceName);
     this._services.push(service);
     return service;
   }

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const rclnodejs = require('bindings')('rclnodejs');
-const debug = require('debug')('rcl_publisher');
+const debug = require('debug')('rclnodejs:publisher');
 const Entity = require('./entity.js');
 
 /**
@@ -53,6 +53,7 @@ class Publisher extends Entity {
     let rawRosMessage = rclMessage.serialize();
     if (rawRosMessage) {
       rclnodejs.publish(this._handle, rawRosMessage);
+      debug('Message has been published.');
     } else {
       debug('Message was not published:', rclMessage);
     }

--- a/lib/service.js
+++ b/lib/service.js
@@ -16,6 +16,7 @@
 
 const rclnodejs = require('bindings')('rclnodejs');
 const Entity = require('./entity.js');
+const debug = require('debug')('rclnodejs:service');
 
 /**
  * @class - Class representing a Service in ROS
@@ -32,10 +33,12 @@ class Service extends Entity {
 
   processRequest(headerHandle, request) {
     this._request.deserialize(request);
+    debug('Service has received a request from client.');
     let response = this._callback(this._request, new this._typeClass.Response());
 
     let rawROSResponse = response.serialize();
     rclnodejs.sendResponse(this._handle, rawROSResponse, headerHandle);
+    debug('Service has processed the request and sent the response.');
   }
 
   static createService(nodeHandle, serviceName, typeClass, callback, qos) {

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -16,6 +16,7 @@
 
 const rclnodejs = require('bindings')('rclnodejs');
 const Entity = require('./entity.js');
+const debug = require('debug')('rclnodejs:subscription');
 
 /**
  * @class - Class representing a Subscription in ROS
@@ -32,6 +33,7 @@ class Subscription extends Entity {
 
   processResponse(msg) {
     this._message.deserialize(msg);
+    debug('Message received.');
     this._callback(this._message);
   }
 


### PR DESCRIPTION
By leveraging the debug module, we add some useful information to the
JavaScript code, which could help you dignose the program when you are
debugging.

If you want to show all modules, please run:
  >DEBUG=rclnodejs* node example/subscription-multiarray-example.js

Or if you just want to show a specific module, like the subscription,
run:
  >DEBUG=rclnodejs:subscription node example/subscription-multiarray-example.js

Fix #53