### PR TITLE
[UT] Use RegExp to verifiy the console output

### DIFF
--- a/test/test-cross-lang.js
+++ b/test/test-cross-lang.js
@@ -194,7 +194,7 @@ describe('Cross-language interaction', function() {
 
       var pyClient = utils.launchPythonProcess([`${__dirname}/py/client.py`]);
       pyClient.stdout.on('data', function(data) {
-        assert.deepEqual(parseInt(data, 10), 3);
+        assert.ok(new RegExp('3').test(data.toString()));
         if (!destroy) {
           node.destroy();
           destroy = true;
@@ -223,7 +223,7 @@ describe('Cross-language interaction', function() {
                                     'add_two_ints_client');
       var cppClient = childProcess.spawn(cppClientPath, ['-s', 'cpp_js_add_two_ints']);
       cppClient.stdout.on('data', function(data) {
-        assert.deepStrictEqual(data.toString().trim(), 'Result of add_two_ints: 5');
+        assert.ok(new RegExp('Result of add_two_ints: 5').test(data.toString()));
         node.destroy();
         done();
       });

--- a/test/test-interactive.js
+++ b/test/test-interactive.js
@@ -69,7 +69,7 @@ describe('rclnodejs interactive testing', function() {
       var destroy = false;
       var client = childProcess.fork(`${__dirname}/client_setup.js`, {silent: true});
       client.stdout.on('data', function(data) {
-        assert.deepEqual(parseInt(data, 10), 3);
+        assert.ok(new RegExp('3').test(data.toString()));
         if (!destroy) {
           client.kill('SIGINT');
           node.destroy();

--- a/test/test-msg-type-cpp-node.js
+++ b/test/test-msg-type-cpp-node.js
@@ -395,7 +395,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
 
       subscription.stdout.on('data', (data) => {
         if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim(), expected);
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -422,7 +422,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
 
       subscription.stdout.on('data', (data) => {
         if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim(), expected);
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -450,7 +450,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
 
       subscription.stdout.on('data', (data) => {
         if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim(), expected);
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -477,7 +477,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
 
       subscription.stdout.on('data', (data) => {
         if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim(), expected);
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -504,7 +504,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
 
       subscription.stdout.on('data', (data) => {
         if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim(), expected);
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -531,7 +531,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
 
       subscription.stdout.on('data', (data) => {
         if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim(), expected);
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -558,7 +558,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
 
       subscription.stdout.on('data', (data) => {
         if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim().toLowerCase(), expected);
+          assert.ok(new RegExp(expected).test(data.toString().toLowerCase()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -585,7 +585,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
 
       subscription.stdout.on('data', (data) => {
         if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim().toLowerCase(), expected);
+          assert.ok(new RegExp(expected).test(data.toString().toLowerCase()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -611,8 +611,8 @@ describe('Rclnodejs - Cpp message type testing', function() {
       const expected = '7fffffff';
 
       subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim().toLowerCase(), expected);
+        if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString().toLowerCase()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -638,8 +638,8 @@ describe('Rclnodejs - Cpp message type testing', function() {
       const expected = 'ffffffff';
 
       subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim().toLowerCase(), expected);
+        if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString().toLowerCase()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -665,8 +665,8 @@ describe('Rclnodejs - Cpp message type testing', function() {
       const expected = '1fffffffffffff';
 
       subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim().toLowerCase(), expected);
+        if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString().toLowerCase()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -692,8 +692,8 @@ describe('Rclnodejs - Cpp message type testing', function() {
       const expected = '1fffffffffffff';
 
       subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim().toLowerCase(), expected);
+        if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString().toLowerCase()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -719,8 +719,8 @@ describe('Rclnodejs - Cpp message type testing', function() {
       const expected = '3.14';
 
       subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim(), expected);
+        if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -746,8 +746,8 @@ describe('Rclnodejs - Cpp message type testing', function() {
       const expected = '3.1415926';
 
       subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim(), expected);
+        if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -780,8 +780,8 @@ describe('Rclnodejs - Cpp message type testing', function() {
       const expected = '(0.5, 127, 255, 255)';
 
       subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim(), expected);
+        if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -820,8 +820,8 @@ describe('Rclnodejs - Cpp message type testing', function() {
       const expected = 'ABC';
 
       subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim(), expected);
+        if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -854,8 +854,8 @@ describe('Rclnodejs - Cpp message type testing', function() {
       const expected = '(123456,789,main frame)';
 
       subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.deepStrictEqual(data.toString().trim(), expected);
+        if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
@@ -894,7 +894,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
       const expected = '(123456,789,main frame,[Tom,Jerry,],[1,2,],[2,3,],[4,5,6,])';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          assert.deepStrictEqual(data.toString().trim(), expected);
+          assert.notDeepStrictEqual(data.toString().indexOf(expected), -1);
           timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');

--- a/test/test-msg-type-py-node.js
+++ b/test/test-msg-type-py-node.js
@@ -374,12 +374,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = 'True';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -400,12 +400,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = "b'A'";
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -426,12 +426,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = 'a';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -452,12 +452,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = 'Hello World';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -478,12 +478,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '127';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -504,12 +504,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '255';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -530,12 +530,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '32767';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -556,12 +556,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '65535';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -582,12 +582,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '2147483647';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -608,12 +608,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '4294967295';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -634,12 +634,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '9007199254740991';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -660,12 +660,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '9007199254740991';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -686,12 +686,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '3.14';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
-          timer.cancel();
           assert.ok(Math.abs(parseFloat(data.toString()) - expected) < 0.000001);
-          done();
+          timer.cancel();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -703,21 +703,21 @@ describe('Rclnodejs - Python message type testing', function() {
     it('Float64', function(done) {
       var node = rclnodejs.createNode('float64_js_publisher');
       const Float64 = 'std_msgs/msg/Float64';
-      const msg = 3.14;
+      const msg = 3.1415926;
       var destroy = false;
 
       var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Float64']);
       var publisher = node.createPublisher(Float64, 'Float64_js_py_channel');
 
-      const expected = '3.14';
+      const expected = '3.1415926';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.ok(Math.abs(parseFloat(data.toString()) - expected) < 0.000001);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -754,12 +754,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = 'ABC';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -784,12 +784,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '(127.0,255.0,255.0,0.5)';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -816,12 +816,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = '(123456,789,main frame)';
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.ok(new RegExp(expected).test(data.toString()));
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }
       });
       var timer = node.createTimer(100, () => {
@@ -854,12 +854,12 @@ describe('Rclnodejs - Python message type testing', function() {
       const expected = "(123456,789,main frame,['Tom', 'Jerry'],[1.0, 2.0],[2.0, 3.0],[4.0, 5.0, 6.0])";
       subscription.stdout.on('data', (data) => {
         if (!destroy) {
+          assert.notDeepStrictEqual(data.toString().indexOf(expected), -1);
           timer.cancel();
-          assert.deepStrictEqual(data.toString(), expected);
-          done();
           node.destroy();
           subscription.kill('SIGINT');
           destroy = true;
+          done();
         }       
       });
       var timer = node.createTimer(100, () => {


### PR DESCRIPTION
Use RegExp to verify the console output rather than compare
the exact wording from subscription process output. This is useful
when the debug flag is enabled.