### PR TITLE
[PnP]Add PnP tests for rclnodejs client (JavaScript)

### DIFF
--- a/benchmark/rclnodejs/client-endurance-test.js
+++ b/benchmark/rclnodejs/client-endurance-test.js
@@ -1,0 +1,44 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const rclnodejs = require('../../index.js');
+
+rclnodejs.init().then(() => {
+  console.log('The client will send a SetBool request continuously until receiving response 864000 times.');
+  console.log(`Begin at ${new Date().toString()}.`);
+
+  const node = rclnodejs.createNode('endurance_client_rclnodejs');
+  const client = node.createClient('std_srvs/srv/SetBool', 'set_flag');
+  let sentTimes = 0;
+  let receivedTimes = 0;
+  let totalTimes = 864000;
+
+  let sendRequest = function(response) {
+    client.sendRequest(true, (response) => {
+      if (++receivedTimes > totalTimes) {
+        rclnodejs.shutdown();
+        console.log(`End at ${new Date().toString()}`);
+      } else {
+        setImmediate(sendRequest);
+      }
+    });
+  };
+
+  sendRequest();
+  rclnodejs.spin(node);
+}).catch((e) => {
+  console.log(`Error: ${e}`);
+});

--- a/benchmark/rclnodejs/client-stress-test.js
+++ b/benchmark/rclnodejs/client-stress-test.js
@@ -1,0 +1,46 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/* eslint-disable camelcase */
+const rclnodejs = require('../../index.js');
+
+rclnodejs.init().then(() => {
+  console.log('The client will send a GetMap request continuously(response contains a size of 10MB array) \
+    until receiving response 36000 times.');
+  console.log(`Begin at ${new Date().toString()}.`);
+
+  const node = rclnodejs.createNode('stress_client_rclnodejs');
+  const client = node.createClient('nav_msgs/srv/GetMap', 'get_map');
+  let sentTimes = 0;
+  let receivedTimes = 0;
+  let totalTimes = 36000;
+
+  let sendRequest = function(response) {
+    client.sendRequest({_dummy: true}, (response) => {
+      if (++receivedTimes > totalTimes) {
+        rclnodejs.shutdown();
+        console.log(`End at ${new Date().toString()}`);
+      } else {
+        setImmediate(sendRequest);
+      }
+    });
+  };
+
+  sendRequest();
+  rclnodejs.spin(node);
+}).catch((e) => {
+  console.log(`Error: ${e}`);
+});

--- a/benchmark/rclnodejs/publisher-endurance-test.js
+++ b/benchmark/rclnodejs/publisher-endurance-test.js
@@ -1,0 +1,55 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/* eslint-disable camelcase */
+const rclnodejs = require('../../index.js');
+
+rclnodejs.init().then(() => {
+  const JointState = 'sensor_msgs/msg/JointState';
+  const state = {
+    header: {
+      stamp: {
+        sec: 123456,
+        nanosec: 789,
+      },
+      frame_id: 'main_frame',
+    },
+    name: ['Tom', 'Jerry'],
+    position: [1, 2],
+    velocity: [2, 3],
+    effort: [4, 5, 6],
+  };
+
+  console.log('The publisher will publish a JointState topic every 100ms.');
+  console.log(`Begin at ${new Date().toString()} and end in about 24 hours.`);
+
+  let node = rclnodejs.createNode('endurance_publisher_rclnodejs');
+  let publisher = node.createPublisher(JointState, 'endurance_topic');
+  let sentTimes = 0;
+  let totalTimes = 864000;
+
+  let timer = setInterval(() => {
+    if (sentTimes++ > totalTimes) {
+      clearInterval(timer);
+      rclnodejs.shutdown();
+      console.log(`End at ${new Date().toString()}`);
+    } else {
+      publisher.publish(state);
+    }}, 100);
+  rclnodejs.spin(node);
+}).catch((err) => {
+  console.log(err);
+});

--- a/benchmark/rclnodejs/publisher-stress-test.js
+++ b/benchmark/rclnodejs/publisher-stress-test.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/* eslint-disable camelcase */
+const rclnodejs = require('../../index.js');
+
+const message = {
+  layout: {
+    dim: [
+      {label: 'height',  size: 10, stride: 600},
+      {label: 'width',   size: 20, stride: 60},
+      {label: 'channel', size: 3,  stride: 4},
+    ],
+    data_offset: 0,
+  },
+  data: Uint8Array.from({length: 1024 * 1024 * 10}, (v, k) => k)
+};
+
+rclnodejs.init().then(() => {
+  console.log(
+    'The publisher will publish a UInt8MultiArray topic(contains a size of 10MB array) every 100ms.');
+  console.log(`Begin at ${new Date().toString()} and end in about 1 hour.`);
+
+  let node = rclnodejs.createNode('stress_publisher_rclnodejs');
+  const publisher = node.createPublisher('std_msgs/msg/UInt8MultiArray', 'stress_topic');
+  let sentTimes = 0;
+  let totalTimes = 36000;
+
+  let timer = setInterval(() => {
+    if (sentTimes++ > totalTimes) {
+      clearInterval(timer);
+      rclnodejs.shutdown();
+      console.log(`End at ${new Date().toString()}`);
+    } else {
+      publisher.publish(message);
+    }}, 100);
+  rclnodejs.spin(node);
+}).catch((err) => {
+  console.log(err);
+});

