### PR TITLE
Change the ros2 package url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN /bin/bash -c 'echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /e
     && apt-key adv  --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 RUN apt-get update && apt-get install -y build-essential cppcheck cmake libopencv-dev \
-    python-empy python3-dev python3-empy python3-nose python3-pip python3-pyparsing python3-setuptools python3-vcstool libtinyxml-dev libeigen3-dev
+    python-empy python3-dev python3-empy python3-nose python3-pip python3-pyparsing python3-setuptools python3-vcstool libtinyxml-dev libeigen3-dev python3-catkin-pkg-modules
 
 # dependencies for RViz
 RUN apt-get install -y libcurl4-openssl-dev libqt5core5a libqt5gui5 libqt5opengl5 libqt5widgets5 libxaw7-dev libgles2-mesa-dev libglu1-mesa-dev qtbase5-dev
@@ -33,7 +33,7 @@ RUN git config --global user.name $GIT_USER_NAME \
 ENV ROS2_WS=/root
 WORKDIR $ROS2_WS
 
-RUN wget http://ci.ros2.org/view/packaging/job/packaging_linux/lastSuccessfulBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2 \
+RUN wget https://ci.ros2.org/view/packaging/job/packaging_xenial_linux/lastSuccessfulBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2 \
     && tar xf ros2-package-linux-x86_64.tar.bz2
 
 RUN echo "source $ROS2_WS/ros2-linux/local_setup.bash" >> $HOME/.bashrc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ before_build:
   - refreshenv
   - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;%PATH%"
   - python -m pip install -U setuptools pip
-  - python -m pip install EmPy pyparsing pyyaml
+  - python -m pip install EmPy pyparsing pyyaml catkin_pkg
 
 build_script:
   - cd  c:\proj\rclnodejs

--- a/circle.yml
+++ b/circle.yml
@@ -9,9 +9,9 @@ dependencies:
     - brew install python
     - brew install python@2
     - brew install asio tinyxml2 wget
-    - brew install tinyxml eigen pcre
+    - brew install tinyxml eigen pcre poco
     - brew install openssl
-    - python3 -m pip install pyyaml setuptools argcomplete pyparsing cmake
+    - python3 -m pip install pyyaml setuptools argcomplete pyparsing cmake catkin_pkg
     - mkdir -p ~/ros2_install && cd ~/ros2_install && wget https://ci.ros2.org/view/packaging/job/packaging_osx/lastSuccessfulBuild/artifact/ws/ros2-package-osx-x86_64.tar.bz2 && tar xf ros2-package-osx-x86_64.tar.bz2
     - wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
     - nvm install v8.11.2


### PR DESCRIPTION
As the ros2 ci build farm has switched the ubuntu from Xenial to
Bionic(https://github.com/ros2/ci/pull/148), we have to change the url
of the package url in order to get the right one.

Fix NONE