### PR TITLE
Synchronize the handles when added

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -134,6 +134,8 @@ class Node {
     let timer = new Timer(timerHandle, period, callback);
     debug('Finish creating timer, period = %d.', period);
     this._timers.push(timer);
+    this.syncHandles();
+
     return timer;
   }
 
@@ -196,6 +198,8 @@ class Node {
     let subscription = Subscription.createSubscription(this.handle, typeClass, topic, callback, qos);
     debug('Finish creating subscription, topic = %s.', topic);
     this._subscriptions.push(subscription);
+    this.syncHandles();
+
     return subscription;
   }
 
@@ -221,6 +225,8 @@ class Node {
     let client = Client.createClient(this.handle, serviceName, typeClass, qos);
     debug('Finish creating client, service = %s.', serviceName);
     this._clients.push(client);
+    this.syncHandles();
+
     return client;
   }
 
@@ -262,6 +268,8 @@ class Node {
     let service = Service.createService(this.handle, serviceName, typeClass, callback, qos);
     debug('Finish creating service, service = %s.', serviceName);
     this._services.push(service);
+    this.syncHandles();
+
     return service;
   }
 


### PR DESCRIPTION
When adding new handles of timer/subscription/client/service, they
should be synchronized to the native side, which will be used in the rcl
to query the events.