### PR TITLE
Handle the SIGINT

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,4 +239,10 @@ let rcl = {
   },
 };
 
+process.on('SIGINT', () => {
+  debug('Catch ctrl+c event and will cleanup and terminate.');
+  rcl.shutdown();
+  process.exit(0);
+});
+
 module.exports = rcl;


### PR DESCRIPTION
When rclnodejs receives the SIGINT, it must be handled correctly to
release the resources and quit.

Fix #244