### PR TITLE
[PnP]Add PnP tests for rclnodejs client (Python)

### DIFF
--- a/benchmark/rclpy/client-endurance-test.py
+++ b/benchmark/rclpy/client-endurance-test.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 Intel Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from datetime import datetime
+from std_srvs.srv import *
+
+def main():
+  rclpy.init()
+
+  print('The client will send a SetBool request continuously until receiving response 864000 times.')
+  print('Begin at ' + str(datetime.now()))
+
+  node = rclpy.create_node('endurance_client_rclpy')
+  client = node.create_client(SetBool, 'set_flag')
+  request = SetBool.Request()
+  request.data = True
+  totalTimes = 864000
+  receivedTimes = 0
+
+  while rclpy.ok():
+    if receivedTimes > totalTimes:
+      node.destroy_node()
+      rclpy.shutdown()
+      print('End at ' + str(datetime.now()))
+    else:
+      client.call(request)
+      rclpy.spin_once(node)
+      if client.response is not None:
+        receivedTimes += 1
+
+if __name__ == '__main__':
+  main()

--- a/benchmark/rclpy/client-stress-test.py
+++ b/benchmark/rclpy/client-stress-test.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 Intel Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from datetime import datetime
+from nav_msgs.srv import *
+
+def main():
+  rclpy.init()
+
+  print(
+    'The client will send a GetMap request continuously(response contains a size of 10MB array) until receiving 36000 response times.')
+  print('Begin at ' + str(datetime.now()))
+  node = rclpy.create_node('stress_client_rclpy')
+  client = node.create_client(GetMap, 'get_map')
+  request = GetMap.Request()
+  totalTimes = 36000
+  receivedTimes = 0
+
+  while rclpy.ok():
+    if receivedTimes > totalTimes:
+      node.destroy_node()
+      rclpy.shutdown()
+      print('End at ' + str(datetime.now()))
+    else:
+      client.call(request)
+      rclpy.spin_once(node)
+      if client.response is not None:
+        receivedTimes += 1
+
+if __name__ == '__main__':
+  main()

--- a/benchmark/rclpy/publisher-endurance-test.py
+++ b/benchmark/rclpy/publisher-endurance-test.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 Intel Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from datetime import datetime
+from std_msgs.msg import *
+from builtin_interfaces.msg import *
+from sensor_msgs.msg import *
+import threading
+
+def main():
+  rclpy.init()
+
+  print('The publisher will publish a JointState topic every 100ms.')
+  print('Begin at ' + str(datetime.now()) + 'and end in about 24 hours')
+  node = rclpy.create_node('endurance_publisher_rclpy')
+  publisher = node.create_publisher(JointState, 'endurance_topic')
+  time = Time()
+  time.sec = 123456
+  time.nanosec = 789
+  header = Header()
+  header.stamp = time
+  header.frame_id = 'main_frame'
+  msg = JointState()
+  msg.header = header
+  msg.name = ['Tom', 'Jerry']
+  msg.position = [1.0, 2.0]
+  msg.velocity = [2.0, 3.0]
+  msg.effort = [4.0, 5.0, 6.0]
+  totalTimes = 864000
+  sentTimes = 0
+
+  def publish_topic():
+    nonlocal publisher
+    nonlocal msg
+    nonlocal timer
+    nonlocal sentTimes
+    if sentTimes > totalTimes:
+      timer.cancel()
+      node.destroy_node()
+      rclpy.shutdown()
+      print('End at ' + str(datetime.now()))
+    else:
+      publisher.publish(msg)
+      sentTimes += 1
+      timer = threading.Timer(0.1, publish_topic)
+      timer.start()
+
+  timer = threading.Timer(0.1, publish_topic)
+  timer.start()
+
+if __name__ == '__main__':
+  main()
+

--- a/benchmark/rclpy/publisher-stress-test.py
+++ b/benchmark/rclpy/publisher-stress-test.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 Intel Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from builtin_interfaces.msg import *
+from datetime import datetime
+from std_msgs.msg import *
+import threading
+
+def main():
+  rclpy.init()
+
+  widthDim = MultiArrayDimension()
+  widthDim.label = 'width'
+  widthDim.size = 20;
+  widthDim.stride = 60;
+
+  heightDim = MultiArrayDimension()
+  heightDim.label = 'height'
+  heightDim.size = 10;
+  heightDim.stride = 600;
+
+  channelDim = MultiArrayDimension()
+  channelDim.label = 'channel'
+  channelDim.size = 3;
+  channelDim.stride = 4;
+
+  layout = MultiArrayLayout()
+  layout.dim = [widthDim, heightDim, channelDim]
+  layout.data_offset = 0;
+
+  multiArray = UInt8MultiArray()
+  multiArray.layout = layout
+  multiArray.data = [x & 0xff for x in range(1024 * 1024 * 10)]
+
+  print('The publisher will publish a UInt8MultiArray topic(contains a size of 10MB array) every 100ms.')
+  print('Begin at ' + str(datetime.now()) + 'and end in about 1 hour')
+  node = rclpy.create_node('stress_publisher_rclpy')
+  publisher = node.create_publisher(UInt8MultiArray, 'stress_topic')
+  totalTimes = 36000
+  sentTimes = 0
+
+  def publish_topic():
+    nonlocal publisher
+    nonlocal multiArray
+    nonlocal timer
+    nonlocal sentTimes
+    if sentTimes > totalTimes:
+      timer.cancel()
+      node.destroy_node()
+      rclpy.shutdown()
+      print('End at ' + str(datetime.now()))
+    else:
+      publisher.publish(multiArray)
+      sentTimes += 1
+      timer = threading.Timer(0.1, publish_topic)
+      timer.start()
+
+  timer = threading.Timer(0.1, publish_topic)
+  timer.start()
+
+if __name__ == '__main__':
+  main()

