### PR TITLE
[PnP]Add PnP tests for rclnodejs client (C++)

### DIFF
--- a/benchmark/rclcpp/CMakeLists.txt
+++ b/benchmark/rclcpp/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(rclcpp_benchmark)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
+find_package(nav_msgs REQUIRED)
+
+function(custom_executable target)
+  add_executable(${target} ${target}.cpp)
+  ament_target_dependencies(${target}
+    "example_interfaces"
+    "nav_msgs"
+    "rclcpp"
+    "rcutils"
+    "sensor_msgs"
+    "std_msgs"
+    "std_srvs")
+endfunction()
+
+custom_executable(publisher-endurance-test)
+custom_executable(subscription-endurance-test)
+custom_executable(publisher-stress-test)
+custom_executable(subscription-stress-test)
+custom_executable(client-endurance-test)
+custom_executable(service-endurance-test)
+custom_executable(client-stress-test)
+custom_executable(service-stress-test)

--- a/benchmark/rclcpp/client-endurance-test.cpp
+++ b/benchmark/rclcpp/client-endurance-test.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <memory>
+#include <utility>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_srvs/srv/set_bool.hpp"
+#include "./utilities.hpp"
+
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+
+  printf(
+      "The client will send a SetBool request every 100ms until receiving"
+      " response 864000 times.\n");
+  printf("Begin at %s\n", GetCurrentTime());
+
+  auto node = rclcpp::Node::make_shared("endurance_client_rclcpp");
+  auto client = node->create_client<std_srvs::srv::SetBool>("set_flag");
+  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
+  auto totalTimes = 864000;
+  auto receivedTimes = 0;
+
+  while (rclcpp::ok()) {
+    if (receivedTimes > totalTimes) {
+      rclcpp::shutdown();
+      printf("End at %s\n", GetCurrentTime());
+    } else {
+      client->async_send_request(
+          request,
+          [&receivedTimes](std::shared_future<
+                   std::pair<std_srvs::srv::SetBool::Request::SharedPtr,
+                             std_srvs::srv::SetBool::Response::SharedPtr>>
+                       result) {
+                         receivedTimes++;
+                         (void)result; });
+      rclcpp::spin_some(node);
+    }
+  }
+
+  return 0;
+}

--- a/benchmark/rclcpp/client-stress-test.cpp
+++ b/benchmark/rclcpp/client-stress-test.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <memory>
+#include <utility>
+
+#include "nav_msgs/srv/get_map.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "./utilities.hpp"
+
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+
+  printf(
+      "The client will send a GetMap request(response contains a size of 10MB "
+      "array) every 100ms until receiving response 36000 times.\n");
+  printf("Begin at %s\n", GetCurrentTime());
+
+  auto node = rclcpp::Node::make_shared("stress_client_rclcpp");
+  auto client = node->create_client<nav_msgs::srv::GetMap>("get_map");
+  auto request = std::make_shared<nav_msgs::srv::GetMap::Request>();
+  auto totalTimes = 36000;
+  auto receivedTimes = 0;
+
+  while (rclcpp::ok()) {
+    if (receivedTimes > totalTimes) {
+      rclcpp::shutdown();
+      printf("End at %s\n", GetCurrentTime());
+    } else {
+      client->async_send_request(
+          request,
+          [&receivedTimes](std::shared_future<
+                   std::pair<nav_msgs::srv::GetMap::Request::SharedPtr,
+                             nav_msgs::srv::GetMap::Response::SharedPtr>>
+                       result) {
+                         receivedTimes++;
+                         (void)result; });
+      rclcpp::spin_some(node);
+    }
+  }
+
+  return 0;
+}

