### PR TITLE
Check the consistency of the message's members when being serialized

### DIFF
--- a/lib/message_translator.js
+++ b/lib/message_translator.js
@@ -25,7 +25,7 @@ function isTypedArray(value) {
 function copyMsgObject(msg, obj) {
   if (typeof obj === 'object') {
     for (let i in obj) {
-      if (typeof msg[i] !== 'undefined') {
+      if (msg.hasMember(i)) {
         const type = typeof obj[i];
         if (type === 'string' || type === 'number' || type === 'boolean') {
           // A primitive-type value

--- a/rosidl_gen/generator.json
+++ b/rosidl_gen/generator.json
@@ -1,6 +1,6 @@
 {
   "name": "rosidl-generator",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Generate JavaScript object from ROS IDL(.msg) files",
   "authors": [
     "Minggang Wang <minggang.wang@intel.com>",

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -178,6 +178,14 @@ function getPackageNameByType(type) {
     return type.pkgName;
   }
 }
+
+function extractMemberNames(fields) {
+  let memberNames = [];
+  fields.forEach(field => {
+    memberNames.push(field.name);
+  });
+  return JSON.stringify(memberNames);
+}
 }}
 
 {{? usePlainTypedArray}}
@@ -231,9 +239,13 @@ class {{=objectWrapper}} {
     this._{{=field.name}}Array = [];
     {{?}}
     {{~}}
+
     if (typeof other === 'object' && other._refObject) {
       this._refObject = new {{=refObjectType}}(other._refObject.toObject());
       {{~ it.spec.fields :field}}
+      {{? field.type.isPrimitiveType && !field.type.isArray}}
+      this._{{=field.name}}Intialized = true;
+      {{?}}
       {{? field.type.isArray}}
       this._wrapperFields.{{=field.name}} = {{=getWrapperNameByType(field.type)}}.createArray();
       this._wrapperFields.{{=field.name}}.copy(other._wrapperFields.{{=field.name}});
@@ -247,6 +259,9 @@ class {{=objectWrapper}} {
     } else {
       this._refObject = new {{=refObjectType}}();
       {{~ it.spec.fields :field}}
+      {{? field.type.isPrimitiveType && !field.type.isArray}}
+      this._{{=field.name}}Intialized = false;
+      {{?}}
       {{? field.type.isArray}}
       this._wrapperFields.{{=field.name}} = {{=getWrapperNameByType(field.type)}}.createArray();
       {{?? !field.type.isPrimitiveType || (field.type.type === 'string' && it.spec.msgName !== 'String')}}
@@ -287,14 +302,23 @@ class {{=objectWrapper}} {
     return this._refObject.ref();
   }
 
-  freeze(own = false) {
+  freeze(own = false, checkConsistency = false) {
+    if (checkConsistency) {
+    {{~ it.spec.fields :field}}
+    {{? field.type.isPrimitiveType && !field.type.isArray}}
+      if (!this._{{=field.name}}Intialized) {
+        throw new TypeError('Invalid argument: {{=field.name}} in {{=it.spec.msgName}}');
+      }
+    {{?}}
+    {{~}}
+    }
     {{~ it.spec.fields :field}}
     {{? field.type.isArray && field.type.isPrimitiveType && !isTypedArrayType(field.type)}}
     this._wrapperFields.{{=field.name}}.fill(this._{{=field.name}}Array);
-    this._wrapperFields.{{=field.name}}.freeze(own);
+    this._wrapperFields.{{=field.name}}.freeze(own, checkConsistency);
     this._refObject.{{=field.name}} = this._wrapperFields.{{=field.name}}.refObject;
     {{?? !field.type.isPrimitiveType || field.type.isArray}}
-    this._wrapperFields.{{=field.name}}.freeze(own);
+    this._wrapperFields.{{=field.name}}.freeze(own, checkConsistency);
     this._refObject.{{=field.name}} = this._wrapperFields.{{=field.name}}.refObject;
     {{?? field.type.type === 'string' && it.spec.msgName !== 'String'}}
     if (own) {
@@ -310,12 +334,15 @@ class {{=objectWrapper}} {
   }
 
   serialize() {
-    this.freeze();
+    this.freeze(false, true);
     return this._refObject.ref();
   }
 
   deserialize(refObject) {
     {{~ it.spec.fields :field}}
+    {{? field.type.isPrimitiveType && !field.type.isArray}}
+    this._{{=field.name}}Intialized = true;
+    {{?}}
     {{? field.type.isArray && field.type.isPrimitiveType && !isTypedArrayType(field.type)}}
     refObject.{{=field.name}}.data.length = refObject.{{=field.name}}.size;
     for (let index = 0; index < refObject.{{=field.name}}.size; index++) {
@@ -381,13 +408,23 @@ class {{=objectWrapper}} {
     {{?? !field.type.isPrimitiveType && !field.type.isArray}}
     return this._wrapperFields.{{=field.name}};
     {{?? !field.type.isArray && field.type.type === 'string' && it.spec.msgName !== 'String'}}
+    if (!this._{{=field.name}}Intialized) {
+      return undefined;
+    }
     return this._wrapperFields.{{=field.name}}.data;
     {{?? true}}
+    if (!this._{{=field.name}}Intialized) {
+      return undefined;
+    }
     return this._refObject.{{=field.name}};
     {{?}}
   }
 
   set {{=field.name}}(value) {
+    {{? field.type.isPrimitiveType && !field.type.isArray}}
+    this._{{=field.name}}Intialized = true;
+    {{?}}
+
     {{? field.type.isArray && isTypedArrayType(field.type)}}
     this._wrapperFields['{{=field.name}}'].fill(value);
     {{?? field.type.isArray && field.type.isPrimitiveType}}
@@ -412,6 +449,9 @@ class {{=objectWrapper}} {
     this._refObject = new {{=refObjectType}}(refObject.toObject());
 
     {{~ it.spec.fields :field}}
+    {{? field.type.isPrimitiveType && !field.type.isArray}}
+    this._{{=field.name}}Intialized = true;
+    {{?}}
     {{? field.type.isArray && field.type.isPrimitiveType && !isTypedArrayType(field.type)}}
     refObject.{{=field.name}}.data.length = refObject.{{=field.name}}.size;
     for (let index = 0; index < refObject.{{=field.name}}.size; index++) {
@@ -427,6 +467,9 @@ class {{=objectWrapper}} {
     this._refObject = new {{=refObjectType}}(other._refObject.toObject());
 
     {{~ it.spec.fields :field}}
+    {{? field.type.isPrimitiveType && !field.type.isArray}}
+    this._{{=field.name}}Intialized = true;
+    {{?}}
     {{? field.type.isArray && field.type.isPrimitiveType && !isTypedArrayType(field.type)}}
     this._{{=field.name}}Array = other._{{=field.name}}Array.slice();
     {{?? !field.type.isPrimitiveType || field.type.isArray || (field.type.type === 'string' && it.spec.msgName !== 'String')}}
@@ -441,6 +484,11 @@ class {{=objectWrapper}} {
 
   static get ROSMessageDef() {
     return {{=compactMsgDefJSON}};
+  }
+
+  hasMember(name) {
+    let memberNames = {{=extractMemberNames(it.spec.fields)}};
+    return memberNames.indexOf(name) !== -1;
   }
 }
 

--- a/test/test-compound-msg-type-check.js
+++ b/test/test-compound-msg-type-check.js
@@ -34,10 +34,10 @@ describe('Compound types', function() {
     let msg = new msgColorRGBA();
 
     assert.ok('r' in msg && 'g' in msg && 'b' in msg && 'a' in msg);
-    assert.deepStrictEqual(typeof msg.r, 'number');
-    assert.deepStrictEqual(typeof msg.g, 'number');
-    assert.deepStrictEqual(typeof msg.b, 'number');
-    assert.deepStrictEqual(typeof msg.a, 'number');
+    assert.deepStrictEqual(typeof msg.r, 'undefined');
+    assert.deepStrictEqual(typeof msg.g, 'undefined');
+    assert.deepStrictEqual(typeof msg.b, 'undefined');
+    assert.deepStrictEqual(typeof msg.a, 'undefined');
   });
 
   it('Array', function() {
@@ -60,7 +60,7 @@ describe('Compound types', function() {
     assert.ok('frame_id' in header);
 
     assert.deepStrictEqual(typeof header.stamp, 'object');
-    assert.deepStrictEqual(typeof header.frame_id, 'string');
+    assert.deepStrictEqual(typeof header.frame_id, 'undefined');
   });
 
   it('Complex object', function() {


### PR DESCRIPTION
Currently when a message is instantiated, the values of its data members will
be a "default". Reference the issue 243:

If we have a request which will be sent to the service to calculate the
sum of two integers, and create {a: 1} instead of {a: 1, b: 1} which
means we do not assign the value for member b explicitly. What the
service will receive is {a: 1, b: 0} from the client request. We may
just forget the assignment unintentionally, but rclnodejs should produce
an error.

This patch implements the strategy below:
1. If the type of a data member in the message is primitive, including
Bool, Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Float64,
Float32, Char, Byte and String, the data member will be not be created and
undefined is returned when being queried.

2. Other types of the data members, including compound data member and
arrays (primitive & non primitive), it will be created.

If the message is being serialized, which occurs during publishing a topic or
sending a request, the consistency of the message will be checked. Once
one of the data members is undefined, a TypeError will be thrown to
indicate the name of the invalid one.

Fix #243