### PR TITLE
Use new strategy to verify message transmitting

### DIFF
--- a/test/blacklist.json
+++ b/test/blacklist.json
@@ -1,5 +1,5 @@
 {
-  "Linux": ["test-cross-lang.js", "test-interactive.js", "test-multi-nodes.js"],
-  "Darwin": ["test-cross-lang.js", "test-interactive.js", "test-multi-nodes.js"],
-  "Windows_NT": ["test-cross-lang.js", "test-interactive.js", "test-multi-nodes.js"]
+  "Linux": [],
+  "Darwin": [],
+  "Windows_NT": []
 }

--- a/test/client_setup.js
+++ b/test/client_setup.js
@@ -19,13 +19,15 @@ const rclnodejs = require('../index.js');
 rclnodejs.init().then(function() {
   var node = rclnodejs.createNode('client');
   const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
+  const Int8 = 'std_msgs/msg/Int8';
   var client = node.createClient(AddTwoInts, 'add_two_ints');
   const request = {
     a: 1,
     b: 2,
   };
-  client.sendRequest(request, function(response) {
-    process.stdout.write(response.sum.toString());
+  var publisher = node.createPublisher(Int8, 'back_add_two_ints');
+  client.sendRequest(request, (response) => {
+    publisher.publish(response.sum);
   });
   rclnodejs.spin(node);
 

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -31,3 +31,5 @@ endfunction()
 
 custom_executable(publisher_msg)
 custom_executable(subscription_msg)
+custom_executable(listener)
+custom_executable(add_two_ints_client)

--- a/test/cpp/add_two_ints_client.cpp
+++ b/test/cpp/add_two_ints_client.cpp
@@ -39,7 +39,7 @@ void print_usage()
 // TODO(wjwwood): make this into a method of rclcpp::client::Client.
 example_interfaces::srv::AddTwoInts_Response::SharedPtr send_request(
   rclcpp::Node::SharedPtr node,
-  rclcpp::client::Client<example_interfaces::srv::AddTwoInts>::SharedPtr client,
+  rclcpp::Client<example_interfaces::srv::AddTwoInts>::SharedPtr client,
   example_interfaces::srv::AddTwoInts_Request::SharedPtr request)
 {
   auto result = client->async_send_request(request);

--- a/test/cpp/add_two_ints_client.cpp
+++ b/test/cpp/add_two_ints_client.cpp
@@ -1,0 +1,104 @@
+// Copyright 2014 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rcutils/cmdline_parser.h"
+
+#include "std_msgs/msg/int8.hpp"
+#include "example_interfaces/srv/add_two_ints.hpp"
+
+using namespace std::chrono_literals;
+
+rclcpp::Publisher<std_msgs::msg::Int8>::SharedPtr publisher = nullptr;
+
+void print_usage()
+{
+  printf("Usage for add_two_ints_client app:\n");
+  printf("add_two_ints_client [-t topic_name] [-h]\n");
+  printf("options:\n");
+  printf("-h : Print this help function.\n");
+  printf("-s service_name : Specify the service name for this client. Defaults to add_two_ints.\n");
+}
+
+// TODO(wjwwood): make this into a method of rclcpp::client::Client.
+example_interfaces::srv::AddTwoInts_Response::SharedPtr send_request(
+  rclcpp::Node::SharedPtr node,
+  rclcpp::client::Client<example_interfaces::srv::AddTwoInts>::SharedPtr client,
+  example_interfaces::srv::AddTwoInts_Request::SharedPtr request)
+{
+  auto result = client->async_send_request(request);
+  // Wait for the result.
+  if (rclcpp::spin_until_future_complete(node, result) ==
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    return result.get();
+  } else {
+    return NULL;
+  }
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::Node::make_shared("add_two_ints_client");
+
+  if (rcutils_cli_option_exist(argv, argv + argc, "-h")) {
+    print_usage();
+    return 0;
+  }
+
+  auto topic = std::string("add_two_ints");
+  if (rcutils_cli_option_exist(argv, argv + argc, "-s")) {
+    topic = std::string(rcutils_cli_get_option(argv, argv + argc, "-s"));
+  }
+  auto client = node->create_client<example_interfaces::srv::AddTwoInts>(topic);
+
+  auto request = std::make_shared<example_interfaces::srv::AddTwoInts::Request>();
+  request->a = 2;
+  request->b = 3;
+
+  while (!client->wait_for_service(1s)) {
+    if (!rclcpp::ok()) {
+      printf("add_two_ints_client was interrupted while waiting for the service. Exiting.\n");
+      return 0;
+    }
+    printf("service not available, waiting again...\n");
+  }
+
+  // TODO(wjwwood): make it like `client->send_request(node, request)->sum`
+  // TODO(wjwwood): consider error condition
+  rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
+  custom_qos_profile.depth = 7;
+  auto msg = std::make_shared<std_msgs::msg::Int8>();
+  publisher = node->create_publisher<std_msgs::msg::Int8>(
+    std::string("back_") + topic, custom_qos_profile);
+
+  auto result = send_request(node, client, request);
+  if (result) {
+    // printf("Result of add_two_ints: %zd\n", result->sum);
+    msg->data = result->sum;
+    publisher->publish(msg);
+  } else {
+    printf("add_two_ints_client was interrupted. Exiting.\n");
+  }
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/test/cpp/add_two_ints_client.cpp
+++ b/test/cpp/add_two_ints_client.cpp
@@ -90,14 +90,19 @@ int main(int argc, char ** argv)
   publisher = node->create_publisher<std_msgs::msg::Int8>(
     std::string("back_") + topic, custom_qos_profile);
 
-  auto result = send_request(node, client, request);
-  if (result) {
-    // printf("Result of add_two_ints: %zd\n", result->sum);
-    msg->data = result->sum;
+
+  auto future_result = client->async_send_request(request);
+
+  // Wait for the result.
+  if (rclcpp::spin_until_future_complete(node, future_result) ==
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    // printf("Result of add_two_ints: %zd\n", future_result.get()->sum);
+    msg->data = future_result.get()->sum;
     publisher->publish(msg);
   } else {
-    printf("add_two_ints_client was interrupted. Exiting.\n");
-  }
+    printf("add_two_ints_client_async was interrupted. Exiting.\n");
+  }  
 
   rclcpp::shutdown();
   return 0;

--- a/test/cpp/listener.cpp
+++ b/test/cpp/listener.cpp
@@ -1,0 +1,66 @@
+// Copyright 2014 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rcutils/cmdline_parser.h"
+
+#include "std_msgs/msg/string.hpp"
+
+rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher = nullptr;
+
+void print_usage()
+{
+  printf("Usage for listener app:\n");
+  printf("listener [-t topic_name] [-h]\n");
+  printf("options:\n");
+  printf("-h : Print this help function.\n");
+  printf("-t topic_name : Specify the topic on which to subscribe. Defaults to chatter.\n");
+}
+
+void chatterCallback(const std_msgs::msg::String::SharedPtr msg)
+{
+  publisher->publish(msg);
+}
+
+
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("listener");
+
+  if (rcutils_cli_option_exist(argv, argv + argc, "-h")) {
+    print_usage();
+    return 0;
+  }
+  rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
+  custom_qos_profile.depth = 7;
+  auto topic = std::string("chatter");
+  if (rcutils_cli_option_exist(argv, argv + argc, "-t")) {
+    topic = std::string(rcutils_cli_get_option(argv, argv + argc, "-t"));
+  }
+
+  publisher = node->create_publisher<std_msgs::msg::String>(
+    std::string("back_") + topic, custom_qos_profile);
+  auto sub = node->create_subscription<std_msgs::msg::String>(
+    topic, chatterCallback, rmw_qos_profile_default);
+  
+  rclcpp::spin(node);
+
+  return 0;
+}

--- a/test/cpp/subscription_msg.cpp
+++ b/test/cpp/subscription_msg.cpp
@@ -41,143 +41,209 @@
 #include "std_msgs/msg/header.hpp"
 #include "sensor_msgs/msg/joint_state.hpp"
 
-template <typename T>
-void chatterCallback(const T msg)
-{
-  std::cout << msg->data << std::endl;
+rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr bool_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::Byte>::SharedPtr byte_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::Char>::SharedPtr char_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::String>::SharedPtr str_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::Int8>::SharedPtr int8_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::UInt8>::SharedPtr uint8_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::Int16>::SharedPtr int16_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::UInt16>::SharedPtr uint16_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr int32_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::UInt32>::SharedPtr uint32_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::Int64>::SharedPtr int64_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::UInt64>::SharedPtr uint64_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr float32_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr float64_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::ColorRGBA>::SharedPtr color_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::ByteMultiArray>::SharedPtr array_pub = nullptr;
+rclcpp::Publisher<std_msgs::msg::Header>::SharedPtr header_pub  = nullptr;
+rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr jointstate_pub = nullptr;
+
+void boolCallback(std_msgs::msg::Bool::SharedPtr msg) {
+  bool_pub->publish(msg);
 }
 
-template <typename T>
-void chatterIntCastCallback(const T msg)
-{
-  std::cout << std::hex << static_cast<int>(msg->data) << std::endl;
+void byteCallback(std_msgs::msg::Byte::SharedPtr msg) {
+  byte_pub->publish(msg);
 }
 
-template <typename T>
-void chatterHexCallback(const T msg)
-{
-  std::cout << std::hex << msg->data << std::endl;
+void charCallback(std_msgs::msg::Char::SharedPtr msg) {
+  char_pub->publish(msg);
 }
 
-void chatterPrecisionCallback(const std_msgs::msg::Float64::SharedPtr msg)
-{
-  std::cout << std::setprecision(10) << msg->data << std::endl;
+void strCallback(std_msgs::msg::String::SharedPtr msg) {
+  str_pub->publish(msg);
 }
 
-void chatterColorRGBACallback(const std_msgs::msg::ColorRGBA::SharedPtr msg)
-{
-  std::cout << "(" << msg->a << ", " << msg->r << ", " << msg->g << ", " << msg->b 
-            << ")" << std::endl;
+void int8Callback(std_msgs::msg::Int8::SharedPtr msg) {
+  int8_pub->publish(msg);
 }
 
-void chatterArrayCallback(const std_msgs::msg::ByteMultiArray::SharedPtr msg) {
-  for (const auto &c: msg->data)
-    std::cout << c;
-  std::cout << std::endl;
+void uint8Callback(std_msgs::msg::UInt8::SharedPtr msg) {
+  uint8_pub->publish(msg);
 }
 
-void chatterHeaderCallBack(const std_msgs::msg::Header::SharedPtr msg) 
-{
-  std::cout << "(" << msg->stamp.sec << "," << msg->stamp.nanosec
-            << "," << msg->frame_id << ")" << std::endl;
+void int16Callback(std_msgs::msg::Int16::SharedPtr msg) {
+  int16_pub->publish(msg);
 }
 
-void chatterJointStateCallback(const sensor_msgs::msg::JointState::SharedPtr msg) {
-  std::cout << "(" << msg->header.stamp.sec << "," << msg->header.stamp.nanosec << ","
-            << msg->header.frame_id << ",[";
-  for (const auto &n: msg->name)
-    std::cout << n << ",";
-  std::cout << "],[";
-
-  for (const auto &p: msg->position)
-    std::cout << p << ",";
-  std::cout << "],[";
-
-  for (const auto &v: msg->velocity)
-    std::cout << v << ",";
-  std::cout << "],[";
-
-  for (const auto &e: msg->effort)
-    std::cout << e << ",";
-  std::cout << "])" << std::endl;;
+void uint16Callback(std_msgs::msg::UInt16::SharedPtr msg) {
+  uint16_pub->publish(msg);
 }
-  
+
+void int32Callback(std_msgs::msg::Int32::SharedPtr msg) {
+  int32_pub->publish(msg);
+}
+
+void uint32Callback(std_msgs::msg::UInt32::SharedPtr msg) {
+  uint32_pub->publish(msg);
+}
+
+void int64Callback(std_msgs::msg::Int64::SharedPtr msg) {
+  int64_pub->publish(msg);
+}
+
+void uint64Callback(std_msgs::msg::UInt64::SharedPtr msg) {
+  uint64_pub->publish(msg);
+}
+
+void float32Callback(std_msgs::msg::Float32::SharedPtr msg) {
+  float32_pub->publish(msg);
+}
+
+void float64Callback(std_msgs::msg::Float64::SharedPtr msg) {
+  float64_pub->publish(msg);
+}
+
+void colorCallback(std_msgs::msg::ColorRGBA::SharedPtr msg) {
+  color_pub->publish(msg);
+}
+
+void arrayCallback(std_msgs::msg::ByteMultiArray::SharedPtr msg) {
+  array_pub->publish(msg);
+}
+
+void headerCallback(std_msgs::msg::Header::SharedPtr msg) {
+  header_pub->publish(msg);
+}
+
+void jointstateCallback(sensor_msgs::msg::JointState::SharedPtr msg) {
+  jointstate_pub->publish(msg);
+}
+
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("cpp_subscription");
 
   // Bool
+  bool_pub = node->create_publisher<std_msgs::msg::Bool>(
+    std::string("back_") + std::string("Bool_js_cpp_channel"), rmw_qos_profile_default);
   auto bool_sub = node->create_subscription<std_msgs::msg::Bool>(std::string("Bool_js_cpp_channel"),
-    chatterCallback<std_msgs::msg::Bool::SharedPtr>, rmw_qos_profile_default);
+    boolCallback, rmw_qos_profile_default);
 
   // Byte
+  byte_pub = node->create_publisher<std_msgs::msg::Byte>(
+    std::string("back_") + std::string("Byte_js_cpp_channel"), rmw_qos_profile_default);
   auto byte_sub = node->create_subscription<std_msgs::msg::Byte>(std::string("Byte_js_cpp_channel"),
-    chatterCallback<std_msgs::msg::Byte::SharedPtr>, rmw_qos_profile_default);
+    byteCallback, rmw_qos_profile_default);
 
   // Char
+  char_pub = node->create_publisher<std_msgs::msg::Char>(
+    std::string("back_") + std::string("Char_js_cpp_channel"), rmw_qos_profile_default);
   auto char_sub = node->create_subscription<std_msgs::msg::Char>(std::string("Char_js_cpp_channel"),
-    chatterCallback<std_msgs::msg::Char::SharedPtr>, rmw_qos_profile_default);
+    charCallback, rmw_qos_profile_default);
 
   // String
-  auto string_sub = node->create_subscription<std_msgs::msg::String>(std::string("String_js_cpp_channel"),
-    chatterCallback<std_msgs::msg::String::SharedPtr>, rmw_qos_profile_default);
+  str_pub = node->create_publisher<std_msgs::msg::String>(
+    std::string("back_") + std::string("String_js_cpp_channel"), rmw_qos_profile_default);
+  auto str_sub = node->create_subscription<std_msgs::msg::String>(std::string("String_js_cpp_channel"),
+    strCallback, rmw_qos_profile_default);
 
   // Int8
+  int8_pub = node->create_publisher<std_msgs::msg::Int8>(
+    std::string("back_") + std::string("Int8_js_cpp_channel"), rmw_qos_profile_default);
   auto int8_sub = node->create_subscription<std_msgs::msg::Int8>(std::string("Int8_js_cpp_channel"),
-    chatterIntCastCallback<std_msgs::msg::Int8::SharedPtr>, rmw_qos_profile_default);    
+    int8Callback, rmw_qos_profile_default);
 
   // UInt8
+  uint8_pub = node->create_publisher<std_msgs::msg::UInt8>(
+    std::string("back_") + std::string("UInt8_js_cpp_channel"), rmw_qos_profile_default);
   auto uint8_sub = node->create_subscription<std_msgs::msg::UInt8>(std::string("UInt8_js_cpp_channel"),
-    chatterIntCastCallback<std_msgs::msg::UInt8::SharedPtr>, rmw_qos_profile_default);
+    uint8Callback, rmw_qos_profile_default);
 
   // Int16
+  int16_pub = node->create_publisher<std_msgs::msg::Int16>(
+    std::string("back_") + std::string("Int16_js_cpp_channel"), rmw_qos_profile_default);
   auto int16_sub = node->create_subscription<std_msgs::msg::Int16>(std::string("Int16_js_cpp_channel"),
-  chatterHexCallback<std_msgs::msg::Int16::SharedPtr>, rmw_qos_profile_default);
+    int16Callback, rmw_qos_profile_default);
 
   // UInt16
+  uint16_pub = node->create_publisher<std_msgs::msg::UInt16>(
+    std::string("back_") + std::string("UInt16_js_cpp_channel"), rmw_qos_profile_default);
   auto uint16_sub = node->create_subscription<std_msgs::msg::UInt16>(std::string("UInt16_js_cpp_channel"),
-  chatterHexCallback<std_msgs::msg::UInt16::SharedPtr>, rmw_qos_profile_default);
+    uint16Callback, rmw_qos_profile_default);
   
   // Int32
+  int32_pub = node->create_publisher<std_msgs::msg::Int32>(
+    std::string("back_") + std::string("Int32_js_cpp_channel"), rmw_qos_profile_default);
   auto int32_sub = node->create_subscription<std_msgs::msg::Int32>(std::string("Int32_js_cpp_channel"),
-  chatterHexCallback<std_msgs::msg::Int32::SharedPtr>, rmw_qos_profile_default);
+    int32Callback, rmw_qos_profile_default);
 
   // UInt32
+  uint32_pub = node->create_publisher<std_msgs::msg::UInt32>(
+    std::string("back_") + std::string("UInt32_js_cpp_channel"), rmw_qos_profile_default);
   auto uint32_sub = node->create_subscription<std_msgs::msg::UInt32>(std::string("UInt32_js_cpp_channel"),
-  chatterHexCallback<std_msgs::msg::UInt32::SharedPtr>, rmw_qos_profile_default);
+    uint32Callback, rmw_qos_profile_default);
   
   // Int64
+  int64_pub = node->create_publisher<std_msgs::msg::Int64>(
+    std::string("back_") + std::string("Int64_js_cpp_channel"), rmw_qos_profile_default);
   auto int64_sub = node->create_subscription<std_msgs::msg::Int64>(std::string("Int64_js_cpp_channel"),
-  chatterHexCallback<std_msgs::msg::Int64::SharedPtr>, rmw_qos_profile_default);
+    int64Callback, rmw_qos_profile_default);
 
   // UInt64
+  uint64_pub = node->create_publisher<std_msgs::msg::UInt64>(
+    std::string("back_") + std::string("UInt64_js_cpp_channel"), rmw_qos_profile_default);
   auto uint64_sub = node->create_subscription<std_msgs::msg::UInt64>(std::string("UInt64_js_cpp_channel"),
-  chatterHexCallback<std_msgs::msg::UInt64::SharedPtr>, rmw_qos_profile_default);
+    uint64Callback, rmw_qos_profile_default);
 
   // Float32
+  float32_pub = node->create_publisher<std_msgs::msg::Float32>(
+    std::string("back_") + std::string("Float32_js_cpp_channel"), rmw_qos_profile_default);
   auto float32_sub = node->create_subscription<std_msgs::msg::Float32>(std::string("Float32_js_cpp_channel"),
-  chatterCallback<std_msgs::msg::Float32::SharedPtr>, rmw_qos_profile_default);
+    float32Callback, rmw_qos_profile_default);
 
-  // UInt64
+  // Float64
+  float64_pub = node->create_publisher<std_msgs::msg::Float64>(
+    std::string("back_") + std::string("Float64_js_cpp_channel"), rmw_qos_profile_default);
   auto float64_sub = node->create_subscription<std_msgs::msg::Float64>(std::string("Float64_js_cpp_channel"),
-  chatterPrecisionCallback, rmw_qos_profile_default);
+    float64Callback, rmw_qos_profile_default);
   
   // ColorRGBA
