### PR TITLE
Pre-generate the JavaScript messages during installation by postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "install": "node-gyp rebuild",
     "docs": "cd docs && make",
     "test": "node ./scripts/compile_cpp.js && node ./scripts/run_test.js",
-    "lint": "eslint --max-warnings=0 index.js scripts lib example rosidl_gen rosidl_parser test benchmark/rclnodejs && node ./scripts/cpplint.js"
+    "lint": "eslint --max-warnings=0 index.js scripts lib example rosidl_gen rosidl_parser test benchmark/rclnodejs && node ./scripts/cpplint.js",
+    "postinstall": "node scripts/generate_messages.js"
   },
   "authors": [
     "Minggang Wang <minggang.wang@intel.com>",

--- a/scripts/compile_cpp.js
+++ b/scripts/compile_cpp.js
@@ -73,6 +73,12 @@ if (!fs.existsSync(publisherPath) && !fs.existsSync(subscriptionPath) &&
   compileProcess.on('close', (code) => {
     copyAll([publisherPath, subscriptionPath, listenerPath, clientPath], testCppDir);
   });
+  compileProcess.stdout.on('data', (data) => {
+    console.log(`${data}`);
+  });
+  compileProcess.stderr.on('data', (data) => {
+    console.log(`${data}`);
+  });
 } else {
   copyAll([publisherPath, subscriptionPath, , listenerPath, clientPath], testCppDir);
 }

--- a/scripts/generate_messages.js
+++ b/scripts/generate_messages.js
@@ -1,0 +1,24 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const generator = require('../rosidl_gen/generator.js');
+
+console.log('Start to generate the JavaScript messages...');
+generator.generateAll(true).then(() => {
+  console.log('Generation is done.');
+}).catch((e) => {
+  console.log(`Caught error: ${e}`);
+});


### PR DESCRIPTION
To accelerate the speed of first-time start up, we better pre-generate
the messages during installation. Thus we do not have to wait the work
to be done when the module is initialized.

Fix #356