### PR TITLE
[PnP]Remove the period parameter when running stress testing

### DIFF
--- a/benchmark/rclcpp/publisher-stress-test.cpp
+++ b/benchmark/rclcpp/publisher-stress-test.cpp
@@ -48,14 +48,12 @@ int main(int argc, char* argv[]) {
   msg->data = std::vector<uint8_t>(1024 * 1024 * 10, 255);
 
   auto totalTimes = 0;
-  int ms = 0;
   printf("How many times do you want to run?\n");
   scanf("%d", &totalTimes);
-  printf("Please enter the period of publishing a topic in millisecond\n");
-  scanf("%d", &ms);
+
   printf(
       "The publisher will publish a UInt8MultiArray topic(contains a size of "
-      "10MB array) %d times every %dms.\n", totalTimes, ms);
+      "10MB array) %d times.\n", totalTimes);
   printf("Begin at %s\n", GetCurrentTime());
 
   auto node = rclcpp::Node::make_shared("stress_publisher_rclcpp");
@@ -63,8 +61,6 @@ int main(int argc, char* argv[]) {
       node->create_publisher<std_msgs::msg::UInt8MultiArray>("stress_topic");
   auto sentTimes = 0;
 
-  auto period = std::chrono::milliseconds(ms);
-  rclcpp::WallRate wall_rate(period);
   while (rclcpp::ok()) {
     if (sentTimes > totalTimes) {
       rclcpp::shutdown();
@@ -74,7 +70,6 @@ int main(int argc, char* argv[]) {
       sentTimes++;
       rclcpp::spin_some(node);
     }
-    wall_rate.sleep();
   }
 
   return 0;

--- a/benchmark/rclpy/publisher-stress-test.py
+++ b/benchmark/rclpy/publisher-stress-test.py
@@ -46,33 +46,21 @@ def main():
   multiArray.data = [x & 0xff for x in range(1024 * 1024 * 10)]
 
   times = input('How many times do you want to run? ')
-  ms = input('Please enter the period of publishing a topic in millisecond ')
-  period = int(ms) / 100
-  print('The publisher will publish a UInt8MultiArray topic(contains a size of 10MB array) %s times every %sms.' % (times, ms))
+  print('The publisher will publish a UInt8MultiArray topic(contains a size of 10MB array) %s times.' % times)
   print('Begin at ' + str(datetime.now()))
   node = rclpy.create_node('stress_publisher_rclpy')
   publisher = node.create_publisher(UInt8MultiArray, 'stress_topic')
   totalTimes = int(times)
   sentTimes = 0
 
-  def publish_topic():
-    nonlocal publisher
-    nonlocal multiArray
-    nonlocal timer
-    nonlocal sentTimes
+  while rclpy.ok():
     if sentTimes > totalTimes:
-      timer.cancel()
       node.destroy_node()
       rclpy.shutdown()
       print('End at ' + str(datetime.now()))
     else:
       publisher.publish(multiArray)
       sentTimes += 1
-      timer = threading.Timer(period, publish_topic)
-      timer.start()
-
-  timer = threading.Timer(period, publish_topic)
-  timer.start()
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
To have a heavy work load onto the CPU, we'd better remove the period
parameter used to control a topic and running it in a loop instead.

Fix #325