### PR TITLE
Fix the error when providing an empty array to assign the property

### DIFF
--- a/lib/message_translator.js
+++ b/lib/message_translator.js
@@ -44,7 +44,7 @@ function copyMsgObject(msg, obj) {
             // 3. Assign
             msg[i].fill(msgArray);
           } else {
-            // It's an array of primitive-type elements
+            // It's an array of primitive-type elements or an empty array
             msg[i] = obj[i];
           }
         } else {

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -393,7 +393,7 @@ class {{=objectWrapper}} {
     {{?? field.type.isArray && field.type.isPrimitiveType}}
     this._{{=field.name}}Array = value;
     {{?? field.type.isArray && !field.type.isPrimitiveType}}
-    this._wrapperFields.{{=field.name}}.copy(value);
+    this._wrapperFields.{{=field.name}}.fill(value);
     {{?? !field.type.isPrimitiveType && !field.type.isArray}}
     this._wrapperFields.{{=field.name}}.copy(value);
     {{?? !field.type.isArray && field.type.type === 'string' && it.spec.msgName !== 'String'}}
@@ -580,7 +580,7 @@ class {{=arrayWrapper}} {
   }
 
   copy(other) {
-    if (! other instanceof {{=arrayWrapper}}) {
+    if (! (other instanceof {{=arrayWrapper}})) {
       throw new TypeError('Invalid argument: should provide "{{=arrayWrapper}}".');
     }
 

--- a/test/test-array-data.js
+++ b/test/test-array-data.js
@@ -192,13 +192,13 @@ describe('rclnodejs message communication', function() {
       values: [
         {
           header: {stamp: {sec: 11223, nanosec: 44556}, frame_id: 'f001', },
-          height: 240, width: 320, fields: [{}], is_bigendian: false, point_step: 16, row_step: 320*16,
+          height: 240, width: 320, fields: [], is_bigendian: false, point_step: 16, row_step: 320*16,
           data: uint8Data,
           is_dense: false,
         },
         {
           header: {stamp: {sec: 11223, nanosec: 44556}, frame_id: 'f001', },
-          height: 240, width: 320, fields: [{}], is_bigendian: false, point_step: 16, row_step: 320*16,
+          height: 240, width: 320, fields: [], is_bigendian: false, point_step: 16, row_step: 320*16,
           data: Uint8Array.from(uint8Data),
           is_dense: false,
         },


### PR DESCRIPTION
When assigning a value to an property of the message, whose type is array, we
should use the fill() method instead of copy(), because the copy()
method is designed to copy value from another wrapper, not an array.

Fix #235