### PR TITLE
Disable two interaction test

### DIFF
--- a/test/blacklist.json
+++ b/test/blacklist.json
@@ -1,5 +1,5 @@
 {
-  "Linux": [],
-  "Darwin": [],
-  "Windows_NT": []
+  "Linux": ["test-cross-lang.js", "test-multi-nodes.js"],
+  "Darwin": ["test-cross-lang.js", "test-multi-nodes.js"],
+  "Windows_NT": ["test-cross-lang.js", "test-multi-nodes.js"]
 }


### PR DESCRIPTION
The npm test failed frequently when we were running the case of
interaction testing. As we know, the performance of machine of the CIs
will affect it, so we disable these two cases temporarily.

Fix NONE