--- a/benchmark/rclnodejs/service-endurance-test.js
+++ b/benchmark/rclnodejs/service-endurance-test.js
@@ -1,0 +1,31 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const rclnodejs = require('../../index.js');
+
+rclnodejs.init().then(() => {
+  let node = rclnodejs.createNode('endurance_service_rclnodejs');
+
+  node.createService('std_srvs/srv/SetBool', 'set_flag', (request, response) => {
+    let result = response.template;
+    result.success = true;
+    result.message = 'The flag has been set.';
+    response.send(result);
+  });
+  rclnodejs.spin(node);
+}).catch((e) => {
+  console.log(`Error: ${e}`);
+});

--- a/benchmark/rclnodejs/service-stress-test.js
+++ b/benchmark/rclnodejs/service-stress-test.js
@@ -1,0 +1,63 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/* eslint-disable camelcase */
+const rclnodejs = require('../../index.js');
+
+const mapData = {
+  map: {
+    header: {
+      stamp: {
+        sec: 123456,
+        nanosec: 789,
+      },
+      frame_id: 'main_frame'
+    },
+    info: {
+      map_load_time: {
+        sec: 123456,
+        nanosec: 789,
+      },
+      resolution: 1.0,
+      width: 1024,
+      height: 768,
+      origin: {
+        position: {
+          x: 0.0,
+          y: 0.0,
+          z: 0.0
+        },
+        orientation: {
+          x: 0.0,
+          y: 0.0,
+          z: 0.0,
+          w: 0.0
+        }
+      }
+    },
+    data: Int8Array.from({length: 1024 * 1024 * 10}, (v, k) => k)
+  }
+};
+
+rclnodejs.init().then(() => {
+  let node = rclnodejs.createNode('stress_service_rclnodejs');
+  node.createService('nav_msgs/srv/GetMap', 'get_map', (request, response) => {
+    return mapData;
+  });
+  rclnodejs.spin(node);
+}).catch((e) => {
+  console.log(`Error: ${e}`);
+});

--- a/benchmark/rclnodejs/subscription-endurance-test.js
+++ b/benchmark/rclnodejs/subscription-endurance-test.js
@@ -1,0 +1,28 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const rclnodejs = require('../../index.js');
+
+rclnodejs.init().then(() => {
+  const node = rclnodejs.createNode('endurance_subscription_rclnodejs');
+  let count = 0;
+
+  node.createSubscription('sensor_msgs/msg/JointState', 'endurance_topic', (state) => {
+  });
+  rclnodejs.spin(node);
+}).catch(e => {
+  console.log(e);
+});

--- a/benchmark/rclnodejs/subscription-stress-test.js
+++ b/benchmark/rclnodejs/subscription-stress-test.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const rclnodejs = require('../../index.js');
+
+rclnodejs.init().then(() => {
+  const node = rclnodejs.createNode('stress_subscription_rclnodejs');
+
+  node.createSubscription('std_msgs/msg/UInt8MultiArray', 'stress_topic', (array) => {
+  });
+  rclnodejs.spin(node);
+}).catch(e => {
+  console.log(e);
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "install": "node-gyp rebuild",
     "docs": "cd docs && make",
     "test": "node ./scripts/compile_cpp.js && node ./scripts/run_test.js",
-    "lint": "eslint --max-warnings=0 index.js scripts lib example rosidl_gen rosidl_parser test && node ./scripts/cpplint.js"
+    "lint": "eslint --max-warnings=0 index.js scripts lib example rosidl_gen rosidl_parser test benchmark/rclnodejs && node ./scripts/cpplint.js"
   },
   "authors": [
     "Minggang Wang <minggang.wang@intel.com>",


### PR DESCRIPTION
This patch added the tests used for rclnodejs. We defined two kinds of
PnP tests, which are stress testing and endurance testing.

This patch added the tests used for rclnodejs. We defined two kinds of
PnP tests, which are stress testing and endurance testing.

1. Stress testing
The test case is designed to find the behaviour beyond the normal
expected overload, and we can find the breaking points and short term
memory leaks through the tests. There is one test case for each of the
publisher/subscription and client/service. The strategy is:

- A publisher publishes a topic of std_msgs/UInt8MultiArray type every
  100ms, which contains an array of size 10MB, and sends 36000 times
  totally.
- A client sends a request of nav_msgs/GetMap whose response will
  contains an array of size 10MB until it receives the response from the
  service 36000 times.

2. Endurance testing
The test case is designed to find the expected overload for a longer
term, and we can find the long term memory leaks through the tests.
There is one test for each of the publisher/subscription and
client/service. The stragegy is:

- A publisher publishes a topic of std_msgs/JointState type every
  100ms for 24 hours (864000 totally).
- A client sends a request of std_srvs/SetBool until it receives the
  response from the service 864000 times.

All tests begin with a line of output 'Begin' and end with 'End'.

Fix #277