### PR TITLE
Change parameter type of timer from uint64_t to int64_t

### DIFF
--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -72,7 +72,7 @@ NAN_METHOD(CreateTimer) {
   *timer = rcl_get_zero_initialized_timer();
   THROW_ERROR_IF_NOT_EQUAL(
       RCL_RET_OK,
-      rcl_timer_init(timer, RCL_MS_TO_NS((uint64_t)period_ms), nullptr,
+      rcl_timer_init(timer, RCL_MS_TO_NS(period_ms), nullptr,
           rcl_get_default_allocator()), rcl_get_error_string_safe());
 
   auto js_obj = RclHandle::NewInstance(timer, nullptr, [timer] {
@@ -144,7 +144,7 @@ NAN_METHOD(TimerGetTimeUntilNextCall) {
 NAN_METHOD(TimerGetTimeSinceLastCall) {
   RclHandle* timer_handle = RclHandle::Unwrap<RclHandle>(info[0]->ToObject());
   rcl_timer_t* timer = reinterpret_cast<rcl_timer_t*>(timer_handle->ptr());
-  uint64_t elapsed_time = 0;
+  int64_t elapsed_time = 0;
 
   THROW_ERROR_IF_NOT_EQUAL(
       RCL_RET_OK, rcl_timer_get_time_since_last_call(timer, &elapsed_time),


### PR DESCRIPTION
This patch fixed the compile error caused by
https://github.com/ros2/rcl/commit/44801b398e6f053eb6b474d2caf9bb5319e3add3

Fix #265