--- a/benchmark/rclpy/service-endurance-test.py
+++ b/benchmark/rclpy/service-endurance-test.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 Intel Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from std_srvs.srv import *
+
+def callback(request, response):
+  response.success = True
+  response.message = 'The flag has been set.'
+  return response
+
+def main():
+  rclpy.init()
+  node = rclpy.create_node('endurance_service_rclpy')
+  service = node.create_service(SetBool, 'set_flag', callback)
+
+  while rclpy.ok():
+    rclpy.spin_once(node)
+
+if __name__ == '__main__':
+  main()

--- a/benchmark/rclpy/service-stress-test.py
+++ b/benchmark/rclpy/service-stress-test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 Intel Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from std_srvs.srv import *
+from std_msgs.msg import *
+from nav_msgs.srv import *
+from nav_msgs.msg import *
+from builtin_interfaces.msg import *
+from sensor_msgs.msg import *
+from geometry_msgs.msg import *
+
+mapData = OccupancyGrid()
+stamp = Time();
+stamp.sec = 123456
+stamp.nanosec = 789
+header = Header()
+header.stamp = stamp;
+header.frame_id = 'main_frame'
+
+info = MapMetaData()
+map_load_time = Time()
+map_load_time.sec = 123456
+map_load_time.nanosec = 789
+info.resolution = 1.0
+info.width = 1024
+info.height = 768
+
+position = Point()
+position.x = 0.0
+position.y = 0.0
+position.z = 0.0
+
+orientation = Quaternion()
+orientation.x = 0.0
+orientation.y = 0.0
+orientation.z = 0.0
+orientation.w = 0.0
+
+origin = Pose()
+origin.position = position
+origin.orientation = orientation
+info.map_load_time = map_load_time
+info.origin = origin;
+
+mapData.header = header
+mapData.info = info
+mapData.data = [x & 0x7f for x in range(1024 * 1024 * 10)]
+
+def callback(request, response):
+  global mapData
+  response.map = mapData
+  return response
+
+def main():
+  rclpy.init()
+  node = rclpy.create_node('stress_service_rclpy')
+  service = node.create_service(GetMap, 'get_map', callback)
+
+  while rclpy.ok():
+    rclpy.spin_once(node)
+
+if __name__ == '__main__':
+  main()

--- a/benchmark/rclpy/subscription-endurance-test.py
+++ b/benchmark/rclpy/subscription-endurance-test.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 Intel Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from sensor_msgs.msg import *
+
+def callback(msg):
+  pass
+
+def main():
+  rclpy.init()
+
+  node = rclpy.create_node('endurance_subscription_rclpy')
+  publisher = node.create_subscription(JointState, 'endurance_topic', callback)
+  while rclpy.ok():
+    rclpy.spin_once(node)
+
+if __name__ == '__main__':
+  main()
+

--- a/benchmark/rclpy/subscription-stress-test.py
+++ b/benchmark/rclpy/subscription-stress-test.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 Intel Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from std_msgs.msg import *
+
+def callback(msg):
+  pass
+
+def main():
+  rclpy.init()
+
+  node = rclpy.create_node('stress_subscription_rclpy')
+  subscription = node.create_subscription(UInt8MultiArray, 'stress_topic', callback)
+  while rclpy.ok():
+    rclpy.spin_once(node)
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
This patch added the tests used for rclnodejs. We defined two kinds of
PnP tests, which are stress testing and endurance testing.

1. Stress testing
The test case is designed to find the behaviour beyond the normal
expected overload, and we can find the breaking points and short term
memory leaks through the tests. There is one test case for each of the
publisher/subscription and client/service. The strategy is:

- A publisher publishes a topic of std_msgs/UInt8MultiArray type every
  100ms, which contains an array of size 10MB, and sends 36000 times
  totally.
- A client sends a request of nav_msgs/GetMap whose response will
  contains an array of size 10MB until it receives the response from the
  service 36000 times.

2. Endurance testing
The test case is designed to find the expected overload for a longer
term, and we can find the long term memory leaks through the tests.
There is one test for each of the publisher/subscription and
client/service. The stragegy is:

- A publisher publishes a topic of std_msgs/JointState type every
  100ms for 24 hours (864000 totally).
- A client sends a request of std_srvs/SetBool until it receives the
  response from the service 864000 times.

All tests begin with a line of output 'Begin' and end with 'End'.

Fix #278