### PR TITLE
Consistent message String type naming and timer for publisher

### DIFF
--- a/test/client_setup.js
+++ b/test/client_setup.js
@@ -17,7 +17,7 @@
 const rclnodejs = require('../index.js');
 
 rclnodejs.init().then(function() {
-  var node = rclnodejs.createNode('service');
+  var node = rclnodejs.createNode('client');
   const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
   var client = node.createClient(AddTwoInts, 'add_two_ints');
   const request = {

--- a/test/publisher_msg.js
+++ b/test/publisher_msg.js
@@ -26,13 +26,13 @@ rclnodejs.init().then(() => {
   msg.data = rclValue;
 
   var publisher = node.createPublisher(msgType, rclType + '_channel');
-  var timer = setInterval(() => {
+  var timer = node.createTimer(100, () => {
     publisher.publish(msg);
-  }, 100);
+  });
 
   rclnodejs.spin(node);
   process.on('SIGINT', (m) => {
-    clearInterval(timer);
+    timer.cancel();
     node.destroy();
     rclnodejs.shutdown();
     process.exit(0);

--- a/test/publisher_msg_colorrgba.js
+++ b/test/publisher_msg_colorrgba.js
@@ -27,13 +27,13 @@ rclnodejs.init().then(() => {
   };
 
   var publisher = node.createPublisher(ColorRGBA, 'ColorRGBA_channel');
-  var timer = setInterval(() => {
+  var timer = node.createTimer(100, () => {
     publisher.publish(msg);
-  }, 100);
+  });
 
   rclnodejs.spin(node);
   process.on('SIGINT', (m) => {
-    clearInterval(timer);
+    timer.cancel();
     node.destroy();
     rclnodejs.shutdown();
     process.exit(0);

--- a/test/publisher_msg_header.js
+++ b/test/publisher_msg_header.js
@@ -31,13 +31,13 @@ rclnodejs.init().then(() => {
   };
 
   var publisher = node.createPublisher(Header, 'Header_channel');
-  var timer = setInterval(() => {
+  var timer = node.createTimer(100, () => {
     publisher.publish(header);
-  }, 100);
+  });
 
   rclnodejs.spin(node);
   process.on('SIGINT', (m) => {
-    clearInterval(timer);
+    timer.cancel();
     node.destroy();
     rclnodejs.shutdown();
     process.exit(0);

--- a/test/publisher_msg_jointstate.js
+++ b/test/publisher_msg_jointstate.js
@@ -37,13 +37,13 @@ rclnodejs.init().then(() => {
   };
 
   var publisher = node.createPublisher(JointState, 'JointState_channel');
-  var timer = setInterval(() => {
+  var timer = node.createTimer(100, () => {
     publisher.publish(state);
-  }, 100);
+  });
 
   rclnodejs.spin(node);
   process.on('SIGINT', (m) => {
-    clearInterval(timer);
+    timer.cancel();
     node.destroy();
     rclnodejs.shutdown();
     process.exit(0);

--- a/test/test-cross-lang.js
+++ b/test/test-cross-lang.js
@@ -34,11 +34,11 @@ describe('Cross-language interaction', function() {
   describe('Node.js Subcription', function() {
     it('Node.js subscription should receive msg from C++ publisher', (done) => {
       var node = rclnodejs.createNode('cpp_pub_js_sub');
-      const rclString = 'std_msgs/msg/String';
+      const RclString = 'std_msgs/msg/String';
       var destroy = false;
       var cppTalkPath = path.join(process.env['AMENT_PREFIX_PATH'], 'lib', 'demo_nodes_cpp', 'talker');
       var cppTalker = childProcess.spawn(cppTalkPath, ['-t', 'cpp_js_chatter']);
-      var subscription = node.createSubscription(rclString, 'cpp_js_chatter', (msg) => {
+      var subscription = node.createSubscription(RclString, 'cpp_js_chatter', (msg) => {
         assert.ok(/Hello World:/.test(msg.data));
         if (!destroy) {
           node.destroy();
@@ -52,10 +52,10 @@ describe('Cross-language interaction', function() {
 
     it('Node.js subscription should receive msg from Python publisher', (done) => {
       var node = rclnodejs.createNode('cpp_pub_py_sub');
-      const rclString = 'std_msgs/msg/String';
+      const RclString = 'std_msgs/msg/String';
       var destroy = false;
       var pyTalker = utils.launchPythonProcess([`${__dirname}/py/talker.py`]);
-      var subscription = node.createSubscription(rclString, 'py_js_chatter', (msg) => {
+      var subscription = node.createSubscription(RclString, 'py_js_chatter', (msg) => {
         assert.ok(/Hello World/.test(msg.data));
         if (!destroy) {
           node.destroy();
@@ -71,13 +71,13 @@ describe('Cross-language interaction', function() {
   describe('Node.js publisher', function() {
     it('Cpp subscription should receive msg from Node.js publisher', (done) => {
       var node = rclnodejs.createNode('js_pub_cpp_sub');
-      const rclString = 'std_msgs/msg/String';
+      const RclString = 'std_msgs/msg/String';
       var destroy = false;
 
       let text = 'Greeting from Node.js publisher';
       let cppListenerPath = path.join(process.env['AMENT_PREFIX_PATH'], 'lib', 'demo_nodes_cpp', 'listener');
       var cppListener = childProcess.spawn(cppListenerPath, ['-t', 'js_cpp_chatter']);
-      var publisher = node.createPublisher(rclString, 'js_cpp_chatter');
+      var publisher = node.createPublisher(RclString, 'js_cpp_chatter');
       const msg = text;
       var timer = setInterval(() => {
         publisher.publish(msg);
@@ -98,12 +98,12 @@ describe('Cross-language interaction', function() {
 
     it('Python subscription should receive msg from Node.js publisher', function(done) {
       var node = rclnodejs.createNode('js_pub_py_sub');
-      const rclString = 'std_msgs/msg/String';
+      const RclString = 'std_msgs/msg/String';
       var destroy = false;
 
       let text = 'Greeting from Node.js publisher to Python subscription';
       var pyListener = utils.launchPythonProcess([`${__dirname}/py/listener.py`]);
-      var publisher = node.createPublisher(rclString, 'js_py_chatter');
+      var publisher = node.createPublisher(RclString, 'js_py_chatter');
       var msg = text;
 
       var timer = setInterval(() => {

--- a/test/test-cross-lang.js
+++ b/test/test-cross-lang.js
@@ -79,14 +79,14 @@ describe('Cross-language interaction', function() {
       var cppListener = childProcess.spawn(cppListenerPath, ['-t', 'js_cpp_chatter']);
       var publisher = node.createPublisher(RclString, 'js_cpp_chatter');
       const msg = text;
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
 
       cppListener.stdout.on('data', (data) => {
         if (!destroy) {
           assert.ok(new RegExp(text).test(data.toString()));
-          clearInterval(timer);
+          timer.cancel();
           node.destroy();
           cppListener.kill('SIGINT');
           destroy = true;
@@ -106,13 +106,13 @@ describe('Cross-language interaction', function() {
       var publisher = node.createPublisher(RclString, 'js_py_chatter');
       var msg = text;
 
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       pyListener.stdout.on('data', (data) => {
         if (!destroy) {
           assert.ok(new RegExp(text).test(data.toString()));
-          clearInterval(timer);
+          timer.cancel();
           node.destroy();
           pyListener.kill('SIGINT');
           destroy = true;
@@ -133,18 +133,18 @@ describe('Cross-language interaction', function() {
       var client = node.createClient(AddTwoInts, 'js_py_add_two_ints');
       const request = {a: 1, b: 2};
 
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         client.sendRequest(request, (response) => {
           if (!destroy) {
             assert.deepStrictEqual(response.sum, 3);
-            clearInterval(timer);
+            timer.cancel();
             node.destroy();
             pyService.kill('SIGINT');
             destroy = true;
             done();
           }      
         });
-      }, 100);
+      });
 
       rclnodejs.spin(node);
     });

--- a/test/test-destruction.js
+++ b/test/test-destruction.js
@@ -81,8 +81,8 @@ describe('Node destroy testing', function() {
     var pub2 = node.createPublisher(float32, 'pub2_topic');
     assert.deepStrictEqual(2, node._publishers.length);
 
-    var rclString = 'std_msgs/msg/String';
-    var sub1 = node.createSubscription(rclString, 'sub1_topic', function(msg) {
+    var RclString = 'std_msgs/msg/String';
+    var sub1 = node.createSubscription(RclString, 'sub1_topic', function(msg) {
       console.log(`Received ${msg}`);
     });
     assert.deepStrictEqual(1, node._subscriptions.length);

--- a/test/test-existance.js
+++ b/test/test-existance.js
@@ -146,12 +146,12 @@ describe('rclnodejs class existance testing', function() {
   });
 
   describe('Publisher class', function() {
-    var node, rclString, publisher;
+    var node, RclString, publisher;
 
     before(function() {
       node = rclnodejs.createNode('Publisher');
-      rclString = 'std_msgs/msg/String';
-      publisher = node.createPublisher(rclString, 'chatter');
+      RclString = 'std_msgs/msg/String';
+      publisher = node.createPublisher(RclString, 'chatter');
     });
 
     after(function() {

--- a/test/test-msg-type-py-node.js
+++ b/test/test-msg-type-py-node.js
@@ -374,7 +374,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = 'True';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -382,9 +382,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);
     });
 
@@ -400,7 +400,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = "b'A'";
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -408,9 +408,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);
     });
 
@@ -426,7 +426,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = 'a';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -434,9 +434,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);
     });
 
@@ -452,7 +452,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = 'Hello World';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -460,9 +460,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);
     });
     
@@ -478,7 +478,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '127';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -486,9 +486,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);
     });
 
@@ -504,7 +504,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '255';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -512,9 +512,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);
     });
 
@@ -530,7 +530,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '32767';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -538,9 +538,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);
     });
 
@@ -556,7 +556,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '65535';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -564,9 +564,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);
     });
 
@@ -582,7 +582,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '2147483647';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -590,9 +590,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);
     });
     
@@ -608,7 +608,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '4294967295';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -616,9 +616,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);
     });
 
@@ -634,7 +634,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '9007199254740991';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -642,9 +642,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);
     });
 
@@ -660,7 +660,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '9007199254740991';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -668,9 +668,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);
     });
 
@@ -686,7 +686,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '3.14';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.ok(Math.abs(parseFloat(data.toString()) - expected) < 0.000001);
           done();
           node.destroy();
@@ -694,9 +694,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);
     });
 
@@ -712,7 +712,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '3.14';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.ok(Math.abs(parseFloat(data.toString()) - expected) < 0.000001);
           done();
           node.destroy();
@@ -720,9 +720,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);
     });
   });
@@ -754,7 +754,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = 'ABC';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -762,9 +762,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(byteArray);
-      }, 100);
+      });
       rclnodejs.spin(node);
     });
 
@@ -784,7 +784,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '(127.0,255.0,255.0,0.5)';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -792,9 +792,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);      
     });
 
@@ -816,7 +816,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '(123456,789,main frame)';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -824,9 +824,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);      
     });
 
@@ -854,7 +854,7 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = "(123456,789,main frame,['Tom', 'Jerry'],[1.0, 2.0],[2.0, 3.0],[4.0, 5.0, 6.0])";
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          clearInterval(timer);
+          timer.cancel();
           assert.deepStrictEqual(data.toString(), expected);
           done();
           node.destroy();
@@ -862,9 +862,9 @@ describe('Rclnodejs - Python message type testing', function() {
           destroy = true;
         }       
       });
-      var timer = setInterval(() => {
+      var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      }, 100);
+      });
       rclnodejs.spin(node);      
     });
   });

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -113,7 +113,7 @@ describe('rclnodejs node test suite', function() {
 
 describe('rcl node methods testing', function() {
   var node;
-  var rclString, GetParameters;
+  var RclString, GetParameters;
   this.timeout(60 * 1000);
 
   before(function() {
@@ -126,7 +126,7 @@ describe('rcl node methods testing', function() {
 
   beforeEach(function() {
     node = rclnodejs.createNode('my_node', '/my_ns');
-    rclString = 'std_msgs/msg/String';
+    RclString = 'std_msgs/msg/String';
     GetParameters = 'rcl_interfaces/srv/GetParameters';
   });
 
@@ -142,7 +142,7 @@ describe('rcl node methods testing', function() {
   });
 
   it('node.createPublisher', function() {
-    node.createPublisher(rclString, 'chatter');
+    node.createPublisher(RclString, 'chatter');
 
     var invalidParams = [
       ['chatter?', Error, /topic name is invalid/],
@@ -152,7 +152,7 @@ describe('rcl node methods testing', function() {
 
     invalidParams.forEach(function(invalidParam) {
       assertThrowsError(() => {
-        node.createPublisher(rclString, invalidParam[0]);
+        node.createPublisher(RclString, invalidParam[0]);
       }, invalidParam[1], invalidParam[2], 'Failed to createPublisher');
     });
   });
@@ -166,12 +166,12 @@ describe('rcl node methods testing', function() {
       [true, 'validServiceName'],
       [{f: 'abc'}, 'validServiceName'],
       [['a', 'b', 'c'], 'validSerivceName'],
-      [rclString, 2],
-      [rclString, undefined],
-      [rclString, null],
-      [rclString, false],
-      [rclString, {n: 'invalidServiceName'}],
-      [rclString, [1, 2, 3]],
+      [RclString, 2],
+      [RclString, undefined],
+      [RclString, null],
+      [RclString, false],
+      [RclString, {n: 'invalidServiceName'}],
+      [RclString, [1, 2, 3]],
       [undefined, null]
     ];
 
@@ -183,7 +183,7 @@ describe('rcl node methods testing', function() {
   });
 
   it('node.createSubscription', function() {
-    node.createSubscription(rclString, 'chatter', () => {});
+    node.createSubscription(RclString, 'chatter', () => {});
 
     var invalidParams = [
       ['chatter?', /topic name is invalid/],
@@ -193,7 +193,7 @@ describe('rcl node methods testing', function() {
 
     invalidParams.forEach(function(invalidParam) {
       assertThrowsError(() => {
-        node.createSubscription(rclString, invalidParam[0], () => {});
+        node.createSubscription(RclString, invalidParam[0], () => {});
       }, Error, invalidParam[1], 'Failed to createSubscription');
     });
   });
@@ -207,12 +207,12 @@ describe('rcl node methods testing', function() {
       [true, 'validTopicName', undefined],
       [{f: 'abc'}, 'validTopicName', null],
       [['a', 'b', 'c'], 'validTopicName', undefined],
-      [rclString, 2, null],
-      [rclString, undefined, undefined],
-      [rclString, null, null],
-      [rclString, false, undefined],
-      [rclString, {n: 'invalidServiceName'}, null],
-      [rclString, [1, 2, 3], undefined],
+      [RclString, 2, null],
+      [RclString, undefined, undefined],
+      [RclString, null, null],
+      [RclString, false, undefined],
+      [RclString, {n: 'invalidServiceName'}, null],
+      [RclString, [1, 2, 3], undefined],
       [undefined, null, null]
     ];
 

--- a/test/test-single-process.js
+++ b/test/test-single-process.js
@@ -37,6 +37,8 @@ describe('Test rclnodejs nodes in a single process', function() {
     var subscription = subscriptionNode.createSubscription(RclString, 'single_ps_channel1', (msg) => {
       timer.cancel();
       assert.deepStrictEqual(msg.data, 'Hello World');
+      publisherNode.destroy();
+      subscriptionNode.destroy();
       done();
     });
 
@@ -57,6 +59,7 @@ describe('Test rclnodejs nodes in a single process', function() {
     var subscription = node.createSubscription(RclString, 'new_style_require1', (msg) => {
       timer.cancel();
       assert.deepStrictEqual(msg.data, 'Hello World');
+      node.destroy();
       done();
     }); 
 
@@ -68,7 +71,7 @@ describe('Test rclnodejs nodes in a single process', function() {
     rclnodejs.spin(node);
   });
 
-  it('Client/Service is a one process', function(done) {
+  it('Client/Service in one process', function(done) {
     var clientNode = rclnodejs.createNode('single_ps_client');
     var serviceNode = rclnodejs.createNode('single_ps_service');
     const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
@@ -96,7 +99,7 @@ describe('Test rclnodejs nodes in a single process', function() {
     rclnodejs.spin(clientNode);
   });
 
-  it('Client/Service is a one process - service callback syntax #2', function(done) {
+  it('Client/Service in one process - service callback syntax #2', function(done) {
     var clientNode = rclnodejs.createNode('single_ps_client_2');
     var serviceNode = rclnodejs.createNode('single_ps_service_2');
     const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
@@ -124,7 +127,7 @@ describe('Test rclnodejs nodes in a single process', function() {
     rclnodejs.spin(clientNode);
   });
 
-  it('Client/Service is a one process - service callback syntax #3', function(done) {
+  it('Client/Service in one process - service callback syntax #3', function(done) {
     var clientNode = rclnodejs.createNode('single_ps_client_3');
     var serviceNode = rclnodejs.createNode('single_ps_service_3');
     const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
@@ -170,6 +173,7 @@ describe('Test rclnodejs nodes in a single process', function() {
       client.sendRequest(request, (response) => {
         timer.cancel();
         assert.deepStrictEqual(response.sum, 3);
+        node.destroy();
         done();
       });
     });


### PR DESCRIPTION
* Use RclString naming for all std_msgs/msg/String type
* For all publishers/clients, use the `node.createTimer` timer from rcl
* Add node destruction before rclnodejs shutdown