### PR TITLE
[PnP]Customize the amount of data to be sent for publisher/service

### DIFF
--- a/benchmark/rclcpp/publisher-stress-test.cpp
+++ b/benchmark/rclcpp/publisher-stress-test.cpp
@@ -23,6 +23,13 @@
 int main(int argc, char* argv[]) {
   rclcpp::init(argc, argv);
 
+  auto totalTimes = 0;
+  auto amount = 0;
+  printf("How many times do you want to run?\n");
+  scanf("%d", &totalTimes);
+  printf("The amount of data(MB) to be sent in one loop.\n");
+  scanf("%d", &amount);
+
   auto heightDim = std::make_shared<std_msgs::msg::MultiArrayDimension>();
   heightDim->label = "height";
   heightDim->size = 10;
@@ -45,15 +52,11 @@ int main(int argc, char* argv[]) {
 
   auto msg = std::make_shared<std_msgs::msg::UInt8MultiArray>();
   msg->layout = *layout;
-  msg->data = std::vector<uint8_t>(1024 * 1024 * 10, 255);
-
-  auto totalTimes = 0;
-  printf("How many times do you want to run?\n");
-  scanf("%d", &totalTimes);
+  msg->data = std::vector<uint8_t>(1024 * 1024 * amount, 255);
 
   printf(
       "The publisher will publish a UInt8MultiArray topic(contains a size of "
-      "10MB array) %d times.\n", totalTimes);
+      "%dMB array) %d times.\n", amount, totalTimes);
   printf("Begin at %s\n", GetCurrentTime());
 
   auto node = rclcpp::Node::make_shared("stress_publisher_rclcpp");

--- a/benchmark/rclcpp/service-stress-test.cpp
+++ b/benchmark/rclcpp/service-stress-test.cpp
@@ -20,10 +20,15 @@
 
 int main(int argc, char* argv[]) {
   rclcpp::init(argc, argv);
+
+  auto amount = 0;
+  printf("The amount of data(MB) to be sent for each request.\n");
+  scanf("%d", &amount);
+
   auto node = rclcpp::Node::make_shared("stress_service_rclcpp");
   auto sub = node->create_service<nav_msgs::srv::GetMap>(
       "get_map",
-      [](const std::shared_ptr<rmw_request_id_t> request_header,
+      [amount](const std::shared_ptr<rmw_request_id_t> request_header,
          const std::shared_ptr<nav_msgs::srv::GetMap::Request> request,
          const std::shared_ptr<nav_msgs::srv::GetMap::Response> response) {
         (void)request_header;
@@ -43,7 +48,7 @@ int main(int argc, char* argv[]) {
         response->map.info.origin.orientation.y = 0.0;
         response->map.info.origin.orientation.z = 0.0;
         response->map.info.origin.orientation.w = 0.0;
-        response->map.data = std::vector<int8_t>(1024 * 1024 * 10, 125);
+        response->map.data = std::vector<int8_t>(1024 * 1024 * amount, 125);
       });
   rclcpp::spin(node);
 

--- a/benchmark/rclnodejs/publisher-stress-test.js
+++ b/benchmark/rclnodejs/publisher-stress-test.js
@@ -24,40 +24,43 @@ const rl = readline.createInterface({
 });
 
 rl.question('How many times do you want to run? ', (times) => {
-  const message = {
-    layout: {
-      dim: [
-        {label: 'height',  size: 10, stride: 600},
-        {label: 'width',   size: 20, stride: 60},
-        {label: 'channel', size: 3,  stride: 4},
-      ],
-      data_offset: 0,
-    },
-    data: Uint8Array.from({length: 1024 * 1024 * 10}, (v, k) => k)
-  };
+  rl.question('The amount of data(MB) to be sent in one loop. ', (amount) => {
+    amount = parseInt(amount, 10);
+    const message = {
+      layout: {
+        dim: [
+          {label: 'height',  size: 10, stride: 600},
+          {label: 'width',   size: 20, stride: 60},
+          {label: 'channel', size: 3,  stride: 4},
+        ],
+        data_offset: 0,
+      },
+      data: Uint8Array.from({length: 1024 * 1024 * amount}, (v, k) => k)
+    };
 
-  rclnodejs.init().then(() => {
-    console.log('The publisher will publish a UInt8MultiArray topic(contains a size of 10MB array)' +
-        `${times} times.`);
-    console.log(`Begin at ${new Date().toString()}.`);
+    rclnodejs.init().then(() => {
+      console.log(`The publisher will publish a UInt8MultiArray topic(contains a size of ${amount}MB array)` +
+          ` ${times} times.`);
+      console.log(`Begin at ${new Date().toString()}.`);
 
-    let node = rclnodejs.createNode('stress_publisher_rclnodejs');
-    const publisher = node.createPublisher('std_msgs/msg/UInt8MultiArray', 'stress_topic');
-    let sentTimes = 0;
-    let totalTimes = parseInt(times, 10);
+      let node = rclnodejs.createNode('stress_publisher_rclnodejs');
+      const publisher = node.createPublisher('std_msgs/msg/UInt8MultiArray', 'stress_topic');
+      let sentTimes = 0;
+      let totalTimes = parseInt(times, 10);
 
-    setImmediate(() => {
-      while (sentTimes++ < totalTimes) {
-        publisher.publish(message);
-      }
-      rclnodejs.shutdown();
-      console.log(`End at ${new Date().toString()}`);
+      setImmediate(() => {
+        while (sentTimes++ < totalTimes) {
+          publisher.publish(message);
+        }
+        rclnodejs.shutdown();
+        console.log(`End at ${new Date().toString()}`);
+      });
+
+      rclnodejs.spin(node);
+    }).catch((err) => {
+      console.log(err);
     });
 
-    rclnodejs.spin(node);
-  }).catch((err) => {
-    console.log(err);
+    rl.close();
   });
-
-  rl.close();
 });

--- a/benchmark/rclnodejs/service-stress-test.js
+++ b/benchmark/rclnodejs/service-stress-test.js
@@ -16,48 +16,59 @@
 
 /* eslint-disable camelcase */
 const rclnodejs = require('../../index.js');
+const readline = require('readline');
 
-const mapData = {
-  map: {
-    header: {
-      stamp: {
-        sec: 123456,
-        nanosec: 789,
-      },
-      frame_id: 'main_frame'
-    },
-    info: {
-      map_load_time: {
-        sec: 123456,
-        nanosec: 789,
-      },
-      resolution: 1.0,
-      width: 1024,
-      height: 768,
-      origin: {
-        position: {
-          x: 0.0,
-          y: 0.0,
-          z: 0.0
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+rl.question('The amount of data(MB) to be sent for each request. ', (amount) => {
+  amount = parseInt(amount, 10);
+  const mapData = {
+    map: {
+      header: {
+        stamp: {
+          sec: 123456,
+          nanosec: 789,
         },
-        orientation: {
-          x: 0.0,
-          y: 0.0,
-          z: 0.0,
-          w: 0.0
+        frame_id: 'main_frame'
+      },
+      info: {
+        map_load_time: {
+          sec: 123456,
+          nanosec: 789,
+        },
+        resolution: 1.0,
+        width: 1024,
+        height: 768,
+        origin: {
+          position: {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0
+          },
+          orientation: {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            w: 0.0
+          }
         }
-      }
-    },
-    data: Int8Array.from({length: 1024 * 1024 * 10}, (v, k) => k)
-  }
-};
+      },
+      data: Int8Array.from({length: 1024 * 1024 * amount}, (v, k) => k)
+    }
+  };
 
-rclnodejs.init().then(() => {
-  let node = rclnodejs.createNode('stress_service_rclnodejs');
-  node.createService('nav_msgs/srv/GetMap', 'get_map', (request, response) => {
-    return mapData;
+  rclnodejs.init().then(() => {
+    let node = rclnodejs.createNode('stress_service_rclnodejs');
+    node.createService('nav_msgs/srv/GetMap', 'get_map', (request, response) => {
+      return mapData;
+    });
+    rclnodejs.spin(node);
+  }).catch((e) => {
+    console.log(`Error: ${e}`);
   });
-  rclnodejs.spin(node);
-}).catch((e) => {
-  console.log(`Error: ${e}`);
+
+  rl.close();
 });

--- a/benchmark/rclpy/publisher-stress-test.py
+++ b/benchmark/rclpy/publisher-stress-test.py
@@ -22,6 +22,10 @@ import threading
 def main():
   rclpy.init()
 
+  times = input('How many times do you want to run? ')
+  amount = input('The amount of data(MB) to be sent in one loop. ')
+  amount = int(amount)
+
   widthDim = MultiArrayDimension()
   widthDim.label = 'width'
   widthDim.size = 20;
@@ -43,10 +47,9 @@ def main():
 
   multiArray = UInt8MultiArray()
   multiArray.layout = layout
-  multiArray.data = [x & 0xff for x in range(1024 * 1024 * 10)]
+  multiArray.data = [x & 0xff for x in range(1024 * 1024 * amount)]
 
-  times = input('How many times do you want to run? ')
-  print('The publisher will publish a UInt8MultiArray topic(contains a size of 10MB array) %s times.' % times)
+  print('The publisher will publish a UInt8MultiArray topic(contains a size of %dMB array) %s times.' % (amount, times))
   print('Begin at ' + str(datetime.now()))
   node = rclpy.create_node('stress_publisher_rclpy')
   publisher = node.create_publisher(UInt8MultiArray, 'stress_topic')

--- a/benchmark/rclpy/service-stress-test.py
+++ b/benchmark/rclpy/service-stress-test.py
@@ -22,6 +22,9 @@ from builtin_interfaces.msg import *
 from sensor_msgs.msg import *
 from geometry_msgs.msg import *
 
+amount = input('The amount of data(MB) to be sent for each request. ')
+amount = int(amount)
+
 mapData = OccupancyGrid()
 stamp = Time();
 stamp.sec = 123456
@@ -57,7 +60,7 @@ info.origin = origin;
 
 mapData.header = header
 mapData.info = info
-mapData.data = [x & 0x7f for x in range(1024 * 1024 * 10)]
+mapData.data = [x & 0x7f for x in range(1024 * 1024 * amount)]
 
 def callback(request, response):
   global mapData


### PR DESCRIPTION
This patch added an additional parameter which will ask tester to input
the amount of data to be sent when running the stress testing, see instruction
below:

- For publisher, the amount input will decide the size of data
  to be sent in one loop.

- For service, the amount input will decide the size of data
  to be sent for each request it received in response.

Fix #329