### PR TITLE
Use aysnc method to grab the version of generator

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,15 +35,29 @@ function inherits(target, source) {
 
 inherits(rclnodejs.ShadowNode, Node);
 
-/* eslint-disable */
 function getCurrentGeneratorVersion() {
   let jsonFilePath = path.join(generator.generatedRoot, 'generator.json');
-  if (fs.existsSync(jsonFilePath)) {
-    return JSON.parse(fs.readFileSync(jsonFilePath, 'utf8')).version;
-  }
-  return null;
+
+  return new Promise((resolve, reject) => {
+    fs.open(jsonFilePath, 'r', (err, fd) => {
+      if (err) {
+        if (err.code === 'ENOENT') {
+          resolve(null);
+          return;
+        }
+        reject(err);
+      } else {
+        fs.readFile(jsonFilePath, 'utf8', (err, data) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(JSON.parse(data).version);
+          }
+        });
+      }
+    });
+  });
 }
-/* eslint-enable */
 
 /**
  * A module that exposes the rclnodejs interfaces.
@@ -87,19 +101,23 @@ let rcl = {
   init(...args) {
     return new Promise((resolve, reject) => {
       if (!this._initialized) {
-        let version = getCurrentGeneratorVersion();
-        let forced = version === null || compareVersions(version, generator.version()) === -1
-                     ? true
-                     : false;
-        if (forced) {
-          debug('The generator will begin to create JavaScript code from ROS IDL files...');
-        }
-        generator.generateAll(forced).then(() => {
-          rclnodejs.init(args);
-          debug('Finish initializing rcl with args = %o.', args);
-          this._initialized = true;
-          resolve();
-        }).catch((e) => {
+        getCurrentGeneratorVersion().then(version => {
+          let forced = version === null || compareVersions(version, generator.version()) === -1
+                       ? true
+                       : false;
+          if (forced) {
+            debug('The generator will begin to create JavaScript code from ROS IDL files...');
+          }
+
+          generator.generateAll(forced).then(() => {
+            rclnodejs.init(args);
+            debug('Finish initializing rcl with args = %o.', args);
+            this._initialized = true;
+            resolve();
+          }).catch(e => {
+            reject(e);
+          });
+        }).catch(e => {
           reject(e);
         });
       } else {

--- a/lib/client.js
+++ b/lib/client.js
@@ -50,7 +50,7 @@ class Client extends Entity {
    */
   sendRequest(request, callback) {
     let rclRequest = request;
-    if (!request instanceof this._typeClass) {
+    if (!(request instanceof this._typeClass.Request)) {
       rclRequest = new this._typeClass();
       rclRequest.data = request;
     }

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -45,7 +45,7 @@ class Publisher extends Entity {
     // TODO(minggang): Support to convert a plain JavaScript value/object to a ROS message,
     // thus we can invoke this function like: publisher.publish('hello world').
     let rclMessage = message;
-    if (!message instanceof this._typeClass) {
+    if (!(message instanceof this._typeClass)) {
       rclMessage = new this._typeClass();
       rclMessage.data = message;
     }


### PR DESCRIPTION
To combine with JavaScript convention, we should read a file
asynchronously in order not to block the thread, which can be
achieved by using the async version of readFile.

Also, this patch fixed a bug caused by 5d764f54.

Fix #183