### PR TITLE
[rosidl]Move the translator to rosidl-generator module

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,6 @@ const path = require('path');
 const QoS = require('./lib/qos.js');
 const rclnodejs = require('bindings')('rclnodejs');
 const validator = require('./lib/validator.js');
-const translator = require('./lib/message_translator.js');
 
 function inherits(target, source) {
   let properties = Object.getOwnPropertyNames(source.prototype);
@@ -246,7 +245,7 @@ let rcl = {
    * @return {Object|undefined} A plain JavaScript of that type
    */
   createMessageObject(type) {
-    return translator.toPlainObject(this.createMessage(type));
+    return this.createMessage(type).toPlainObject();
   },
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -17,8 +17,6 @@
 const rclnodejs = require('bindings')('rclnodejs');
 const Entity = require('./entity.js');
 const debug = require('debug')('rclnodejs:client');
-const {toROSMessage} = require('./message_translator.js');
-const {toPlainObject} = require('./message_translator.js');
 
 /**
  * @class - Class representing a Client in ROS
@@ -51,18 +49,15 @@ class Client extends Entity {
    * @see {@link ResponseCallback}
    */
   sendRequest(request, callback) {
-    let rclRequest;
-    if (request instanceof this._typeClass.Request) {
-      rclRequest = request;
-    } else {
-      rclRequest = toROSMessage(this._typeClass.Request, request);
-    }
+    let requestToSend = (request instanceof this._typeClass.Request)
+      ? request
+      : new this._typeClass.Request(request);
     if (typeof (callback) !== 'function') {
       throw new TypeError('Invalid argument');
     }
 
-    let rawROSRequest = rclRequest.serialize();
-    this._sequenceNumber = rclnodejs.sendRequest(this._handle, rawROSRequest);
+    let rawRequest = requestToSend.serialize();
+    this._sequenceNumber = rclnodejs.sendRequest(this._handle, rawRequest);
     debug(`Client has sent a ${this._serviceName} request.`);
     this._callback = callback;
   }
@@ -74,7 +69,7 @@ class Client extends Entity {
   processResponse(response) {
     this._response.deserialize(response);
     debug(`Client has received ${this._serviceName} response from service.`);
-    this._callback(toPlainObject(this._response));
+    this._callback(this._response.toPlainObject());
   }
 
   static createClient(nodeHandle, serviceName, typeClass, qos) {

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -17,7 +17,6 @@
 const rclnodejs = require('bindings')('rclnodejs');
 const debug = require('debug')('rclnodejs:publisher');
 const Entity = require('./entity.js');
-const {toROSMessage} = require('./message_translator.js');
 
 /**
  * @class - Class representing a Publisher in ROS
@@ -43,19 +42,16 @@ class Publisher extends Entity {
    * @return {undefined}
    */
   publish(message) {
-    let rclMessage;
-    if (message instanceof this._typeClass) {
-      rclMessage = message;
-    } else {
-      // Enables call by plain object/number/string argument
-      //  e.g. publisher.publish(3.14);
-      //       publisher.publish('The quick brown fox...');
-      //       publisher.publish({linear: {x: 0, y: 1, z: 2}, ...});
-      rclMessage = toROSMessage(this._typeClass, message);
-    }
+    // Enables call by plain object/number/string argument
+    //  e.g. publisher.publish(3.14);
+    //       publisher.publish('The quick brown fox...');
+    //       publisher.publish({linear: {x: 0, y: 1, z: 2}, ...});
+    let messageToSend = (message instanceof this._typeClass)
+      ? message
+      : new this._typeClass(message);
 
-    let rawRosMessage = rclMessage.serialize();
-    rclnodejs.publish(this._handle, rawRosMessage);
+    let rawMessage = messageToSend.serialize();
+    rclnodejs.publish(this._handle, rawMessage);
     debug(`Message of topic ${this._topic} has been published.`);
   }
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -17,8 +17,6 @@
 const rclnodejs = require('bindings')('rclnodejs');
 const Entity = require('./entity.js');
 const debug = require('debug')('rclnodejs:service');
-const {toROSMessage} = require('./message_translator.js');
-const {toPlainObject} = require('./message_translator.js');
 
 /**
  * The response to client
@@ -36,7 +34,8 @@ class Response {
   }
 
   get template() {
-    return toPlainObject(new this._service._typeClass.Response());
+    let response = new this._service._typeClass.Response();
+    return response.toPlainObject();
   }
 
   get service() {
@@ -51,8 +50,9 @@ class Response {
    * @see {@link Response#template}
    */
   send(response) {
-    const rawROSResponse = toROSMessage(this._service._typeClass.Response, response).serialize();
-    rclnodejs.sendResponse(this._service._handle, rawROSResponse, this._header);
+    let responseToReturn = new this._service._typeClass.Response(response);
+    const rawResponse = responseToReturn.serialize();
+    rclnodejs.sendResponse(this._service._handle, rawResponse, this._header);
     this.sent = true;
   }
 }
@@ -74,13 +74,14 @@ class Service extends Entity {
     this._request.deserialize(request);
     debug(`Service has received a ${this._serviceName} request from client.`);
 
-    const requestObj = toPlainObject(this._request);
+    const plainObj = this._request.toPlainObject();
     const response = new Response(this, headerHandle);
-    const responseRet = this._callback(requestObj, response);
+    let responseToReturn = this._callback(plainObj, response);
 
-    if (!response.sent && responseRet) {
-      const rawROSResponse = toROSMessage(this._typeClass.Response, responseRet).serialize();
-      rclnodejs.sendResponse(this._handle, rawROSResponse, headerHandle);
+    if (!response.sent && responseToReturn) {
+      responseToReturn = new this._typeClass.Response(responseToReturn);
+      const rawResponse = responseToReturn.serialize();
+      rclnodejs.sendResponse(this._handle, rawResponse, headerHandle);
     }
 
     debug(`Service has processed the ${this._serviceName} request and sent the response.`);

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -17,7 +17,6 @@
 const rclnodejs = require('bindings')('rclnodejs');
 const Entity = require('./entity.js');
 const debug = require('debug')('rclnodejs:subscription');
-const {toPlainObject} = require('./message_translator.js');
 
 /**
  * @class - Class representing a Subscription in ROS
@@ -35,7 +34,7 @@ class Subscription extends Entity {
   processResponse(msg) {
     this._message.deserialize(msg);
     debug(`Message of topic ${this._topic} received.`);
-    this._callback(toPlainObject(this._message));
+    this._callback(this._message.toPlainObject());
   }
 
   static createSubscription(nodeHandle, typeClass, topic, callback, qos) {

--- a/rosidl_gen/generator.json
+++ b/rosidl_gen/generator.json
@@ -1,6 +1,6 @@
 {
   "name": "rosidl-generator",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Generate JavaScript object from ROS IDL(.msg) files",
   "authors": [
     "Minggang Wang <minggang.wang@intel.com>",

--- a/rosidl_gen/message_translator.js
+++ b/rosidl_gen/message_translator.js
@@ -152,6 +152,10 @@ function toPlainObject(message) {
 
 function toROSMessage(TypeClass, obj) {
   let msg = new TypeClass();
+  return constructFromPlanObject(msg, obj);
+}
+
+function constructFromPlanObject(msg, obj) {
   const type = typeof obj;
   if (type === 'string' || type === 'number' || type === 'boolean') {
     msg.data = obj;
@@ -164,5 +168,6 @@ function toROSMessage(TypeClass, obj) {
 module.exports = {
   verifyMessageStruct: verifyMessageStruct,
   toROSMessage: toROSMessage,
-  toPlainObject: toPlainObject
+  toPlainObject: toPlainObject,
+  constructFromPlanObject: constructFromPlanObject
 };

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -196,6 +196,7 @@ const ref = require('ref');
 const ArrayType = require('ref-array');
 const primitiveTypes = require('../../rosidl_gen/generator_primitive.js');
 const deallocator = require('../../rosidl_gen/deallocator.js');
+const translator = require('../../rosidl_gen/message_translator.js');
 
 {{~ it.spec.fields :field}}
 {{? shouldRequire(it.spec.baseType, field.type)}}
@@ -257,23 +258,30 @@ class {{=objectWrapper}} {
       this._wrapperFields.{{=field.name}} =  new {{=getWrapperNameByType(field.type)}}(other._wrapperFields.{{=field.name}});
       {{?}}
       {{~}}
+    } else if (typeof other !== 'undefined') {
+      this._initMembers();
+      translator.constructFromPlanObject(this, other);
     } else {
-      this._refObject = new {{=refObjectType}}();
-      {{~ it.spec.fields :field}}
-      {{? field.type.isPrimitiveType && !field.type.isArray}}
-      this._{{=field.name}}Intialized = false;
-      {{?}}
-
-      {{? field.type.isArray}}
-      this._wrapperFields.{{=field.name}} = {{=getWrapperNameByType(field.type)}}.createArray();
-      {{?? !field.type.isPrimitiveType || (field.type.type === 'string' && it.spec.msgName !== 'String')}}
-      this._wrapperFields.{{=field.name}} = new {{=getWrapperNameByType(field.type)}}();
-      {{?? it.spec.msgName === 'String'}}
-      primitiveTypes.initString(this._refObject);
-      {{?}}
-      {{~}}
+      this._initMembers();
     }
     this.freeze();
+  }
+
+  _initMembers() {
+    this._refObject = new {{=refObjectType}}();
+    {{~ it.spec.fields :field}}
+    {{? field.type.isPrimitiveType && !field.type.isArray}}
+    this._{{=field.name}}Intialized = false;
+    {{?}}
+
+    {{? field.type.isArray}}
+    this._wrapperFields.{{=field.name}} = {{=getWrapperNameByType(field.type)}}.createArray();
+    {{?? !field.type.isPrimitiveType || (field.type.type === 'string' && it.spec.msgName !== 'String')}}
+    this._wrapperFields.{{=field.name}} = new {{=getWrapperNameByType(field.type)}}();
+    {{?? it.spec.msgName === 'String'}}
+    primitiveTypes.initString(this._refObject);
+    {{?}}
+    {{~}}
   }
 
   static createFromRefObject(refObject) {
@@ -359,6 +367,10 @@ class {{=objectWrapper}} {
     this._refObject.{{=field.name}} = refObject.{{=field.name}};
     {{?}}
   {{~}}
+  }
+
+  toPlainObject() {
+    return translator.toPlainObject(this);
   }
 
   static freeStruct(refObject) {

--- a/test/test-array-data.js
+++ b/test/test-array-data.js
@@ -17,7 +17,7 @@
 const assert = require('assert');
 const childProcess = require('child_process');
 const rclnodejs = require('../index.js');
-const translator = require('../lib/message_translator.js');
+const translator = require('../rosidl_gen/message_translator.js');
 const arrayGen = require('./array_generator.js');
 
 function isTypedArray(v) {

--- a/test/test-security-related.js
+++ b/test/test-security-related.js
@@ -17,7 +17,7 @@
 const assert = require('assert');
 const rclnodejs = require('../index.js');
 const assertThrowsError = require('./utils.js').assertThrowsError;
-const translator = require('../lib/message_translator.js');
+const translator = require('../rosidl_gen/message_translator.js');
 const arrayGen = require('./array_generator.js');
 
 describe('Destroying non-existent objects testing', function() {


### PR DESCRIPTION
Currently, the translator, which can adapt a plain
JavaScript object to an object of ROS message, resides in the lib/
folder. It seems reasonable to move it to rosidl-generator and be
wrapped by the message class instead of exposing its interfaces to
rclnodejs.

This patch implemented the function described above.

Fix NONE