### PR TITLE
Run the cpp/py client sequentially

### DIFF
--- a/test/test-multi-nodes.js
+++ b/test/test-multi-nodes.js
@@ -186,23 +186,15 @@ describe('Multiple nodes interation testing', function() {
                                     'add_two_ints_client');
       var cppClient = childProcess.spawn(cppClientPath, ['-s', 'pycpp_js_add_two_ints']);
       var pyClientPath = path.join(__dirname, 'py', 'client.py');
-      var pyClient = utils.launchPythonProcess([pyClientPath, 'pycpp_js_add_two_ints']);
-      var cppClientExited = false, pyClientExited = false;
 
       cppClient.stdout.on('data', (data) => {
         assert.deepStrictEqual(data.toString().trim(), 'Result of add_two_ints: 5');
-        cppClientExited = true;
-        if (pyClientExited) {
-          done();
-        }
-      });
+        var pyClient = utils.launchPythonProcess([pyClientPath, 'pycpp_js_add_two_ints']);
 
-      pyClient.stdout.on('data', (data) => {
-        assert.deepStrictEqual(data.toString().trim(), '3');
-        pyClientExited = true;
-        if (cppClientExited) {
+        pyClient.stdout.on('data', (data) => {
+          assert.deepStrictEqual(data.toString().trim(), '3');
           done();
-        }          
+        });
       });
     });
   });


### PR DESCRIPTION
Originally, we launched the cpp and python client simultaneously, but it
seems that the request is never sent on Windows CI(appveyor)
which leads a timeout of  60000ms. So we will launch the two clients
(cpp and python) one by one.