+  color_pub = node->create_publisher<std_msgs::msg::ColorRGBA>(
+    std::string("back_") + std::string("ColorRGBA_js_cpp_channel"), rmw_qos_profile_default);
   auto colorrgba_sub = node->create_subscription<std_msgs::msg::ColorRGBA>(std::string("ColorRGBA_js_cpp_channel"),
-    chatterColorRGBACallback, rmw_qos_profile_default);
+    colorCallback, rmw_qos_profile_default);
   
   // Array
+  array_pub = node->create_publisher<std_msgs::msg::ByteMultiArray>(
+    std::string("back_") + std::string("ByteMultiArray_js_cpp_channel"), rmw_qos_profile_default);
   auto array_sub = node->create_subscription<std_msgs::msg::ByteMultiArray>(std::string("Array_js_cpp_channel"),
-    chatterArrayCallback, rmw_qos_profile_default);
+    arrayCallback, rmw_qos_profile_default);
 
   // Header
+  header_pub = node->create_publisher<std_msgs::msg::Header>(
+    std::string("back_") + std::string("Header_js_cpp_channel"), rmw_qos_profile_default);
   auto header_sub = node->create_subscription<std_msgs::msg::Header>(std::string("Header_js_cpp_channel"),
-    chatterHeaderCallBack, rmw_qos_profile_default);
+    headerCallback, rmw_qos_profile_default);
 
   // Complex object: JointState
