### PR TITLE
Adapt to an object as parameter when invoking require method

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,14 +167,15 @@ let rcl = {
    * @return {object} - the object of the required package/interface.
    */
   require(name) {
-    if (typeof (name) !== 'string') {
-      throw new TypeError('Invalid argument');
+    if (typeof (name.package) === 'string' && typeof (name.type) === 'string' && typeof (name.message) === 'string') {
+      return loader.loadInterface(name.package, name.type, name.message);
     }
 
     if (name.indexOf('/') !== -1) {
       let [packageName, type, messageName] = name.split('/');
       return loader.loadInterface(packageName, type, messageName);
     }
+
     return loader.loadInterfaceInPackage(name);
   },
 


### PR DESCRIPTION
Currently we support two kinds of parameter to require a specific
message, like:
1.
// Require a package, including msg and srv.
let String = rclnodejs.require('std_msgs').msg.String;
2.
// Require a single message or service.
let String = rclnodejs.require('std_msgs/msg/String');

This patch enables to require a message by an object, e.g.

let String = rclnodejs.require({package: 'std_msgs', type: 'msg',
message: 'String'});

Fix #189