### PR TITLE
[UT]Update path splitter for all platforms

### DIFF
--- a/test/test-message-object.js
+++ b/test/test-message-object.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const assert = require('assert');
+const os = require('os');
 const rclnodejs = require('../index.js');
 
 describe('Rclnodejs createMessage() testing', function() {
@@ -30,7 +31,9 @@ describe('Rclnodejs createMessage() testing', function() {
 
   it('Test .createMessage() for every message in system', function() {
     const packages = require('../rosidl_gen/packages.js');
-    const installedPackagesRoot = process.env.AMENT_PREFIX_PATH.split(':');
+    const installedPackagesRoot =  (os.type() === 'Windows_NT')
+      ? process.env.AMENT_PREFIX_PATH.split(';')
+      : process.env.AMENT_PREFIX_PATH.split(':');
     let promises = [];
     installedPackagesRoot.forEach((path) => {
       let promise = packages.findPackagesInDirectory(path).then((pkgs) => {
@@ -131,7 +134,9 @@ describe('Rclnodejs createMessageObject() testing', function() {
 
   it('Test .createMessageObject() for every message in system', function() {
     const packages = require('../rosidl_gen/packages.js');
-    const installedPackagesRoot = process.env.AMENT_PREFIX_PATH.split(':');
+    const installedPackagesRoot =  (os.type() === 'Windows_NT')
+      ? process.env.AMENT_PREFIX_PATH.split(';')
+      : process.env.AMENT_PREFIX_PATH.split(':');
     let promises = [];
     installedPackagesRoot.forEach((path) => {
       let promise = packages.findPackagesInDirectory(path).then((pkgs) => {

--- a/test/test-rosidl-message-generator.js
+++ b/test/test-rosidl-message-generator.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const assert = require('assert');
+const os = require('os');
 const rclnodejs = require('../index.js');
 
 describe('ROSIDL Node.js message generator test suite', function() {
@@ -30,7 +31,9 @@ describe('ROSIDL Node.js message generator test suite', function() {
   it('Try require all message classes', function() {
     this.timeout(60 * 1000);
     const packages = require('../rosidl_gen/packages.js');
-    const installedPackagesRoot = process.env.AMENT_PREFIX_PATH.split(':');
+    const installedPackagesRoot =  (os.type() === 'Windows_NT')
+      ? process.env.AMENT_PREFIX_PATH.split(';')
+      : process.env.AMENT_PREFIX_PATH.split(':');
     let promises = [];
     installedPackagesRoot.forEach((path) => {
       let promise = packages.findPackagesInDirectory(path).then((pkgs) => {


### PR DESCRIPTION
Split the path by different splitters of platforms: `;` for Windows
and `:` for Linux and macOS.

Fix: #339