### PR TITLE
Use TypedArray for primitive array so that it can save memory and run faster at the same time

### DIFF
--- a/lib/message_translator.js
+++ b/lib/message_translator.js
@@ -18,6 +18,10 @@
 
 const debug = require('debug')('rclnodejs:message_translator');
 
+function isTypedArray(value) {
+  return ArrayBuffer.isView(value) && !(value instanceof DataView);
+}
+
 function copyMsgObject(msg, obj) {
   if (typeof obj === 'object') {
     for (let i in obj) {
@@ -26,7 +30,7 @@ function copyMsgObject(msg, obj) {
         if (type === 'string' || type === 'number' || type === 'boolean') {
           // A primitive-type value
           msg[i] = obj[i];
-        } else if (Array.isArray(obj[i])) {  // TODO(Kenny): deal with TypedArray
+        } else if (Array.isArray(obj[i]) || isTypedArray(obj[i])) {
           // It's an array
           if (typeof obj[i][0] === 'object') {
             // It's an array of objects: converting to ROS message objects
@@ -45,7 +49,7 @@ function copyMsgObject(msg, obj) {
           }
         } else {
           // Proceed further of this object
-          copyMsgObject(msg[i], obj[i]);  // TODO(Kenny): deal with TypedArray
+          copyMsgObject(msg[i], obj[i]);
         }
       } else {
         // Extra fields in obj (but not in msg)

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -72,8 +72,40 @@ function getPrimitiveNameByType(type) {
   }
 }
 
-let primitiveBaseType = ['Bool', 'Int8', 'UInt8', 'Int16', 'UInt16', 'Int32', 'UInt32',
-                         'Int64', 'UInt64', 'Float64', 'Float32', 'Char', 'Byte', 'String'];
+function getTypedArrayName(type) {
+  if (type.type === 'int8') {
+    return 'Int8Array';
+  } else if (type.type === 'uint8') {
+    return 'Uint8Array';
+  } else if (type.type === 'int16') {
+    return 'Int16Array';
+  } else if (type.type === 'uint16') {
+    return 'Uint16Array';
+  } else if (type.type === 'int32') {
+    return 'Int32Array';
+  } else if (type.type === 'uint32') {
+    return 'Uint32Array';
+  } else if (type.type === 'int64') {
+    return 'Int64Array';
+  } else if (type.type === 'uint64') {
+    return 'Uint64Array';
+  } else if (type.type === 'float64') {
+    return 'Float64Array';
+  } else if (type.type === 'float32') {
+    return 'Float32Array';
+  } else if (type.type === 'char') {
+    return 'Int8Array';
+  } else if (type.type === 'byte') {
+    return 'Uint8Array';
+  } else {
+    return '';
+  }
+}
+
+const primitiveBaseType = ['Bool', 'Int8', 'UInt8', 'Int16', 'UInt16', 'Int32', 'UInt32',
+                           'Int64', 'UInt64', 'Float64', 'Float32', 'Char', 'Byte', 'String'];
+const typedArrayType = ['int8', 'uint8', 'int16', 'uint16', 'int32', 'uint32',
+                        'int64', 'uint64', 'float64', 'float32', 'char', 'byte'];
 
 let existedModules = [];
 
@@ -83,6 +115,10 @@ function isExisted(requiredModule) {
 
 function isPrimitivePackage(baseType) {
   return primitiveBaseType.indexOf(baseType.type) !== -1;
+}
+
+function isTypedArrayType(type) {
+  return typedArrayType.indexOf(type.type) !== -1;
 }
 
 function shouldRequire(baseType, fieldType) {
@@ -272,7 +308,14 @@ class {{=objectWrapper}} {
 
   {{~ it.spec.fields :field}}
   get {{=field.name}}() {
-    {{? field.type.isArray && field.type.isPrimitiveType}}
+    {{? field.type.isArray && isTypedArrayType(field.type)}}
+    const src = this._wrapperFields['{{=field.name}}'].data;
+    let values = new {{=getTypedArrayName(field.type)}}(src.length);
+    for (let i = 0; i < src.length; ++i) {
+      values[i] = src[i].data;
+    }
+    return values;
+    {{?? field.type.isArray && field.type.isPrimitiveType}}
     let values = [];
     this._wrapperFields['{{=field.name}}'].data.forEach((wrapper, index) => {
       values.push(wrapper.data);
@@ -348,14 +391,15 @@ class {{=arrayWrapper}} {
   }
 
   fill(values) {
-    let length = values.length;
+    const length = values.length;
     this._resize(length);
     {{? isPrimitivePackage(it.spec.baseType)}}
-    values.forEach((value, index) => {
+    // Use for loop to make it also work for TypedArray
+    for (let i = 0; i < length; ++i) {
       let wrapper = new {{=objectWrapper}}();
-      wrapper.data = value;
-      this._wrappers[index] = wrapper;
-    });
+      wrapper.data = values[i];
+      this._wrappers[i] = wrapper;
+    }
     {{?? !isPrimitivePackage(it.spec.baseType)}}
     values.forEach((value, index) => {
       this._wrappers[index].copy(value);

--- a/test/test-array.js
+++ b/test/test-array.js
@@ -39,9 +39,9 @@ describe('rclnodejs message communication', function() {
       assert.deepStrictEqual(state.header.stamp.nanosec, 789);
       assert.deepStrictEqual(state.header.frame_id, 'main frame');
       assert.deepStrictEqual(state.name, ['Tom', 'Jerry']);
-      assert.deepStrictEqual(state.position, [1, 2]);
-      assert.deepStrictEqual(state.velocity, [2, 3]);
-      assert.deepStrictEqual(state.effort, [4, 5, 6]);
+      assert.deepStrictEqual(state.position, Float64Array.from([1, 2]));
+      assert.deepStrictEqual(state.velocity, Float64Array.from([2, 3]));
+      assert.deepStrictEqual(state.effort, Float64Array.from([4, 5, 6]));
 
       if (!destroy) {
         publisher.kill('SIGINT');

--- a/test/test-message-translator-complex.js
+++ b/test/test-message-translator-complex.js
@@ -127,6 +127,17 @@ describe('Rclnodejs message translation: complex types', function() {
           },
           data: [1.0, 2.0, 3.0, 8.5, 6.75, 0.5, -0.25],
         },
+        {
+          layout: {
+            dim: [
+              {label: 'height',  size: 480, stride: 921600},
+              {label: 'width',   size: 640, stride: 1920},
+              {label: 'channel', size: 3,   stride: 8},
+            ],
+            data_offset: 1024,
+          },
+          data: Float32Array.from([1.0, 2.0, 3.0, 8.5, 6.75, 0.5, -0.25]),
+        },
       ]
     },
     {
@@ -141,7 +152,72 @@ describe('Rclnodejs message translation: complex types', function() {
             ],
             data_offset: 0,
           },
-          data: [-10, 1, 2, 3, 8, 6, 0, -25],
+          data: [-10, 1, 2, 3, 8, 6, 0, -25], // Provide data via Array
+        },
+        {
+          layout: {
+            dim: [
+              {label: 'height',  size: 10, stride: 600},
+              {label: 'width',   size: 20, stride: 60},
+              {label: 'channel', size: 3,   stride: 4},
+            ],
+            data_offset: 0,
+          },
+          data: Int32Array.from([-10, 1, 2, 3, 8, 6, 0, -25]), // Provide data via TypedArray
+        },
+      ]
+    },
+    {
+      pkg: 'std_msgs', type: 'Int16MultiArray',
+      values: [
+        {
+          layout: {
+            dim: [
+              {label: 'height',  size: 10, stride: 600},
+              {label: 'width',   size: 20, stride: 60},
+              {label: 'channel', size: 3,   stride: 4},
+            ],
+            data_offset: 0,
+          },
+          data: [-10, 1, 2, 3, 8, 6, 0, -25], // Provide data via Array
+        },
+        {
+          layout: {
+            dim: [
+              {label: 'height',  size: 10, stride: 600},
+              {label: 'width',   size: 20, stride: 60},
+              {label: 'channel', size: 3,   stride: 4},
+            ],
+            data_offset: 0,
+          },
+          data: Int16Array.from([-10, 1, 2, 3, 8, 6, 0, -25]), // Provide data via TypedArray
+        },
+      ]
+    },
+    {
+      pkg: 'std_msgs', type: 'Int8MultiArray',
+      values: [
+        {
+          layout: {
+            dim: [
+              {label: 'height',  size: 10, stride: 600},
+              {label: 'width',   size: 20, stride: 60},
+              {label: 'channel', size: 3,   stride: 4},
+            ],
+            data_offset: 0,
+          },
+          data: [-10, 1, 2, 3, 8, 6, 0, -25], // Provide data via Array
+        },
+        {
+          layout: {
+            dim: [
+              {label: 'height',  size: 10, stride: 600},
+              {label: 'width',   size: 20, stride: 60},
+              {label: 'channel', size: 3,   stride: 4},
+            ],
+            data_offset: 0,
+          },
+          data: Int8Array.from([-10, 1, 2, 3, 8, 6, 0, -25]), // Provide data via TypedArray
         },
       ]
     },
@@ -185,6 +261,8 @@ describe('Rclnodejs message translation: complex types', function() {
               node.destroy();
               resolve();
             } else {
+              console.log('got', value);
+              console.log('expected', v);
               reject('case ' + i + '. Expected: ' + v + ', Got: ' + value);
             }
           });

--- a/test/test-message-type.js
+++ b/test/test-message-type.js
@@ -299,9 +299,9 @@ describe('Rclnodejs message type testing', function() {
         publisher.kill('SIGINT');
 
         assert.deepStrictEqual(state.name, ['Tom', 'Jerry']);
-        assert.deepStrictEqual(state.position, [1, 2]);
-        assert.deepStrictEqual(state.velocity, [2, 3]);
-        assert.deepStrictEqual(state.effort, [4, 5, 6]);
+        assert.deepStrictEqual(state.position, Float64Array.from([1, 2]));
+        assert.deepStrictEqual(state.velocity, Float64Array.from([2, 3]));
+        assert.deepStrictEqual(state.effort, Float64Array.from([4, 5, 6]));
 
         done();
       });

--- a/test/test-msg-type-cpp-node.js
+++ b/test/test-msg-type-cpp-node.js
@@ -322,7 +322,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
 
       var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'Array_cpp_js_channel', '-m', 'Array']);
       var subscription = node.createSubscription(ByteMultiArray, 'Array_cpp_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, [65, 66, 67]);
+        assert.deepStrictEqual(msg.data, Uint8Array.from([65, 66, 67]));
 
         if (!destroy) {
           node.destroy();
@@ -366,9 +366,9 @@ describe('Rclnodejs - Cpp message type testing', function() {
         assert.deepStrictEqual(msg.header.stamp.nanosec, 789);
         assert.deepStrictEqual(msg.header.frame_id, 'main frame');
         assert.deepStrictEqual(msg.name, ['Tom', 'Jerry']);
-        assert.deepStrictEqual(msg.position, [1, 2]);
-        assert.deepStrictEqual(msg.velocity, [2, 3]);
-        assert.deepStrictEqual(msg.effort, [4, 5, 6]);
+        assert.deepStrictEqual(msg.position, Float64Array.from([1, 2]));
+        assert.deepStrictEqual(msg.velocity, Float64Array.from([2, 3]));
+        assert.deepStrictEqual(msg.effort, Float64Array.from([4, 5, 6]));
 
         if (!destroy) {
           node.destroy();

--- a/test/test-msg-type-py-node.js
+++ b/test/test-msg-type-py-node.js
@@ -302,7 +302,7 @@ describe('Rclnodejs - Python message type testing', function() {
       var destroy = false;
       var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'Array']);
       var subscription = node.createSubscription(ByteMultiArray, 'Array_py_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, [65, 66, 67]);
+        assert.deepStrictEqual(msg.data, Uint8Array.from([65, 66, 67]));
 
         if (!destroy) {
           node.destroy();
@@ -344,9 +344,9 @@ describe('Rclnodejs - Python message type testing', function() {
         assert.deepStrictEqual(msg.header.stamp.nanosec, 789);
         assert.deepStrictEqual(msg.header.frame_id, 'main frame');
         assert.deepStrictEqual(msg.name, ['Tom', 'Jerry']);
-        assert.deepStrictEqual(msg.position, [1, 2]);
-        assert.deepStrictEqual(msg.velocity, [2, 3]);
-        assert.deepStrictEqual(msg.effort, [4, 5, 6]);
+        assert.deepStrictEqual(msg.position, Float64Array.from([1, 2]));
+        assert.deepStrictEqual(msg.velocity, Float64Array.from([2, 3]));
+        assert.deepStrictEqual(msg.effort, Float64Array.from([4, 5, 6]));
 
         if (!destroy) {
           node.destroy();


### PR DESCRIPTION
There is still possibility to deeper engage continuous memory in primitive ROS array (like what `rclcpp` does), but that's another story and will be tracked in another issue.