### PR TITLE
Use a number variable of message class to hold the array element

### DIFF
--- a/rosidl_gen/generator.json
+++ b/rosidl_gen/generator.json
@@ -1,6 +1,6 @@
 {
   "name": "rosidl-generator",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Generate JavaScript object from ROS IDL(.msg) files",
   "authors": [
     "Minggang Wang <minggang.wang@intel.com>",

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -226,12 +226,20 @@ const {{=refObjectArrayType}} = StructType({
 class {{=objectWrapper}} {
   constructor(other) {
     this._wrapperFields = {};
+    {{~ it.spec.fields :field}}
+    {{? field.type.isArray && field.type.isPrimitiveType && !isTypedArrayType(field.type)}}
+    this._{{=field.name}}Array = [];
+    {{?}}
+    {{~}}
     if (typeof other === 'object' && other._refObject) {
       this._refObject = new {{=refObjectType}}(other._refObject.toObject());
       {{~ it.spec.fields :field}}
       {{? field.type.isArray}}
       this._wrapperFields.{{=field.name}} = {{=getWrapperNameByType(field.type)}}.createArray();
       this._wrapperFields.{{=field.name}}.copy(other._wrapperFields.{{=field.name}});
+      {{? field.type.isPrimitiveType && !isTypedArrayType(field.type)}}
+      this.{{=field.name}} = other.{{=field.name}};
+      {{?}}
       {{?? !field.type.isPrimitiveType || (field.type.type === 'string' && it.spec.msgName !== 'String')}}
       this._wrapperFields.{{=field.name}} =  new {{=getWrapperNameByType(field.type)}}(other._wrapperFields.{{=field.name}});
       {{?}}
@@ -248,6 +256,7 @@ class {{=objectWrapper}} {
       {{?}}
       {{~}}
     }
+
     this.freeze();
   }
 
@@ -280,7 +289,11 @@ class {{=objectWrapper}} {
 
   freeze(own = false) {
     {{~ it.spec.fields :field}}
-    {{? !field.type.isPrimitiveType || field.type.isArray}}
+    {{? field.type.isArray && field.type.isPrimitiveType && !isTypedArrayType(field.type)}}
+    this._wrapperFields.{{=field.name}}.fill(this._{{=field.name}}Array);
+    this._wrapperFields.{{=field.name}}.freeze(own);
+    this._refObject.{{=field.name}} = this._wrapperFields.{{=field.name}}.refObject;
+    {{?? !field.type.isPrimitiveType || field.type.isArray}}
     this._wrapperFields.{{=field.name}}.freeze(own);
     this._refObject.{{=field.name}} = this._wrapperFields.{{=field.name}}.refObject;
     {{?? field.type.type === 'string' && it.spec.msgName !== 'String'}}
@@ -303,7 +316,12 @@ class {{=objectWrapper}} {
 
   deserialize(refObject) {
     {{~ it.spec.fields :field}}
-    {{? !field.type.isPrimitiveType || field.type.isArray}}
+    {{? field.type.isArray && field.type.isPrimitiveType && !isTypedArrayType(field.type)}}
+    refObject.{{=field.name}}.data.length = refObject.{{=field.name}}.size;
+    for (let index = 0; index < refObject.{{=field.name}}.size; index++) {
+      this._{{=field.name}}Array[index] = refObject.{{=field.name}}.data[index].data;
+    }
+    {{?? !field.type.isPrimitiveType || field.type.isArray}}
     this._wrapperFields.{{=field.name}}.copyRefObject(refObject.{{=field.name}});
     {{?? field.type.type === 'string' && it.spec.msgName !== 'String'}}
     this._wrapperFields.{{=field.name}}.data = refObject.{{=field.name}}.data;
@@ -357,11 +375,7 @@ class {{=objectWrapper}} {
     {{? field.type.isArray && isTypedArrayType(field.type)}}
     return this._wrapperFields['{{=field.name}}'].data;
     {{?? field.type.isArray && field.type.isPrimitiveType}}
-    let values = [];
-    this._wrapperFields['{{=field.name}}'].data.forEach((wrapper, index) => {
-      values.push(wrapper.data);
-    });
-    return values;
+    return this._{{=field.name}}Array;
     {{?? field.type.isArray && !field.type.isPrimitiveType}}
     return this._wrapperFields.{{=field.name}};
     {{?? !field.type.isPrimitiveType && !field.type.isArray}}
@@ -374,8 +388,10 @@ class {{=objectWrapper}} {
   }
 
   set {{=field.name}}(value) {
-    {{? field.type.isArray && field.type.isPrimitiveType}}
+    {{? field.type.isArray && isTypedArrayType(field.type)}}
     this._wrapperFields['{{=field.name}}'].fill(value);
+    {{?? field.type.isArray && field.type.isPrimitiveType}}
+    this._{{=field.name}}Array = value;
     {{?? field.type.isArray && !field.type.isPrimitiveType}}
     this._wrapperFields.{{=field.name}}.copy(value);
     {{?? !field.type.isPrimitiveType && !field.type.isArray}}
@@ -396,7 +412,12 @@ class {{=objectWrapper}} {
     this._refObject = new {{=refObjectType}}(refObject.toObject());
 
     {{~ it.spec.fields :field}}
-    {{? !field.type.isPrimitiveType || field.type.isArray || (field.type.type === 'string' && it.spec.msgName !== 'String')}}
+    {{? field.type.isArray && field.type.isPrimitiveType && !isTypedArrayType(field.type)}}
+    refObject.{{=field.name}}.data.length = refObject.{{=field.name}}.size;
+    for (let index = 0; index < refObject.{{=field.name}}.size; index++) {
+      this._{{=field.name}}Array[index] = refObject.{{=field.name}}.data[index].data;
+    }
+    {{?? !field.type.isPrimitiveType || field.type.isArray || (field.type.type === 'string' && it.spec.msgName !== 'String')}}
     this._wrapperFields.{{=field.name}}.copyRefObject(this._refObject.{{=field.name}});
     {{?}}
     {{~}}
@@ -406,7 +427,9 @@ class {{=objectWrapper}} {
     this._refObject = new {{=refObjectType}}(other._refObject.toObject());
 
     {{~ it.spec.fields :field}}
-    {{? !field.type.isPrimitiveType || field.type.isArray || (field.type.type === 'string' && it.spec.msgName !== 'String')}}
+    {{? field.type.isArray && field.type.isPrimitiveType && !isTypedArrayType(field.type)}}
+    this._{{=field.name}}Array = other._{{=field.name}}Array.slice();
+    {{?? !field.type.isPrimitiveType || field.type.isArray || (field.type.type === 'string' && it.spec.msgName !== 'String')}}
     this._wrapperFields.{{=field.name}}.copy(other._wrapperFields.{{=field.name}});
     {{?}}
     {{~}}

--- a/test/test-array-data.js
+++ b/test/test-array-data.js
@@ -72,8 +72,7 @@ describe('rclnodejs message communication', function() {
     {
       pkg: 'std_msgs', type: 'Int64MultiArray',
       values: [
-        // Waiting for https://github.com/RobotWebTools/rclnodejs/issues/232 to enable this case
-        // {layout: layout, data: [-111, 1, 2, 3, 8, 6, 0, -25, Number.MAX_SAFE_INTEGER] }, // Provide data via Array
+        {layout: layout, data: [-111, 1, 2, 3, 8, 6, 0, -25, Number.MAX_SAFE_INTEGER] }, // Provide data via Array
       ]
     },
     {
@@ -107,8 +106,7 @@ describe('rclnodejs message communication', function() {
     {
       pkg: 'std_msgs', type: 'UInt64MultiArray',
       values: [
-        // Waiting for https://github.com/RobotWebTools/rclnodejs/issues/232 to enable this case
-        // {layout: layout, data: [0, 1, 2, 3, 8, 6, 0, 255, Number.MAX_SAFE_INTEGER] }, // Provide data via Array
+        {layout: layout, data: [0, 1, 2, 3, 8, 6, 0, 255, Number.MAX_SAFE_INTEGER] }, // Provide data via Array
       ]
     },
     {
@@ -146,6 +144,7 @@ describe('rclnodejs message communication', function() {
           assert(msg.layout.dim.data[0].label === v.layout.dim[0].label);
           assert(msg.layout.dim.data[0].size === v.layout.dim[0].size);
           assert(msg.layout.dim.data[0].stride === v.layout.dim[0].stride);
+
           // Second element
           assert(typeof msg.layout.dim.data[1] === 'object');
           assert(msg.layout.dim.data[1].label === v.layout.dim[1].label);


### PR DESCRIPTION
When a message which has an array property, user can get it by the get
method, meanwhile any element in the array can be re-assigned by
operator = through index. But the array gotten by the get method is generated as a
temporary variable and will not influence the one which is stored in
the original message.

This patch creates a member variable to hold the property, which has a
type of primitive array.

Fix #232