--- a/benchmark/rclcpp/publisher-endurance-test.cpp
+++ b/benchmark/rclcpp/publisher-endurance-test.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/joint_state.hpp"
+#include "./utilities.hpp"
+
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+
+  auto msg = std::make_shared<sensor_msgs::msg::JointState>();
+  msg->header.stamp.sec = 123456;
+  msg->header.stamp.nanosec = 789;
+  msg->header.frame_id = std::string("main_frame");
+  msg->name = std::vector<std::string>{"Tom", "Jerry"};
+  msg->position = std::vector<double>{1.0, 2.0};
+  msg->velocity = std::vector<double>{2.0, 3.0};
+  msg->effort = std::vector<double>{4.0, 5.0, 6.0};
+
+  printf(
+      "The publisher will publish a JointState topic every 100ms\n");
+  printf("Begin at %s and end in about 24 hours\n", GetCurrentTime());
+
+  auto node = rclcpp::Node::make_shared("endurance_publisher_rclcpp");
+  auto publisher =
+      node->create_publisher<sensor_msgs::msg::JointState>("endurance_topic");
+  auto totalTimes = 864000;
+  auto sentTimes = 0;
+
+  rclcpp::WallRate wall_rate(std::chrono::milliseconds(100));
+  while (rclcpp::ok()) {
+    if (sentTimes > totalTimes) {
+      rclcpp::shutdown();
+      printf("End at %s\n", GetCurrentTime());
+    } else {
+      publisher->publish(msg);
+      sentTimes++;
+      rclcpp::spin_some(node);
+    }
+    wall_rate.sleep();
+  }
+
+  return 0;
+}

--- a/benchmark/rclcpp/publisher-stress-test.cpp
+++ b/benchmark/rclcpp/publisher-stress-test.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <memory>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/u_int8_multi_array.hpp"
+#include "./utilities.hpp"
+
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+
+  auto heightDim = std::make_shared<std_msgs::msg::MultiArrayDimension>();
+  heightDim->label = "height";
+  heightDim->size = 10;
+  heightDim->stride = 600;
+
+  auto widthDim = std::make_shared<std_msgs::msg::MultiArrayDimension>();
+  widthDim->label = "width";
+  widthDim->size = 20;
+  widthDim->stride = 60;
+
+  auto channelDim = std::make_shared<std_msgs::msg::MultiArrayDimension>();
+  channelDim->label = "channel";
+  channelDim->size = 3;
+  channelDim->stride = 4;
+
+  auto layout = std::make_shared<std_msgs::msg::MultiArrayLayout>();
+  layout->dim = std::vector<std_msgs::msg::MultiArrayDimension>{
+      *heightDim, *widthDim, *channelDim};
+  layout->data_offset = 0;
+
+  auto msg = std::make_shared<std_msgs::msg::UInt8MultiArray>();
+  msg->layout = *layout;
+  msg->data = std::vector<uint8_t>(1024 * 1024 * 10, 255);
+
+  printf(
+      "The publisher will publish a UInt8MultiArray topic(contains a size of "
+      "10MB array) every 100ms.\n");
+  printf("Begin at %s and end in about 1 hour\n", GetCurrentTime());
+
+  auto node = rclcpp::Node::make_shared("stress_publisher_rclcpp");
+  auto publisher =
+      node->create_publisher<std_msgs::msg::UInt8MultiArray>("stress_topic");
+  auto totalTimes = 36000;
+  auto sentTimes = 0;
+
+  rclcpp::WallRate wall_rate(std::chrono::milliseconds(100));
+  while (rclcpp::ok()) {
+    if (sentTimes > totalTimes) {
+      rclcpp::shutdown();
+      printf("End at %s\n", GetCurrentTime());
+    } else {
+      publisher->publish(msg);
+      sentTimes++;
+      rclcpp::spin_some(node);
+    }
+    wall_rate.sleep();
+  }
+
+  return 0;
+}

--- a/benchmark/rclcpp/service-endurance-test.cpp
+++ b/benchmark/rclcpp/service-endurance-test.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_srvs/srv/set_bool.hpp"
+
+int main(int argc, char** argv) {
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("endurance_service_rclnodejs");
+  auto service = node->create_service<std_srvs::srv::SetBool>(
+      "set_flag",
+      [](const std::shared_ptr<rmw_request_id_t> request_header,
+         const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+         const std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
+        (void)request_header;
+        (void)request;
+        response->success = true;
+        response->message = "The flag has been set.";
+      });
+  rclcpp::spin(node);
+
+  return 0;
+}

