### PR TITLE
[rosidl_gen]Regenerate the message files when the generator updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "bindings": "^1.2.1",
+    "compare-versions": "^3.1.0",
     "debug": "^2.6.8",
     "dot": "^1.1.2",
     "fs-extra": "^3.0.1",

--- a/rosidl_gen/generator.js
+++ b/rosidl_gen/generator.js
@@ -93,20 +93,23 @@ function generateStructForPkg(pkg) {
 function generateAll(forcedGenerating) {
   return new Promise((resolve, reject) => {
     if (forcedGenerating || !generator.isRootGererated()) {
-      installedPackagesRoot.forEach((packageRoot) => {
-        let promises = [];
-        packages.findPackagesInDirectory(packageRoot).then((pkgs) => {
-          pkgs.forEach((pkg) => {
-            promises.push(generateStructForPkg(pkg));
-          });
+      fse.copy(path.join(__dirname, 'generator.json'), path.join(generatedRoot, 'generator.json'), err => {
+        if (err) reject(err);
+        installedPackagesRoot.forEach((packageRoot) => {
+          let promises = [];
+          packages.findPackagesInDirectory(packageRoot).then((pkgs) => {
+            pkgs.forEach((pkg) => {
+              promises.push(generateStructForPkg(pkg));
+            });
 
-          Promise.all(promises).then(() => {
-            resolve();
+            Promise.all(promises).then(() => {
+              resolve();
+            }).catch((e) => {
+              reject(e);
+            });
           }).catch((e) => {
             reject(e);
           });
-        }).catch((e) => {
-          reject(e);
         });
       });
     } else {
@@ -135,6 +138,11 @@ const generator = {
   isRootGererated() {
     // eslint-disable-next-line
     return fs.existsSync(generatedRoot);
+  },
+
+  version() {
+    // eslint-disable-next-line
+    return JSON.parse(fs.readFileSync(path.join(__dirname, 'generator.json'), 'utf8')).version;
   }
 };
 

--- a/rosidl_gen/generator.json
+++ b/rosidl_gen/generator.json
@@ -1,0 +1,10 @@
+{
+  "name": "rosidl-generator",
+  "version": "0.0.1",
+  "description": "Generate JavaScript object from ROS IDL(.msg) files",
+  "authors": [
+    "Minggang Wang <minggang.wang@intel.com>",
+    "Kenny Yuan <kaining.yuan@intel.com>"
+  ],
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
Currently, if the generator, which creates JS files from .msg files, is
being updated, we have to remove the original JS files which locate under
'generated' folder manually. All these things should be transparent to
the users, so the rclnodejs will check the version of the existing
generated files, and will regenerate all files if the version is less
than then current generator we are using.

If you enable the debug log, you will read some text like "The generator
will begin to create JavaScript code from ROS IDL files..." to indicate
the detailed status.