### PR TITLE
[PnP]Use spin_until_future_complete to wait the response synchronously

### DIFF
--- a/benchmark/rclcpp/client-endurance-test.cpp
+++ b/benchmark/rclcpp/client-endurance-test.cpp
@@ -41,17 +41,15 @@ int main(int argc, char* argv[]) {
       rclcpp::shutdown();
       printf("End at %s\n", GetCurrentTime());
     } else {
-      client->async_send_request(
-          request,
-          [&receivedTimes](std::shared_future<
-                   std::pair<std_srvs::srv::SetBool::Request::SharedPtr,
-                             std_srvs::srv::SetBool::Response::SharedPtr>>
-                       result) {
-                         receivedTimes++;
-                         (void)result; });
-      rclcpp::spin_some(node);
+      auto result_future = client->async_send_request(request);
+      if (rclcpp::spin_until_future_complete(node, result_future) !=
+          rclcpp::executor::FutureReturnCode::SUCCESS) {
+        RCLCPP_ERROR(node->get_logger(), "service call failed.")
+        return 1;
+      }
+      auto result = result_future.get();
+      receivedTimes++;
     }
   }
-
   return 0;
 }


### PR DESCRIPTION
Currently we take the response from the service through the callback
function passed by async_send_request method.

From this patch, we are going to use the spin_until_future_complete to
wait the response.

Fix #310