+  jointstate_pub = node->create_publisher<sensor_msgs::msg::JointState>(
+    std::string("back_") + std::string("JointState_js_cpp_channel"), rmw_qos_profile_default);
   auto jointstate_sub = node->create_subscription<sensor_msgs::msg::JointState>(std::string("JointState_js_cpp_channel"),
-    chatterJointStateCallback, rmw_qos_profile_default);
+    jointstateCallback, rmw_qos_profile_default);
 
   rclcpp::spin(node);
 

--- a/test/py/client.py
+++ b/test/py/client.py
@@ -15,10 +15,9 @@
 
 import sys
 import rclpy
-from time import sleep
 from std_msgs.msg import String
+from std_msgs.msg import Int8
 from example_interfaces.srv import AddTwoInts
-import signal
 
 node = None
 
@@ -27,16 +26,8 @@ def cleanup():
   node.destroy_node()
   rclpy.shutdown()
 
-def handler(signum, frame):
-  cleanup()
-  sys.exit(0)
-
-def callback(response):
-  print(response.sum)
-
 def main():
   global node
-  signal.signal(signal.SIGINT, handler)
 
   service = 'py_js_add_two_ints'
   if len(sys.argv) > 1:
@@ -45,15 +36,21 @@ def main():
   rclpy.init()
   node = rclpy.create_node('add_client')
   client = node.create_client(AddTwoInts, service)
+  publisher = node.create_publisher(Int8, 'back_' + service)
   request = AddTwoInts.Request()
   request.a = 1
   request.b = 2
 
+  msg = Int8()
   client.call(request)
-  client.wait_for_future()
-  print(client.response.sum)
+  while rclpy.ok():
+    rclpy.spin_once(node)
+    if client.response is not None:
+      msg.data = client.response.sum
+      publisher.publish(msg)
 
   cleanup()
+
 
 if __name__ == '__main__':
   main()

--- a/test/py/listener.py
+++ b/test/py/listener.py
@@ -15,34 +15,31 @@
 
 import sys
 import rclpy
-from time import sleep
 from std_msgs.msg import String
-import signal
 
 node = None
+publisher = None
 
 def cleanup():
   global node
   node.destroy_node()
   rclpy.shutdown()
 
-def handler(signum, frame):
-  cleanup()
-  sys.exit(0)
-
 def callback(msg):
-  sys.stdout.write(msg.data)
-  sys.stdout.flush()
+  global publisher
+  publisher.publish(msg)
 
 def main():
   global node
-  signal.signal(signal.SIGINT, handler)
+  global publisher
 
   topic = 'js_py_chatter'
   if len(sys.argv) > 1:
     topic = sys.argv[1]
+
   rclpy.init()
   node = rclpy.create_node('py_listener')
+  publisher = node.create_publisher(String, 'back_' + topic)
   subscription = node.create_subscription(String, topic, callback)
   while rclpy.ok():
     rclpy.spin_once(node)

--- a/test/py/service.py
+++ b/test/py/service.py
@@ -18,7 +18,6 @@ import rclpy
 from time import sleep
 from std_msgs.msg import String
 from example_interfaces.srv import AddTwoInts
-import signal
 
 node = None
 
@@ -27,17 +26,12 @@ def cleanup():
   node.destroy_node()
   rclpy.shutdown()
 
-def handler(signum, frame):
-  cleanup()
-  sys.exit(0)
-
 def callback(request, response):
   response.sum = request.a + request.b
   return response
 
 def main():
   global node
-  signal.signal(signal.SIGINT, handler)
 
   service = 'js_py_add_two_ints'
   if len(sys.argv) > 1:

--- a/test/py/subscription_msg.py
+++ b/test/py/subscription_msg.py
@@ -22,6 +22,7 @@ from sensor_msgs.msg import *
 import signal
 
 node = None
+publisher = None
 
 def cleanup():
   global node
@@ -33,8 +34,10 @@ def handler(signum, frame):
   sys.exit(0)
 
 def callback(msg):
-  sys.stdout.write(str(msg.data))
-  sys.stdout.flush()
+  # sys.stdout.write(str(msg.data))
+  # sys.stdout.flush()
+  global publisher
+  publisher.publish(msg)
 
 def callback_array(msg):
   sys.stdout.write(''.join([r.decode('utf-8') for r in msg.data]))
@@ -66,6 +69,7 @@ def callback_jointstate(msg):
 
 def main():
   global node
+  global publisher
   rclType = sys.argv[1]
   signal.signal(signal.SIGINT, handler)
   
@@ -73,58 +77,76 @@ def main():
 
   if rclType == 'Bool':
     node = rclpy.create_node('py_bool_subscription')
+    publisher = node.create_publisher(Bool, 'Bool_js_py_back_channel')
     subscription = node.create_subscription(Bool, 'Bool_js_py_channel', callback)
   elif rclType == 'Byte':
     node = rclpy.create_node('py_byte_subscription')
+    publisher = node.create_publisher(Byte, 'Byte_js_py_back_channel');
     subscription = node.create_subscription(Byte, 'Byte_js_py_channel', callback)
   elif rclType == 'Char':
     node = rclpy.create_node('py_char_subscription')
+    publisher = node.create_publisher(Char, 'Char_js_py_back_channel')
     subscription = node.create_subscription(Char, 'Char_js_py_channel', callback)
   elif rclType == 'String':
     node = rclpy.create_node('py_string_subscription')
+    publisher = node.create_publisher(String, 'String_js_py_back_channel')
     subscription = node.create_subscription(String, 'String_js_py_channel', callback)
   elif rclType == 'Int8':
     node = rclpy.create_node('py_int8_subscription')
+    publisher = node.create_publisher(Int8, 'Int8_js_py_back_channel')
     subscription = node.create_subscription(Int8, 'Int8_js_py_channel', callback)
   elif rclType == 'UInt8':
     node = rclpy.create_node('py_uint8_subscription')
+    publisher = node.create_publisher(UInt8, 'UInt8_js_py_back_channel')
     subscription = node.create_subscription(UInt8, 'UInt8_js_py_channel', callback)
   elif rclType == 'Int16':
     node = rclpy.create_node('py_int16_subscription')
+    publisher = node.create_publisher(Int16, 'Int16_js_py_back_channel')
     subscription = node.create_subscription(Int16, 'Int16_js_py_channel', callback)
   elif rclType == 'UInt16':
     node = rclpy.create_node('py_uint16_subscription')
+    publisher = node.create_publisher(UInt16, 'UInt16_js_py_back_channel')
     subscription = node.create_subscription(UInt16, 'UInt16_js_py_channel', callback)
   elif rclType == 'Int32':
     node = rclpy.create_node('py_int32_subscription')
+    publisher = node.create_publisher(Int32, 'Int32_js_py_back_channel')
     subscription = node.create_subscription(Int32, 'Int32_js_py_channel', callback)
   elif rclType == 'UInt32':
     node = rclpy.create_node('py_uint32_subscription')
+    publisher = node.create_publisher(UInt32, 'UInt32_js_py_back_channel')
     subscription = node.create_subscription(UInt32, 'UInt32_js_py_channel', callback)
   elif rclType == 'Int64':
     node = rclpy.create_node('py_int64_subscription')
+    publisher = node.create_publisher(Int64, 'Int64_js_py_back_channel')
     subscription = node.create_subscription(Int64, 'Int64_js_py_channel', callback)
   elif rclType == 'UInt64':
     node = rclpy.create_node('py_uint64_subscription')
+    publisher = node.create_publisher(UInt64, 'UInt64_js_py_back_channel')
     subscription = node.create_subscription(UInt64, 'UInt64_js_py_channel', callback)
   elif rclType == 'Float32':
     node = rclpy.create_node('py_float32_subscription')
+    publisher = node.create_publisher(Float32, 'Float32_js_py_back_channel')
     subscription = node.create_subscription(Float32, 'Float32_js_py_channel', callback)
   elif rclType == 'Float64':
     node = rclpy.create_node('py_float64_subscription')
+    publisher = node.create_publisher(Float64, 'Float64_js_py_back_channel')
     subscription = node.create_subscription(Float64, 'Float64_js_py_channel', callback)
   elif rclType == 'Array':
     node = rclpy.create_node('py_array_subscription')
-    subscription = node.create_subscription(ByteMultiArray, 'Array_js_py_channel', callback_array)
+    publisher = node.create_publisher(ByteMultiArray, 'Array_js_py_back_channel')
+    subscription = node.create_subscription(ByteMultiArray, 'Array_js_py_channel', callback)
   elif rclType == 'ColorRGBA':
     node = rclpy.create_node('py_colorrgba_subscription')
