### PR TITLE
Use dlerror() to get the error diagnostic

### DIFF
--- a/src/rcl_utilities.cpp
+++ b/src/rcl_utilities.cpp
@@ -43,6 +43,8 @@ const char* lib_ext = ".dll";
 void* GetTypeSupportFunctionByInterfaceSymbolName(
     const std::string& symbol_name,
     const std::string& lib_name) {
+  // If the dlopen fails for any reason, it will return nullptr.
+  // You can use GetErrorMessageAndClear() to get error diagnostic.
   void* lib = dlopen(lib_name.c_str(), RTLD_NOW | RTLD_GLOBAL);
 
   if (lib)
@@ -77,5 +79,7 @@ const rosidl_service_type_support_t* GetServiceTypeSupport(
   else
     return nullptr;
 }
+
+const char* GetErrorMessageAndClear() { return dlerror(); }
 
 }  // namespace rclnodejs

--- a/src/rcl_utilities.hpp
+++ b/src/rcl_utilities.hpp
@@ -31,6 +31,8 @@ const rosidl_service_type_support_t* GetServiceTypeSupport(
     const std::string& package_name,
     const std::string& service_name);
 
+const char* GetErrorMessageAndClear();
+
 }  // namespace rclnodejs
 
 #endif

--- a/test/test-message-object.js
+++ b/test/test-message-object.js
@@ -105,6 +105,7 @@ describe('Rclnodejs createMessage() testing', function() {
     'std_msgs/srv/String',
     'msg/String',
     '/msg/String',
+    'unknown/msg/Unknown',
     {package: 'std_msgs', type: 'msg', name: 'CString'},
   ].forEach((testData) => {
     it('expecting exception when passing ' + testData.toString(), function() {
@@ -188,6 +189,7 @@ describe('Rclnodejs createMessageObject() testing', function() {
     'std_msgs/srv/String',
     'msg/String',
     '/msg/String',
+    'unknown/msg/Unknown',
     {package: 'std_msgs', type: 'msg', name: 'CString'},
   ].forEach((testData) => {
     it('expecting exception when passing ' + testData.toString(), function() {


### PR DESCRIPTION
Currently if the library(.so/.dll) can not be found by the dlopen function,
a nullptr will be returned which will be passed to the functions of rcl
later, which is not reasonable.

This patch implements using the dlerror() to get the error message and
throw an error to JavaScript side which is catchable.

Fix #338