### PR TITLE
Use colcon instead of ament

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN /bin/bash -c 'echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /e
     && apt-key adv  --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 RUN apt-get update && apt-get install -y build-essential cppcheck cmake libopencv-dev \
-    python-empy python3-dev python3-empy python3-nose python3-pip python3-pyparsing python3-setuptools python3-vcstool libtinyxml-dev libeigen3-dev python3-catkin-pkg-modules
+    python-empy python3-dev python3-empy python3-nose python3-pip python3-pyparsing python3-setuptools python3-vcstool libtinyxml-dev libeigen3-dev python3-catkin-pkg-modules python3-colcon-common-extensions
 
 # dependencies for RViz
 RUN apt-get install -y libcurl4-openssl-dev libqt5core5a libqt5gui5 libqt5opengl5 libqt5widgets5 libxaw7-dev libgles2-mesa-dev libglu1-mesa-dev qtbase5-dev

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ before_build:
   - refreshenv
   - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;%PATH%"
   - python -m pip install -U setuptools pip
-  - python -m pip install EmPy pyparsing pyyaml catkin_pkg
+  - python -m pip install EmPy pyparsing pyyaml catkin_pkg colcon-common-extensions
 
 build_script:
   - cd  c:\proj\rclnodejs

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ dependencies:
     - brew install asio tinyxml2 wget
     - brew install tinyxml eigen pcre poco
     - brew install openssl
-    - python3 -m pip install pyyaml setuptools argcomplete pyparsing cmake catkin_pkg
+    - python3 -m pip install pyyaml setuptools argcomplete pyparsing cmake catkin_pkg colcon-common-extensions
     - mkdir -p ~/ros2_install && cd ~/ros2_install && wget https://ci.ros2.org/view/packaging/job/packaging_osx/lastSuccessfulBuild/artifact/ws/ros2-package-osx-x86_64.tar.bz2 && tar xf ros2-package-osx-x86_64.tar.bz2
     - wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
     - nvm install v8.11.2

--- a/scripts/compile_cpp.js
+++ b/scripts/compile_cpp.js
@@ -69,7 +69,7 @@ function copyAll(fileList, dest) {
 if (!fs.existsSync(publisherPath) && !fs.existsSync(subscriptionPath) &&
   // eslint-disable-next-line
   !fs.existsSync(listenerPath) && !fs.existsSync(clientPath)) {
-  var compileProcess = child.spawn('ament', ['build', testCppDir, '--skip-install']);
+  var compileProcess = child.spawn('colcon', ['build', '--base-paths', testCppDir]);
   compileProcess.on('close', (code) => {
     copyAll([publisherPath, subscriptionPath, listenerPath, clientPath], testCppDir);
   });


### PR DESCRIPTION
As the latest ROS 2 has switched to colcon to replace the original
ament, we are going to use colcon to build our C++ code in the unit
tests.

Fix #NONE