-    subscription = node.create_subscription(ColorRGBA, 'ColorRGBA_js_py_channel', callback_colorrgba)
+    publisher = node.create_publisher(ColorRGBA, 'ColorRGBA_js_py_back_channel')
+    subscription = node.create_subscription(ColorRGBA, 'ColorRGBA_js_py_channel', callback)
   elif rclType == 'Header':
     node = rclpy.create_node('py_header_subscription')
-    subscription = node.create_subscription(Header, 'Header_js_py_channel', callback_header)         
+    publisher = node.create_publisher(Header, 'Header_js_py_back_channel')
+    subscription = node.create_subscription(Header, 'Header_js_py_channel', callback)         
   elif rclType == 'JointState':
     node = rclpy.create_node('py_jointstate_subscrption')
-    subscription = node.create_subscription(JointState, 'JointState_js_py_channel', callback_jointstate)
+    publisher = node.create_publisher(JointState, 'JointState_js_py_back_channel')
+    subscription = node.create_subscription(JointState, 'JointState_js_py_channel', callback)
   while rclpy.ok():
     rclpy.spin_once(node)
 

--- a/test/py/talker.py
+++ b/test/py/talker.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 import sys
-import signal
+import rclpy
 from time import sleep
 from std_msgs.msg import String
 
-import rclpy
+
 
 node = None
 
@@ -27,13 +27,8 @@ def cleanup():
   node.destroy_node()
   rclpy.shutdown()
 
-def handler(signum, frame):
-  cleanup()
-  sys.exit(0)
-
 def main():
   global node
-  signal.signal(signal.SIGINT, handler)
 
   topic = 'py_js_chatter'
   if len(sys.argv) > 1:

--- a/test/test-cross-lang.js
+++ b/test/test-cross-lang.js
@@ -67,31 +67,27 @@ describe('Cross-language interaction', function() {
       rclnodejs.spin(node);
     });
   });
-    
+
   describe('Node.js publisher', function() {
     it('Cpp subscription should receive msg from Node.js publisher', (done) => {
       var node = rclnodejs.createNode('js_pub_cpp_sub');
       const RclString = 'std_msgs/msg/String';
-      var destroy = false;
 
-      let text = 'Greeting from Node.js publisher';
-      let cppListenerPath = path.join(process.env['AMENT_PREFIX_PATH'], 'lib', 'demo_nodes_cpp', 'listener');
+      let msg = 'Greeting from Node.js publisher';
+      let cppListenerPath = path.join(__dirname, 'cpp', 'listener');
       var cppListener = childProcess.spawn(cppListenerPath, ['-t', 'js_cpp_chatter']);
       var publisher = node.createPublisher(RclString, 'js_cpp_chatter');
-      const msg = text;
+
+      var subscription = node.createSubscription(RclString, 'back_js_cpp_chatter', (backMsg) => {
+        assert.deepStrictEqual(msg, backMsg.data);
+
+        timer.cancel();
+        node.destroy();
+        cppListener.kill('SIGINT');
+        done();
+      });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
-      });
-
-      cppListener.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(text).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          cppListener.kill('SIGINT');
-          destroy = true;
-          done();
-        }
       });
       rclnodejs.spin(node);
     });
@@ -99,26 +95,24 @@ describe('Cross-language interaction', function() {
     it('Python subscription should receive msg from Node.js publisher', function(done) {
       var node = rclnodejs.createNode('js_pub_py_sub');
       const RclString = 'std_msgs/msg/String';
-      var destroy = false;
 
       let text = 'Greeting from Node.js publisher to Python subscription';
       var pyListener = utils.launchPythonProcess([`${__dirname}/py/listener.py`]);
       var publisher = node.createPublisher(RclString, 'js_py_chatter');
+      var subscription = node.createSubscription(RclString, 'back_js_py_chatter', (msg) => {
+        assert.deepStrictEqual(msg.data, text);
+
+        timer.cancel();
+        pyListener.kill('SIGINT');
+        node.destroy();
+        done();
+      });
       var msg = text;
 
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
       });
-      pyListener.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(text).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          pyListener.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
+
       rclnodejs.spin(node);
     });
   });
@@ -181,52 +175,50 @@ describe('Cross-language interaction', function() {
     it('Node.js service should work with Python client', function(done) {
       var node = rclnodejs.createNode('py_js_add_service');
       const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
-      var destroy = false;
+      const Int8 = 'std_msgs/msg/Int8';
 
       var service = node.createService(AddTwoInts, 'py_js_add_two_ints', (request, response) => {
         assert.deepStrictEqual(typeof request.a, 'number');
         assert.deepStrictEqual(typeof request.b, 'number');
         let result = response.template;
         result.sum = request.a + request.b;
-        return result;
+        response.send(result);
+      });
+      var subscription = node.createSubscription(Int8, 'back_py_js_add_two_ints', (msg) => {
+        assert.deepStrictEqual(msg.data, 3);
+        node.destroy();
+        pyClient.kill('SIGINT');
+        done();
       });
       rclnodejs.spin(node);
 
       var pyClient = utils.launchPythonProcess([`${__dirname}/py/client.py`]);
-      pyClient.stdout.on('data', function(data) {
-        assert.ok(new RegExp('3').test(data.toString()));
-        if (!destroy) {
-          node.destroy();
-          destroy = true;
-          done();
-        }
-      });
     });
 
     it('Node.js service should work with C++ client', function(done) {
       var node = rclnodejs.createNode('cpp_js_add_service');
       const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
-      var destroy = false;
+      const Int8 = 'std_msgs/msg/Int8';
 
       var service = node.createService(AddTwoInts, 'cpp_js_add_two_ints', (request, response) => {
         assert.deepStrictEqual(typeof request.a, 'number');
         assert.deepStrictEqual(typeof request.b, 'number');
         let result = response.template;
         result.sum = request.a + request.b;
-        return result;
+        response.send(result);
+      });
+
+      var subscription = node.createSubscription(Int8, 'back_cpp_js_add_two_ints', (backMsg) => {
+        assert.deepStrictEqual(backMsg.data, 5);
+
+        node.destroy();
+        cppClient.kill('SIGINT');
+        done();
       });
       rclnodejs.spin(node);
 
-      var cppClientPath = path.join(process.env['AMENT_PREFIX_PATH'],
-                                    'lib',
-                                    'demo_nodes_cpp',
-                                    'add_two_ints_client');
+      var cppClientPath = path.join(__dirname, 'cpp', 'add_two_ints_client');
       var cppClient = childProcess.spawn(cppClientPath, ['-s', 'cpp_js_add_two_ints']);
-      cppClient.stdout.on('data', function(data) {
-        assert.ok(new RegExp('Result of add_two_ints: 5').test(data.toString()));
-        node.destroy();
-        done();
-      });
     });
   });
 });

