### PR TITLE
Fix int conversion error in rcl_bindings

### DIFF
--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -144,7 +144,7 @@ NAN_METHOD(TimerGetTimeUntilNextCall) {
 NAN_METHOD(TimerGetTimeSinceLastCall) {
   RclHandle* timer_handle = RclHandle::Unwrap<RclHandle>(info[0]->ToObject());
   rcl_timer_t* timer = reinterpret_cast<rcl_timer_t*>(timer_handle->ptr());
-  int64_t elapsed_time = 0;
+  uint64_t elapsed_time = 0;
 
   THROW_ERROR_IF_NOT_EQUAL(
       RCL_RET_OK, rcl_timer_get_time_since_last_call(timer, &elapsed_time),


### PR DESCRIPTION
This is to fix a compilation error when calling `npm install`

> In file included from ../src/rcl_bindings.cpp:33:0:
> ../src/rcl_bindings.cpp: In function ‘Nan::NAN_METHOD_RETURN_TYPE rclnodejs::TimerGetTimeSinceLastCall(Nan::NAN_METHOD_ARGS_TYPE)’:
> ../src/rcl_bindings.cpp:150:74: error: invalid conversion from ‘int64_t* {aka long int*}’ to ‘uint64_t* {aka long unsigned int*}’ [-fpermissive]
>        RCL_RET_OK, rcl_timer_get_time_since_last_call(timer, &elapsed_time),