--- a/benchmark/rclcpp/service-stress-test.cpp
+++ b/benchmark/rclcpp/service-stress-test.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <vector>
+
+#include "nav_msgs/srv/get_map.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("stress_service_rclcpp");
+  auto sub = node->create_service<nav_msgs::srv::GetMap>(
+      "get_map",
+      [](const std::shared_ptr<rmw_request_id_t> request_header,
+         const std::shared_ptr<nav_msgs::srv::GetMap::Request> request,
+         const std::shared_ptr<nav_msgs::srv::GetMap::Response> response) {
+        (void)request_header;
+        (void)request;
+        response->map.header.stamp.sec = 123456;
+        response->map.header.stamp.nanosec = 789;
+        response->map.header.frame_id = "main_frame";
+        response->map.info.map_load_time.sec = 123456;
+        response->map.info.map_load_time.nanosec = 789;
+        response->map.info.resolution = 1.0;
+        response->map.info.width = 1024;
+        response->map.info.height = 768;
+        response->map.info.origin.position.x = 0.0;
+        response->map.info.origin.position.y = 0.0;
+        response->map.info.origin.position.z = 0.0;
+        response->map.info.origin.orientation.x = 0.0;
+        response->map.info.origin.orientation.y = 0.0;
+        response->map.info.origin.orientation.z = 0.0;
+        response->map.info.origin.orientation.w = 0.0;
+        response->map.data = std::vector<int8_t>(1024 * 1024 * 10, 125);
+      });
+  rclcpp::spin(node);
+
+  return 0;
+}

--- a/benchmark/rclcpp/subscription-endurance-test.cpp
+++ b/benchmark/rclcpp/subscription-endurance-test.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/joint_state.hpp"
+
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("endurance_subscription_rclcpp");
+  auto sub = node->create_subscription<sensor_msgs::msg::JointState>(
+      "endurance_topic",
+      [](sensor_msgs::msg::JointState::SharedPtr msg) { (void)msg; });
+  rclcpp::spin(node);
+
+  return 0;
+}

--- a/benchmark/rclcpp/subscription-stress-test.cpp
+++ b/benchmark/rclcpp/subscription-stress-test.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/u_int8_multi_array.hpp"
+
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("stress_subscription_rclcpp");
+  auto sub = node->create_subscription<std_msgs::msg::UInt8MultiArray>(
+      "stress_topic",
+      [](std_msgs::msg::UInt8MultiArray::SharedPtr msg) { (void)msg; });
+  rclcpp::spin(node);
+
+  return 0;
+}

--- a/benchmark/rclcpp/utilities.hpp
+++ b/benchmark/rclcpp/utilities.hpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ctime>
+
+char* GetCurrentTime() {
+  std::time_t result = std::time(nullptr);
+  return std::asctime(std::localtime(&result));
+}


### PR DESCRIPTION
This patch added the tests used for rclnodejs. We defined two kinds of
PnP tests, which are stress testing and endurance testing.

1. Stress testing
The test case is designed to find the behaviour beyond the normal
expected overload, and we can find the breaking points and short term
memory leaks through the tests. There is one test case for each of the
publisher/subscription and client/service. The strategy is:

- A publisher publishes a topic of std_msgs/UInt8MultiArray type every
  100ms, which contains an array of size 10MB.
- A client sends a request of nav_msgs/GetMap whose response will
  contains an array of size 10MB.

2. Endurance testing
The test case is designed to find the expected overload for a longer
term, and we can find the long term memory leaks through the tests.
There is one test for each of the publisher/subscription and
client/service. The stragegy is:

- A publisher publishes a topic of std_msgs/JointState type every
  100ms for 24 hours.
- A client sends a request of std_srvs/SetBool every 100ms for 24 hours.

All tests begin with a line of output 'Beginning' and end with 'Done'.

Fix #279