--- a/test/test-msg-type-cpp-node.js
+++ b/test/test-msg-type-cpp-node.js
@@ -25,383 +25,33 @@ const utils = require('./utils.js');
 describe('Rclnodejs - Cpp message type testing', function() {
   var cppPublisherPath = path.join(__dirname, 'cpp', 'publisher_msg');
   var cppSubscriptionPath = path.join(__dirname, 'cpp', 'subscription_msg');
+  var cppSubscription = childProcess.spawn(cppSubscriptionPath);
 
   this.timeout(60 * 1000);
-  
+
   before(function() {
     return rclnodejs.init();
   });
-  
+
   after(function() {
     rclnodejs.shutdown();
-  });
-  
-  describe('Cpp publisher - Node.js subscription: primitive message types', function() {
-
-    it('Bool', function(done) {
-      var node = rclnodejs.createNode('bool_js_subscription');
-      const Bool = 'std_msgs/msg/Bool';
-      var destroy = false;
-      
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'Bool_cpp_js_channel', '-m', 'Bool']);
-      var subscription = node.createSubscription(Bool, 'Bool_cpp_js_channel', (msg) => {
-        assert.ok(msg.data);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Byte', function(done) {
-      var node = rclnodejs.createNode('byte_js_subscription');
-      const Byte = 'std_msgs/msg/Byte';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'Byte_cpp_js_channel', '-m', 'Byte']);
-      var subscription = node.createSubscription(Byte, 'Byte_cpp_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 255);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Char', function(done) {
-      var node = rclnodejs.createNode('char_js_subscription');
-      const Char = 'std_msgs/msg/Char';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'Char_cpp_js_channel', '-m', 'Char']);
-      var subscription = node.createSubscription(Char, 'Char_cpp_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 65);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('String', function(done) {
-      var node = rclnodejs.createNode('string_js_subscription');
-      const RclString = 'std_msgs/msg/String';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'String_cpp_js_channel', '-m', 'String']);
-      var subscription = node.createSubscription(RclString, 'String_cpp_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 'Hello World');
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });
-    
-    it('Int8', function(done) {
-      var node = rclnodejs.createNode('int8_js_subscription');
-      const Int8 = 'std_msgs/msg/Int8';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'Int8_cpp_js_channel', '-m', 'Int8']);
-      var subscription = node.createSubscription(Int8, 'Int8_cpp_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 127);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('UInt8', function(done) {
-      var node = rclnodejs.createNode('uint8_js_subscription');
-      const UInt8 = 'std_msgs/msg/UInt8';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'UInt8_cpp_js_channel', '-m', 'UInt8']);
-      var subscription = node.createSubscription(UInt8, 'UInt8_cpp_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 255);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });
-    
-    it('Int16', function(done) {
-      var node = rclnodejs.createNode('int16_js_subscription');
-      const Int16 = 'std_msgs/msg/Int16';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'Int16_cpp_js_channel', '-m', 'Int16']);
-      var subscription = node.createSubscription(Int16, 'Int16_cpp_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 0x7fff);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });
-    
-    it('UInt16', function(done) {
-      var node = rclnodejs.createNode('uint16_js_subscription');
-      const UInt16 = 'std_msgs/msg/UInt16';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'UInt16_cpp_js_channel', '-m', 'UInt16']);
-      var subscription = node.createSubscription(UInt16, 'UInt16_cpp_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 0xffff);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });
-    
-    it('Int32', function(done) {
-      var node = rclnodejs.createNode('int32_js_subscription');
-      const Int32 = 'std_msgs/msg/Int32';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'Int32_cpp_js_channel', '-m', 'Int32']);
-      var subscription = node.createSubscription(Int32, 'Int32_cpp_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 0x7fffffff);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });
-    
-    it('UInt32', function(done) {
-      var node = rclnodejs.createNode('uint32_js_subscription');
-      const UInt32 = 'std_msgs/msg/UInt32';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'UInt32_cpp_js_channel', '-m', 'UInt32']);
-      var subscription = node.createSubscription(UInt32, 'UInt32_cpp_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 0xffffffff);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });
-    
-    it('Int64', function(done) {
-      var node = rclnodejs.createNode('int64_js_subscription');
-      const Int64 = 'std_msgs/msg/Int64';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'Int64_cpp_js_channel', '-m', 'Int64']);
-      var subscription = node.createSubscription(Int64, 'Int64_cpp_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, Math.pow(2, 53) - 1);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });
-    
-    it('UInt64', function(done) {
-      var node = rclnodejs.createNode('uint64_js_subscription');
-      const UInt64 = 'std_msgs/msg/UInt64';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'UInt64_cpp_js_channel', '-m', 'UInt64']);
-      var subscription = node.createSubscription(UInt64, 'UInt64_cpp_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, Math.pow(2, 53) - 1);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });
-    
-    it('Float32', function(done) {
-      var node = rclnodejs.createNode('float32_js_subscription');
-      const Float32 = 'std_msgs/msg/Float32';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'Float32_cpp_js_channel', '-m', 'Float32']);
-      var subscription = node.createSubscription(Float32, 'Float32_cpp_js_channel', (msg) => {
-        assert.ok(Math.abs(msg.data - 3.14) < 0.000001);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Float64', function(done) {
-      var node = rclnodejs.createNode('float64_js_subscription');
-      const Float64 = 'std_msgs/msg/Float64';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'Float64_cpp_js_channel', '-m', 'Float64']);
-      var subscription = node.createSubscription(Float64, 'Float64_cpp_js_channel', (msg) => {
-        assert.ok(Math.abs(msg.data - 3.1415926) < 0.0000001);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });    
+    cppSubscription.kill('SIGINT');
   });
 
-  describe('Cpp publisher - Node.js subscription: compound message types', function() {
-
-    it('ColorRGBA', function(done) {
-      var node = rclnodejs.createNode('colorrgba_js_subscription');
-      const ColorRGBA = 'std_msgs/msg/ColorRGBA';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'ColorRGBA_cpp_js_channel', '-m', 'ColorRGBA']);
-      var subscription = node.createSubscription(ColorRGBA, 'ColorRGBA_cpp_js_channel', (msg) => {
-        assert.ok(Math.abs(msg.a - 0.5) < 0.000001);
-        assert.ok(Math.abs(msg.r - 127) < 0.000001);
-        assert.ok(Math.abs(msg.g - 255) < 0.000001);
-        assert.ok(Math.abs(msg.b - 255) < 0.000001);
-
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Array', function(done) {
-      var node = rclnodejs.createNode('array_js_subscription');
-      var ByteMultiArray = 'std_msgs/msg/ByteMultiArray';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'Array_cpp_js_channel', '-m', 'Array']);
-      var subscription = node.createSubscription(ByteMultiArray, 'Array_cpp_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, Uint8Array.from([65, 66, 67]));
-
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Header', function(done) {
-      var node = rclnodejs.createNode('header_js_publisher');
-      const Header = 'std_msgs/msg/Header';
-      var destroy = false;
-
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'Header_cpp_js_channel', '-m', 'Header']);
-      var subscription = node.createSubscription(Header, 'Header_cpp_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.stamp.sec, 123456);
-        assert.deepStrictEqual(msg.stamp.nanosec, 789);
-        assert.deepStrictEqual(msg.frame_id, 'main frame');
-
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-          done();
-        }        
-
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Complex object', function(done) {
-      var node = rclnodejs.createNode('jointstate_js_publisher');
-      const JointState = 'sensor_msgs/msg/JointState';
-      var destroy = false;
-      var publisher = childProcess.spawn(cppPublisherPath, ['-t', 'JointState_cpp_js_channel', '-m', 'JointState']);
-      var subscription = node.createSubscription(JointState, 'JointState_cpp_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.header.stamp.sec, 123456);
-        assert.deepStrictEqual(msg.header.stamp.nanosec, 789);
-        assert.deepStrictEqual(msg.header.frame_id, 'main frame');
-        assert.deepStrictEqual(msg.name, ['Tom', 'Jerry']);
-        assert.deepStrictEqual(msg.position, Float64Array.from([1, 2]));
-        assert.deepStrictEqual(msg.velocity, Float64Array.from([2, 3]));
-        assert.deepStrictEqual(msg.effort, Float64Array.from([4, 5, 6]));
-
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });    
-  });
-
-  describe('Node.js publisher - Cpp subscription: primitive message types', function() {
+  describe('Primitive message types', function() {
 
     it('Bool', function(done) {
       var node = rclnodejs.createNode('bool_js_publisher');
       const Bool = 'std_msgs/msg/Bool';
       const msg = true;
-      var destroy = false;
 
-      var subscription = childProcess.spawn(cppSubscriptionPath, ['-t', 'Bool_js_cpp_channel']);
       var publisher = node.createPublisher(Bool, 'Bool_js_cpp_channel');
-      const expected = '1';
+      var subscription = node.createSubscription(Bool, 'back_Bool_js_cpp_channel', (backMsg) => {
+        assert.deepStrictEqual(backMsg.data, msg);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
 
       var timer = node.createTimer(100, () => {
@@ -414,21 +64,14 @@ describe('Rclnodejs - Cpp message type testing', function() {
       var node = rclnodejs.createNode('byte_js_publisher');
       const Byte = 'std_msgs/msg/Byte';
       const msg = 0x41;
-      var destroy = false;
 
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(Byte, 'Byte_js_cpp_channel');
-      const expected = 'A';
+      var subscription = node.createSubscription(Byte, 'back_Byte_js_cpp_channel', (backMsg) => {
+        assert.deepStrictEqual(backMsg.data, msg);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
 
       var timer = node.createTimer(100, () => {
@@ -442,21 +85,14 @@ describe('Rclnodejs - Cpp message type testing', function() {
       var node = rclnodejs.createNode('char_js_publisher');
       const Char = 'std_msgs/msg/Char';
       const msg = 0x61;
-      var destroy = false;
 
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(Char, 'Char_js_cpp_channel');
-      const expected = 'a';
+      var subscription = node.createSubscription(Char, 'back_Char_js_cpp_channel', (backMsg) => {
+        assert.deepStrictEqual(backMsg.data, msg);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
 
       var timer = node.createTimer(100, () => {
@@ -464,26 +100,19 @@ describe('Rclnodejs - Cpp message type testing', function() {
       });
       rclnodejs.spin(node);
     });
-    
+
     it('String', function(done) {
       var node = rclnodejs.createNode('string_js_publisher');
       const RclString = 'std_msgs/msg/String';
       const msg = 'Hello World';
-      var destroy = false;
 
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(RclString, 'String_js_cpp_channel');
-      const expected = 'Hello World';
+      var subscription = node.createSubscription(RclString, 'back_String_js_cpp_channel', (backMsg) => {
+        assert.deepStrictEqual(backMsg.data, msg);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
 
       var timer = node.createTimer(100, () => {
@@ -491,26 +120,20 @@ describe('Rclnodejs - Cpp message type testing', function() {
       });
       rclnodejs.spin(node);
     });
-    
+
     it('Int8', function(done) {
       var node = rclnodejs.createNode('int8_js_publisher');
       const Int8 = 'std_msgs/msg/Int8';
       const msg = 0x7f;
       var destroy = false;
 
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(Int8, 'Int8_js_cpp_channel');
-      const expected = '7f';
+      var subscription = node.createSubscription(Int8, 'back_Int8_js_cpp_channel', (backMsg) => {
+        assert.deepStrictEqual(backMsg.data, msg);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
 
       var timer = node.createTimer(100, () => {
@@ -518,26 +141,19 @@ describe('Rclnodejs - Cpp message type testing', function() {
       });
       rclnodejs.spin(node);
     });
-    
+
     it('UInt8', function(done) {
       var node = rclnodejs.createNode('uint8_js_publisher');
       const UInt8 = 'std_msgs/msg/UInt8';
       const msg = 0xff;
-      var destroy = false;
 
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(UInt8, 'UInt8_js_cpp_channel');
-      const expected = 'ff';
+      var subscription = node.createSubscription(UInt8, 'back_UInt8_js_cpp_channel', (backMsg) => {
+        assert.deepStrictEqual(backMsg.data, msg);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
 
       var timer = node.createTimer(100, () => {
@@ -545,26 +161,19 @@ describe('Rclnodejs - Cpp message type testing', function() {
       });
       rclnodejs.spin(node);
     });
-    
+
     it('Int16', function(done) {
       var node = rclnodejs.createNode('int16_js_publisher');
       const Int16 = 'std_msgs/msg/Int16';
       const msg = 0x7fff;
-      var destroy = false;
 
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(Int16, 'Int16_js_cpp_channel');
-      const expected = '7fff';
+      var subscription = node.createSubscription(Int16, 'back_Int16_js_cpp_channel', (backMsg) => {
+        assert.deepStrictEqual(backMsg.data, msg);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.ok(new RegExp(expected).test(data.toString().toLowerCase()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
 
       var timer = node.createTimer(100, () => {
@@ -572,53 +181,39 @@ describe('Rclnodejs - Cpp message type testing', function() {
       });
       rclnodejs.spin(node);
     });
-    
+
     it('UInt16', function(done) {
       var node = rclnodejs.createNode('uint16_js_publisher');
       const UInt16 = 'std_msgs/msg/UInt16';
       const msg = 0xffff;
       var destroy = false;
 
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(UInt16, 'UInt16_js_cpp_channel');
-      const expected = 'ffff';
+      var subscription = node.createSubscription(UInt16, 'back_UInt16_js_cpp_channel', (backMsg) => {
+        assert.deepStrictEqual(backMsg.data, msg);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {          
-          assert.ok(new RegExp(expected).test(data.toString().toLowerCase()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
-
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
     });
-    
+
     it('Int32', function(done) {
       var node = rclnodejs.createNode('int32_js_publisher');
       const Int32 = 'std_msgs/msg/Int32';
       const msg = 0x7fffffff;
-      var destroy = false;
 
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(Int32, 'Int32_js_cpp_channel');
-      const expected = '7fffffff';
+      var subscription = node.createSubscription(Int32, 'back_Int32_js_cpp_channel', (backMsg) => {
+        assert.deepStrictEqual(backMsg.data, msg);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString().toLowerCase()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
 
       var timer = node.createTimer(100, () => {
@@ -626,28 +221,20 @@ describe('Rclnodejs - Cpp message type testing', function() {
       });
       rclnodejs.spin(node);
     });
-    
+
     it('UInt32', function(done) {
       var node = rclnodejs.createNode('uint32_js_publisher');
       const UInt32 = 'std_msgs/msg/UInt32';
       const msg = 0xffffffff;
-      var destroy = false;
 
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(UInt32, 'UInt32_js_cpp_channel');
-      const expected = 'ffffffff';
+      var subscription = node.createSubscription(UInt32, 'back_UInt32_js_cpp_channel', (backMsg) => {
+        assert.deepStrictEqual(backMsg.data, msg);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString().toLowerCase()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
-
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
       });
@@ -658,104 +245,73 @@ describe('Rclnodejs - Cpp message type testing', function() {
       var node = rclnodejs.createNode('int64_js_publisher');
       const Int64 = 'std_msgs/msg/Int64';
       const msg = Number.MAX_SAFE_INTEGER;
-      var destroy = false;
 
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(Int64, 'Int64_js_cpp_channel');
-      const expected = '1fffffffffffff';
+      var subscription = node.createSubscription(Int64, 'back_Int64_js_cpp_channel', (backMsg) => {
+        assert.deepStrictEqual(backMsg.data, msg);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString().toLowerCase()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
-
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
     });
-    
+
     it('UInt64', function(done) {
       var node = rclnodejs.createNode('uint64_js_publisher');
       const UInt64 = 'std_msgs/msg/UInt64';
       const msg = Number.MAX_SAFE_INTEGER;
       var destroy = false;
 
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(UInt64, 'UInt64_js_cpp_channel');
-      const expected = '1fffffffffffff';
+      var subscription = node.createSubscription(UInt64, 'back_UInt64_js_cpp_channel', (backMsg) => {
+        assert.deepStrictEqual(backMsg.data, msg);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString().toLowerCase()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
-
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
     });
-    
+
     it('Float32', function(done) {
       var node = rclnodejs.createNode('float32_js_publisher');
       const Float32 = 'std_msgs/msg/Float32';
       const msg = 3.14;
-      var destroy = false;
 
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(Float32, 'Float32_js_cpp_channel');
-      const expected = '3.14';
+      var subscription = node.createSubscription(Float32, 'back_Float32_js_cpp_channel', (backMsg) => {
+        assert.ok(Math.abs(msg - backMsg.data) < 0.01);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
-
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
     });
-    
+
     it('Float64', function(done) {
       var node = rclnodejs.createNode('float64_js_publisher');
       const Float64 = 'std_msgs/msg/Float64';
       const msg = 3.1415926;
-      var destroy = false;
 
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(Float64, 'Float64_js_cpp_channel');
-      const expected = '3.1415926';
+      var subscription = node.createSubscription(Float64, 'back_Float64_js_cpp_channel', (backMsg) => {
+        assert.ok(Math.abs(msg - backMsg.data) < 0.0000001);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
-
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
       });
@@ -763,7 +319,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
     });    
   });
 
-  describe('Node.js publisher - Cpp subscription: compound message types', function() {
+  describe('Compound message types', function() {
     it('ColorRGBA', function(done) {
       var node = rclnodejs.createNode('colorrgba_js_publisher');
       const ColorRGBA = 'std_msgs/msg/ColorRGBA';
@@ -775,19 +331,13 @@ describe('Rclnodejs - Cpp message type testing', function() {
       };
       var destroy = false;
 
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(ColorRGBA, 'ColorRGBA_js_cpp_channel');
-      const expected = '(0.5, 127, 255, 255)';
+      var subscription = node.createSubscription(ColorRGBA, 'back_ColorRGBA_js_cpp_channel', (backMsg) => {
+        assert.deepEqual(msg, backMsg);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
 
       var timer = node.createTimer(100, () => {
@@ -814,28 +364,20 @@ describe('Rclnodejs - Cpp message type testing', function() {
         data: [65, 66, 67],
       };
 
-      var destroy = false;
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(ByteMultiArray, 'Array_js_cpp_channel');
-      const expected = 'ABC';
+      var subscription = node.createSubscription(ByteMultiArray, 'back_ByteMultiArray_js_cpp_channel', (backMsg) => {
+        assert.deepEqual(msg, backMsg);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
-
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
     });
-    
+
     it('Header', function(done) {
       var node = rclnodejs.createNode('header_js_publisher');
       const Header = 'std_msgs/msg/Header';
@@ -848,20 +390,13 @@ describe('Rclnodejs - Cpp message type testing', function() {
         frame_id: 'main frame',
       };
 
-      var destroy = false;
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(Header, 'Header_js_cpp_channel');
-      const expected = '(123456,789,main frame)';
+      var subscription = node.createSubscription(Header, 'back_Header_js_cpp_channel', (backMsg) => {
+        assert.deepEqual(msg, backMsg);
 
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+        timer.cancel();
+        node.destroy();
+        done();
       });
 
       var timer = node.createTimer(100, () => {
@@ -869,7 +404,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
       });
       rclnodejs.spin(node);
     });
-    
+
     it('Complex object', function(done) {
       var node = rclnodejs.createNode('jointstate_js_publisher');
       const JointState = 'sensor_msgs/msg/JointState';
@@ -889,23 +424,18 @@ describe('Rclnodejs - Cpp message type testing', function() {
       };
 
       var destroy = false;
-      var subscription = childProcess.spawn(cppSubscriptionPath);
       var publisher = node.createPublisher(JointState, 'JointState_js_cpp_channel');
-      const expected = '(123456,789,main frame,[Tom,Jerry,],[1,2,],[2,3,],[4,5,6,])';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.notDeepStrictEqual(data.toString().indexOf(expected), -1);
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(JointState, 'back_JointState_js_cpp_channel', (backMsg) => {
+        assert.deepEqual(msg, backMsg);
+
+        timer.cancel();
+        node.destroy();
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
-    });    
-  });  
+    });
+  });
 });

--- a/test/test-msg-type-py-node.js
+++ b/test/test-msg-type-py-node.js
@@ -32,334 +32,7 @@ describe('Rclnodejs - Python message type testing', function() {
     rclnodejs.shutdown();
   });
 
-  describe('Python publisher - rclnodejs subscription: primitive msg types', function() {
-    it('Bool', function(done) {
-      var node = rclnodejs.createNode('bool_js_subscription');
-      const Bool = 'std_msgs/msg/Bool';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'Bool']);
-      var subscription = node.createSubscription(Bool, 'Bool_py_js_channel', (msg) => {
-        assert.ok(msg.data);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Byte', function(done) {
-      var node = rclnodejs.createNode('byte_js_subscription');
-      const Byte = 'std_msgs/msg/Byte';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'Byte']);
-      var subscription = node.createSubscription(Byte, 'Byte_py_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 255);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Char', function(done) {
-      var node = rclnodejs.createNode('char_js_subscription');
-      const Char = 'std_msgs/msg/Char';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'Char']);
-      var subscription = node.createSubscription(Char, 'Char_py_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 65);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('String', function(done) {
-      var node = rclnodejs.createNode('string_js_subscription');
-      const String = 'std_msgs/msg/String';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'String']);
-      var subscription = node.createSubscription(String, 'String_py_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 'Hello World');
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Int8', function(done) {
-      var node = rclnodejs.createNode('int8_js_subscription');
-      const Int8 = 'std_msgs/msg/Int8';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'Int8']);
-      var subscription = node.createSubscription(Int8, 'Int8_py_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 127);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('UInt8', function(done) {
-      var node = rclnodejs.createNode('uint8_js_subscription');
-      const UInt8 = 'std_msgs/msg/UInt8';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'UInt8']);
-      var subscription = node.createSubscription(UInt8, 'UInt8_py_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 255);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Int16', function(done) {
-      var node = rclnodejs.createNode('int16_js_subscription');
-      const Int16 = 'std_msgs/msg/Int16';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'Int16']);
-      var subscription = node.createSubscription(Int16, 'Int16_py_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 0x7fff);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('UInt16', function(done) {
-      var node = rclnodejs.createNode('uint16_js_subscription');
-      const UInt16 = 'std_msgs/msg/UInt16';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'UInt16']);
-      var subscription = node.createSubscription(UInt16, 'UInt16_py_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 0xffff);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Int32', function(done) {
-      var node = rclnodejs.createNode('int32_js_subscription');
-      const Int32 = 'std_msgs/msg/Int32';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'Int32']);
-      var subscription = node.createSubscription(Int32, 'Int32_py_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 0x7fffffff);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('UInt32', function(done) {
-      var node = rclnodejs.createNode('uint32_js_subscription');
-      const UInt32 = 'std_msgs/msg/UInt32';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'UInt32']);
-      var subscription = node.createSubscription(UInt32, 'UInt32_py_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, 0xffffffff);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Int64', function(done) {
-      var node = rclnodejs.createNode('int64_js_subscription');
-      const Int64 = 'std_msgs/msg/Int64';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'Int64']);
-      var subscription = node.createSubscription(Int64, 'Int64_py_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, Number.MAX_SAFE_INTEGER);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('UInt64', function(done) {
-      var node = rclnodejs.createNode('uint64_js_subscription');
-      const UInt64 = 'std_msgs/msg/UInt64';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'UInt64']);
-      var subscription = node.createSubscription(UInt64, 'UInt64_py_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, Number.MAX_SAFE_INTEGER);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Float32', function(done) {
-      var node = rclnodejs.createNode('float32_js_subscription');
-      const Float32 = 'std_msgs/msg/Float32';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'Float32']);
-      var subscription = node.createSubscription(Float32, 'Float32_py_js_channel', (msg) => {
-        assert.ok(Math.abs(msg.data - 3.14) < 0.000001);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Float64', function(done) {
-      var node = rclnodejs.createNode('float64_js_subscription');
-      const Float64 = 'std_msgs/msg/Float64';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'Float64']);
-      var subscription = node.createSubscription(Float64, 'Float64_py_js_channel', (msg) => {
-        assert.ok(Math.abs(msg.data - 3.14) < 0.000001);
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-  });
-
-  describe('Python publisher - rlcnodejs subscription: compound msg types', function() {
-    this.timeout(60 * 1000);
-
-    it('ColorRGBA', function(done) {
-      var node = rclnodejs.createNode('colorrgba_js_subscription');
-      const ColorRGBA = 'std_msgs/msg/ColorRGBA';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'ColorRGBA']);
-      var subscription = node.createSubscription(ColorRGBA, 'ColorRGBA_py_js_channel', (msg) => {
-        assert.ok(Math.abs(msg.a - 0.5) < 0.000001);
-        assert.ok(Math.abs(msg.r - 127) < 0.000001);
-        assert.ok(Math.abs(msg.g - 255) < 0.000001);
-        assert.ok(Math.abs(msg.b - 255) < 0.000001);
-
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Array', function(done) {
-      var node = rclnodejs.createNode('array_js_subscription');
-      const ByteMultiArray = 'std_msgs/msg/ByteMultiArray';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'Array']);
-      var subscription = node.createSubscription(ByteMultiArray, 'Array_py_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.data, Uint8Array.from([65, 66, 67]));
-
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Header', function(done) {
-      var node = rclnodejs.createNode('header_js_publisher');
-      const Header = 'std_msgs/msg/Header';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'Header']);
-      var subscription = node.createSubscription(Header, 'Header_py_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.stamp.sec, 123456);
-        assert.deepStrictEqual(msg.stamp.nanosec, 789);
-        assert.deepStrictEqual(msg.frame_id, 'main frame');
-
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-
-    it('Complex object', function(done) {
-      var node = rclnodejs.createNode('jointstate_js_publisher');
-      const JointState = 'sensor_msgs/msg/JointState';
-      var destroy = false;
-      var publisher = utils.launchPythonProcess([`${__dirname}/py/publisher_msg.py`, 'JointState']);
-      var subscription = node.createSubscription(JointState, 'JointState_py_js_channel', (msg) => {
-        assert.deepStrictEqual(msg.header.stamp.sec, 123456);
-        assert.deepStrictEqual(msg.header.stamp.nanosec, 789);
-        assert.deepStrictEqual(msg.header.frame_id, 'main frame');
-        assert.deepStrictEqual(msg.name, ['Tom', 'Jerry']);
-        assert.deepStrictEqual(msg.position, Float64Array.from([1, 2]));
-        assert.deepStrictEqual(msg.velocity, Float64Array.from([2, 3]));
-        assert.deepStrictEqual(msg.effort, Float64Array.from([4, 5, 6]));
-
-        if (!destroy) {
-          node.destroy();
-          publisher.kill('SIGINT');
-          destroy = true;
-        }
-        done();
-      });
-      rclnodejs.spin(node);
-    });
-  });
-
-  describe('Rclnodejs publisher - Python subscription: primitive msg types', function(done) {
+  describe('Primitive msg types', function(done) {
     this.timeout(60 * 1000);
 
     it('Bool', function(done) {
@@ -368,19 +41,14 @@ describe('Rclnodejs - Python message type testing', function() {
       const msg = true;
       var destroy = false;
 
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Bool']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Bool']);
       var publisher = node.createPublisher(Bool, 'Bool_js_py_channel');
-
-      const expected = 'True';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(Bool, 'Bool_js_py_back_channel', (backMsg) => {
+        assert.deepStrictEqual(msg, backMsg.data);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
@@ -394,19 +62,14 @@ describe('Rclnodejs - Python message type testing', function() {
       const msg = 'A';
       var destroy = false;
 
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Byte']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Byte']);
       var publisher = node.createPublisher(Byte, 'Byte_js_py_channel');
-
-      const expected = "b'A'";
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(Byte, 'Byte_js_py_back_channel', (backMsg) => {
+        assert.deepStrictEqual(msg.charCodeAt(0), backMsg.data);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
@@ -420,19 +83,14 @@ describe('Rclnodejs - Python message type testing', function() {
       const msg = 0x61;
       var destroy = false;
 
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Char']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Char']);
       var publisher = node.createPublisher(Char, 'Char_js_py_channel');
-
-      const expected = 'a';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(Char, 'Char_js_py_back_channel', (backMsg) => {
+        assert.deepStrictEqual(msg, backMsg.data);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
@@ -446,45 +104,35 @@ describe('Rclnodejs - Python message type testing', function() {
       const msg = 'Hello World';
       var destroy = false;
 
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'String']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'String']);
       var publisher = node.createPublisher(String, 'String_js_py_channel');
-
-      const expected = 'Hello World';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(String, 'String_js_py_back_channel', (backMsg) => {
+        assert.deepStrictEqual(msg, backMsg.data);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
     });
-    
+
     it('Int8', function(done) {
       var node = rclnodejs.createNode('int8_js_publisher');
       const Int8 = 'std_msgs/msg/Int8';
       const msg = 0x7f;
       var destroy = false;
 
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Int8']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Int8']);
       var publisher = node.createPublisher(Int8, 'Int8_js_py_channel');
-
-      const expected = '127';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(Int8, 'Int8_js_py_back_channel', (backMsg) => {
+        assert.deepStrictEqual(msg, backMsg.data);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
@@ -498,19 +146,14 @@ describe('Rclnodejs - Python message type testing', function() {
       const msg = 0xff;
       var destroy = false;
 
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'UInt8']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'UInt8']);
       var publisher = node.createPublisher(UInt8, 'UInt8_js_py_channel');
-
-      const expected = '255';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(UInt8, 'UInt8_js_py_back_channel', (backMsg) => {
+        assert.deepStrictEqual(msg, backMsg.data);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
@@ -524,19 +167,14 @@ describe('Rclnodejs - Python message type testing', function() {
       const msg = 0x7fff;
       var destroy = false;
 
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Int16']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Int16']);
       var publisher = node.createPublisher(Int16, 'Int16_js_py_channel');
-
-      const expected = '32767';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(Int16, 'Int16_js_py_back_channel', (backMsg) => {
+        assert.deepStrictEqual(msg, backMsg.data);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
@@ -550,19 +188,14 @@ describe('Rclnodejs - Python message type testing', function() {
       const msg = 0xffff;
       var destroy = false;
 
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'UInt16']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'UInt16']);
       var publisher = node.createPublisher(UInt16, 'UInt16_js_py_channel');
-
-      const expected = '65535';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(UInt16, 'UInt16_js_py_back_channel', (backMsg) => {
+        assert.deepStrictEqual(msg, backMsg.data);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
@@ -576,45 +209,35 @@ describe('Rclnodejs - Python message type testing', function() {
       const msg = 0x7fffffff;
       var destroy = false;
 
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Int32']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Int32']);
       var publisher = node.createPublisher(Int32, 'Int32_js_py_channel');
-
-      const expected = '2147483647';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(Int32, 'Int32_js_py_back_channel', (backMsg) => {
+        assert.deepStrictEqual(msg, backMsg.data);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
     });
-    
+
     it('UInt32', function(done) {
       var node = rclnodejs.createNode('uint32_js_publisher');
       const UInt32 = 'std_msgs/msg/UInt32';
       const msg = 0xffffffff;
       var destroy = false;
 
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'UInt32']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'UInt32']);
       var publisher = node.createPublisher(UInt32, 'UInt32_js_py_channel');
-
-      const expected = '4294967295';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(UInt32, 'UInt32_js_py_back_channel', (backMsg) => {
+        assert.deepStrictEqual(msg, backMsg.data);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
@@ -628,19 +251,14 @@ describe('Rclnodejs - Python message type testing', function() {
       const msg = Number.MAX_SAFE_INTEGER;
       var destroy = false;
 
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Int64']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Int64']);
       var publisher = node.createPublisher(Int64, 'Int64_js_py_channel');
-
-      const expected = '9007199254740991';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(Int64, 'Int64_js_py_back_channel', (backMsg) => {
+        assert.deepStrictEqual(msg, backMsg.data);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
@@ -654,19 +272,14 @@ describe('Rclnodejs - Python message type testing', function() {
       const msg = Number.MAX_SAFE_INTEGER;
       var destroy = false;
 
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'UInt64']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'UInt64']);
       var publisher = node.createPublisher(UInt64, 'UInt64_js_py_channel');
-
-      const expected = '9007199254740991';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(UInt64, 'UInt64_js_py_back_channel', (backMsg) => {
+        assert.deepStrictEqual(msg, backMsg.data);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
@@ -680,19 +293,14 @@ describe('Rclnodejs - Python message type testing', function() {
       const msg = 3.14;
       var destroy = false;
 
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Float32']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Float32']);
       var publisher = node.createPublisher(Float32, 'Float32_js_py_channel');
-
-      const expected = '3.14';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(Math.abs(parseFloat(data.toString()) - expected) < 0.000001);
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(Float32, 'Float32_js_py_back_channel', (backMsg) => {
+        assert.ok(Math.abs(msg - backMsg.data) < 0.01);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
@@ -706,19 +314,14 @@ describe('Rclnodejs - Python message type testing', function() {
       const msg = 3.1415926;
       var destroy = false;
 
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Float64']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Float64']);
       var publisher = node.createPublisher(Float64, 'Float64_js_py_channel');
-
-      const expected = '3.1415926';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(Float64, 'Float64_js_py_back_channel', (backMsg) => {
+        assert.ok(Math.abs(msg - backMsg.data) < 0.0000001);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
@@ -727,14 +330,14 @@ describe('Rclnodejs - Python message type testing', function() {
     });
   });
 
-  describe('Rclnodejs publisher - Python subscription: compound msg types', function() {
+  describe('Compound msg types', function() {
     this.timeout(60 * 1000);
 
     it('Array', function(done) {
       var node = rclnodejs.createNode('multiarray_js_publisher');
       const ByteMultiArray = 'std_msgs/msg/ByteMultiArray';
 
-      const byteArray = {
+      const msg = {
         layout: {
           dim: [
             {
@@ -749,21 +352,17 @@ describe('Rclnodejs - Python message type testing', function() {
       };
 
       var destroy = false;
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Array']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Array']);
       var publisher = node.createPublisher(ByteMultiArray, 'Array_js_py_channel');
-      const expected = 'ABC';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
-      });
+      var subscription = node.createSubscription(ByteMultiArray, 'Array_js_py_back_channel', (backMsg) => {
+        assert.deepEqual(msg, backMsg);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
+      });       
       var timer = node.createTimer(100, () => {
-        publisher.publish(byteArray);
+        publisher.publish(msg);
       });
       rclnodejs.spin(node);
     });
@@ -779,18 +378,14 @@ describe('Rclnodejs - Python message type testing', function() {
       };
 
       var destroy = false;
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'ColorRGBA']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'ColorRGBA']);
       var publisher = node.createPublisher(ColorRGBA, 'ColorRGBA_js_py_channel');
-      const expected = '(127.0,255.0,255.0,0.5)';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(ColorRGBA, 'ColorRGBA_js_py_back_channel', (backMsg) => {
+        assert.deepEqual(msg, backMsg);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
@@ -811,18 +406,14 @@ describe('Rclnodejs - Python message type testing', function() {
       };
 
       var destroy = false;
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Header']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Header']);
       var publisher = node.createPublisher(Header, 'Header_js_py_channel');
-      const expected = '(123456,789,main frame)';
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.ok(new RegExp(expected).test(data.toString()));
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }
+      var subscription = node.createSubscription(Header, 'Header_js_py_back_channel', (backMsg) => {
+        assert.deepStrictEqual(msg, backMsg);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);
@@ -849,18 +440,14 @@ describe('Rclnodejs - Python message type testing', function() {
       };
 
       var destroy = false;
-      var subscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'JointState']);
+      var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'JointState']);
       var publisher = node.createPublisher(JointState, 'JointState_js_py_channel');
-      const expected = "(123456,789,main frame,['Tom', 'Jerry'],[1.0, 2.0],[2.0, 3.0],[4.0, 5.0, 6.0])";
-      subscription.stdout.on('data', (data) => {
-        if (!destroy) {
-          assert.notDeepStrictEqual(data.toString().indexOf(expected), -1);
-          timer.cancel();
-          node.destroy();
-          subscription.kill('SIGINT');
-          destroy = true;
-          done();
-        }       
+      var subscription = node.createSubscription(JointState, 'JointState_js_py_back_channel', (backMsg) => {
+        assert.deepEqual(msg, backMsg);
+        timer.cancel();
+        node.destroy();
+        pySubscription.kill('SIGINT');
+        done();
       });
       var timer = node.createTimer(100, () => {
         publisher.publish(msg);

--- a/test/test-multi-nodes.js
+++ b/test/test-multi-nodes.js
@@ -163,18 +163,16 @@ describe('Multiple nodes interation testing', function() {
 
       var pyReceived = false, cppReceived = false;
       var cppSubscription = node.createSubscription(Int8, 'back_pycpp_js_add_two_ints', (backMsg) => {
-        if (backMsg.data === 5) {
+        if (backMsg.data === 5)
           cppReceived = true;
-          cppClient.kill('SIGINT');
-        }
 
-        if (backMsg.data === 3) {
+        if (backMsg.data === 3)
           pyReceived = true;
-          pyClient.kill('SIGINT');
-        }
 
         if (cppReceived && pyReceived) {
           node.destroy();
+          cppClient.kill('SIGINT');
+          pyClient.kill('SIGINT');
           done();
         }
       });

--- a/test/test-multi-nodes.js
+++ b/test/test-multi-nodes.js
@@ -37,44 +37,28 @@ describe('Multiple nodes interation testing', function() {
       const RclString = 'std_msgs/msg/String';
 
       var cppReceived = false, pyReceived = false;
-      var cppSubPath = path.join(process.env['AMENT_PREFIX_PATH'], 'lib', 'demo_nodes_cpp', 'listener');
+      var cppSubPath = path.join(__dirname, 'cpp', 'listener');
       var cppSubscription = childProcess.spawn(cppSubPath, ['-t', 'js_pycpp_chatter']);
       var pySubPath = path.join(__dirname, 'py', 'listener.py');
       var pySubscription = utils.launchPythonProcess([pySubPath, 'js_pycpp_chatter']);
 
       const msg = 'hello world';
-      var jsPublisher = node.createPublisher(RclString, 'js_pycpp_chatter');
-      var timer = node.createTimer(100, () => {
-        jsPublisher.publish(msg);
-      });
+      var count = 0;
+      var jsSubscription1 = node.createSubscription(RclString, 'back_js_pycpp_chatter', (backMsg) => {
+        count++;
+        assert.deepStrictEqual(backMsg.data, msg);
 
-      cppSubscription.stdout.on('data', (data) => {
-        if (!cppReceived) {
-          assert.ok(new RegExp('hello world').test(data.toString()));
-          cppReceived = true;
+        if (count === 2) {
+          node.destroy();
           cppSubscription.kill('SIGINT');
-
-          if (pyReceived) {
-            timer.cancel();
-            node.destroy();
-            done();
-          }
-        }
-      });
-
-      pySubscription.stdout.on('data', (data) => {
-        if (!pyReceived) {
-          assert.ok(new RegExp('hello world').test(data.toString()));
-          pyReceived = true;
           pySubscription.kill('SIGINT');
-
-          if (cppReceived) {
-            timer.cancel();
-            node.destroy();
-            done();
-          }
+          done();
         }
       });
+      var jsPublisher = node.createPublisher(RclString, 'js_pycpp_chatter');
+      setTimeout(() => {
+        jsPublisher.publish(msg);
+      }, 500);
       rclnodejs.spin(node);
     });
 
@@ -168,30 +152,38 @@ describe('Multiple nodes interation testing', function() {
     it('Node.js service - Cpp client and Python client', function(done) {
       var node = rclnodejs.createNode('multi_nodes_js_service');
       const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
+      const Int8 = 'std_msgs/msg/Int8';
       var service = node.createService(AddTwoInts, 'pycpp_js_add_two_ints', (request, response) => {
         assert.deepStrictEqual(typeof request.a, 'number');
         assert.deepStrictEqual(typeof request.b, 'number');
         let result = response.template;
         result.sum = request.a + request.b;
-        return result;
+        response.send(result);
+      });
+
+      var pyReceived = false, cppReceived = false;
+      var cppSubscription = node.createSubscription(Int8, 'back_pycpp_js_add_two_ints', (backMsg) => {
+        if (backMsg.data === 5) {
+          cppReceived = true;
+          cppClient.kill('SIGINT');
+        }
+
+        if (backMsg.data === 3) {
+          pyReceived = true;
+          pyClient.kill('SIGINT');
+        }
+
+        if (cppReceived && pyReceived) {
+          node.destroy();
+          done();
+        }
       });
       rclnodejs.spin(node);
-      var cppClientPath = path.join(process.env['AMENT_PREFIX_PATH'],
-                                    'lib',
-                                    'demo_nodes_cpp',
-                                    'add_two_ints_client');
-      var cppClient = childProcess.spawn(cppClientPath, ['-s', 'pycpp_js_add_two_ints']);
+
       var pyClientPath = path.join(__dirname, 'py', 'client.py');
-
-      cppClient.stdout.on('data', (data) => {
-        assert.deepStrictEqual(data.toString().trim(), 'Result of add_two_ints: 5');
-        var pyClient = utils.launchPythonProcess([pyClientPath, 'pycpp_js_add_two_ints']);
-
-        pyClient.stdout.on('data', (data) => {
-          assert.deepStrictEqual(data.toString().trim(), '3');
-          done();
-        });
-      });
+      var pyClient = utils.launchPythonProcess([pyClientPath, 'pycpp_js_add_two_ints']);
+      var cppClientPath = path.join(__dirname, 'cpp', 'add_two_ints_client');
+      var cppClient = childProcess.spawn(cppClientPath, ['-s', 'pycpp_js_add_two_ints']);
     });
   });
 });


### PR DESCRIPTION
Before we used console output of C++ and Python subscription to
check the message, this may sometimes fail on low performance machine.
Now we use a new strategy to verify message:
* Rclnodejs publisher sends message to C++ or Python subscriptions
* The subscriptions send the message back by creating a new publisher
* The rclnodejs side then creates a new subscription to receive messages

Therefore, there is no need to keep the rclnodejs subscription - C++/Python
publisher cases any more.

Fix: #222