### PR TITLE
Add debug log for C++ code

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,12 @@
 {
+  'target_defaults': {
+    'default_configuration': 'Release',
+    'configurations': {
+      'Debug': {
+        'defines': ['SPDLOG_DEBUG_ON'],
+      },
+    }
+  },
   'targets': [
     {
       'target_name': 'rclnodejs',
@@ -16,6 +24,7 @@
       ],
       'include_dirs': [
         '.',
+        'src/third_party/spdlog/include/',
         "<!(node -e \"require('nan')\")",
       ],
       'cflags!': [

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ dependencies:
     - export PATH=/usr/local/Cellar/numpy/1.13.1_1/libexec/nose/bin:$PATH && mkdir -p ~/ros2_ws/src && cd ~/ros2_ws && wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos && vcs import src < ros2.repos && src/ament/ament_tools/scripts/ament.py build --symlink-install
 
   override:
-    - source ~/ros2_ws/install/local_setup.bash && npm install && npm run lint
+    - source ~/ros2_ws/install/local_setup.bash && git submodule init && git submodule update && npm install && npm run lint
 
 test:
   override:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,6 +18,7 @@ set -e
 
 pushd $(dirname $0) > /dev/null
 
+git submodule update --init --recursive
 npm install --unsafe-perm
 npm run lint
 npm test

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -17,6 +17,7 @@
 #include "rcl_bindings.hpp"
 #include "rcl_handle.hpp"
 #include "shadow_node.hpp"
+#include "spdlog/spdlog.h"
 
 void InitModule(v8::Local<v8::Object> exports) {
   for (uint32_t i = 0;
@@ -29,6 +30,11 @@ void InitModule(v8::Local<v8::Object> exports) {
 
   rclnodejs::ShadowNode::Init(exports);
   rclnodejs::RclHandle::Init(exports);
+
+#ifdef SPDLOG_DEBUG_ON
+  auto console = spdlog::stdout_color_mt("rclnodejs");
+  console->set_level(spdlog::level::debug);
+#endif
 }
 
 NODE_MODULE(rclnodejs, InitModule);

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "handle_manager.hpp"
+#include "spdlog/spdlog.h"
 
 namespace rclnodejs {
 
@@ -66,6 +67,8 @@ void Executor::Stop() {
                });
       while (!handle_closed)
         uv_run(uv_default_loop(), UV_RUN_ONCE);
+
+      SPDLOG_DEBUG(spdlog::get("rclnodejs"), "Background thread stopped.");
     }
   }
 }
@@ -83,6 +86,7 @@ void Executor::DoWork(uv_async_t* handle) {
 }
 
 void Executor::Run(void* arg) {
+  SPDLOG_DEBUG(spdlog::get("rclnodejs"), "Background thread started.");
   Executor* executor = reinterpret_cast<Executor*>(arg);
   HandleManager* handle_manager = executor->handle_manager_;
 

--- a/src/handle_manager.cpp
+++ b/src/handle_manager.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "rcl_handle.hpp"
+#include "spdlog/spdlog.h"
 
 namespace rclnodejs {
 
@@ -54,6 +55,9 @@ void HandleManager::CollectHandles(const v8::Local<v8::Object> node) {
                        &clients_);
   CollectHandlesByType(services.ToLocalChecked()->ToObject(),
                        &services_);
+  SPDLOG_DEBUG(spdlog::get("rclnodejs"),
+      "Add {0:d} timers, {1:d} subscriptions, {2:d} clients, {3:d} services.",
+      timers_.size(), subscriptions_.size(), clients_.size(), services_.size());
 }
 
 uint32_t HandleManager::SubscriptionsCount() {
@@ -91,6 +95,7 @@ bool HandleManager::AddHandlesToWaitSet(rcl_wait_set_t* wait_set) {
     if (rcl_wait_set_add_service(wait_set, service) != RCL_RET_OK)
       return false;
   }
+
   return true;
 }
 


### PR DESCRIPTION
By leveraging spdlog, we will log some error messages when rcl error happens
and some other information.

To enable the log, please run the debug build:
  >node-gyp build --debug

Errors will always to be logged regardless of the build type.

Fix #53