### PR TITLE
Cleanup the configuration of the CIs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,25 +5,39 @@ ENV GIT_USER_EMAIL mrbuild@github.com
 ENV LANG en_US.UTF-8
 
 RUN apt-get update && apt-get install -y git wget locales python
-
-# Install ROS2 requirements
 RUN locale-gen en_US en_US.UTF-8 && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 
 RUN /bin/bash -c 'echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list' \
-    && apt-key adv  --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+&& apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
-RUN apt-get update && apt-get install -y build-essential cppcheck cmake libopencv-dev \
-    python-empy python3-dev python3-empy python3-nose python3-pip python3-pyparsing python3-setuptools python3-vcstool libtinyxml-dev libeigen3-dev python3-catkin-pkg-modules python3-colcon-common-extensions
+# Install prerequisites
+RUN  apt update && apt install -y \
+     libopencv-dev \
+     libasio-dev \
+     libeigen3-dev \
+     libtinyxml2.6.2v5 \
+     libtinyxml2-dev \
+     libfreetype6 \
+     libgles2-mesa-dev \
+     libglu1-mesa-dev \
+     libqt5core5a \
+     libqt5gui5 \
+     libqt5opengl5 \
+     libqt5widgets5 \
+     libx11-dev \
+     libxaw7 \
+     libcurl4-openssl-dev \
+     python3-argcomplete \
+     python3-catkin-pkg-modules \
+     python3-empy \
+     python3-pip \
+     python3-pyparsing \
+     python3-setuptools \
+     python3-yaml \
+     python3-colcon-common-extensions \
+     cmake
 
-# dependencies for RViz
-RUN apt-get install -y libcurl4-openssl-dev libqt5core5a libqt5gui5 libqt5opengl5 libqt5widgets5 libxaw7-dev libgles2-mesa-dev libglu1-mesa-dev qtbase5-dev
-
-# Dependencies for testing
-RUN apt-get install -y clang-format pydocstyle pyflakes python3-coverage python3-mock python3-pep8 uncrustify \
-    && pip3 install argcomplete flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes pytest pytest-cov pytest-runner
-
-# Dependencies for FastRTPS
-RUN apt-get install -y libasio-dev libtinyxml2-dev
+RUN pip3 install -U setuptools
 
 # Configure git
 RUN git config --global user.name $GIT_USER_NAME \
@@ -39,8 +53,8 @@ RUN wget https://ci.ros2.org/view/packaging/job/packaging_xenial_linux/lastSucce
 RUN echo "source $ROS2_WS/ros2-linux/local_setup.bash" >> $HOME/.bashrc
 
 # Install nvm, Node.js and node-gyp
-ENV NODE_VERSION v8.11.2
-RUN wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash \
+ENV NODE_VERSION v8.11.3
+RUN wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash \
     && . $HOME/.nvm/nvm.sh \
     && nvm install $NODE_VERSION && nvm alias default $NODE_VERSION
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,10 +18,10 @@ before_build:
   - cd c:\
   - md download
   - cd download
-  - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2017-04-04-1/asio.1.10.6.nupkg
-  - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2017-04-04-1/eigen.3.3.3.nupkg
+  - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2018-06-12-1/asio.1.12.1.nupkg
+  - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2018-06-12-1/eigen.3.3.4.nupkg
   - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2017-04-04-1/tinyxml-usestl.2.6.2.nupkg
-  - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2017-04-04-1/tinyxml2.4.0.1.nupkg
+  - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2018-06-12-1/tinyxml2.6.0.0.nupkg
   - choco install -y -s c:\download\ asio eigen tinyxml-usestl tinyxml2
   - choco install -y wget
   - appveyor DownloadFile http://ci.ros2.org/view/packaging/job/packaging_windows/lastSuccessfulBuild/artifact/ws/ros2-package-windows-AMD64.zip
@@ -31,8 +31,7 @@ before_build:
   - setx AMENT_PYTHON_EXECUTABLE "c:\Python36"
   - refreshenv
   - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;%PATH%"
-  - python -m pip install -U setuptools pip
-  - python -m pip install EmPy pyparsing pyyaml catkin_pkg colcon-common-extensions
+  - python -m pip install -U catkin_pkg empy pyparsing pyyaml setuptools colcon-common-extensions pip
 
 build_script:
   - cd  c:\proj\rclnodejs

--- a/circle.yml
+++ b/circle.yml
@@ -6,16 +6,17 @@ dependencies:
   pre:
     - brew update
     - brew uninstall python
-    - brew install python
+    - brew install python3
     - brew install python@2
-    - brew install asio tinyxml2 wget
-    - brew install tinyxml eigen pcre poco
-    - brew install openssl
-    - python3 -m pip install pyyaml setuptools argcomplete pyparsing cmake catkin_pkg colcon-common-extensions
+    - brew install wget cmake cppcheck tinyxml eigen pcre poco
+    # install dependencies for Fast-RTPS if you are using it
+    - brew install asio tinyxml2
+    - brew install opencv
+    - python3 -m pip install argcomplete catkin_pkg colcon-common-extensions coverage empy flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes mock nose pep8 pydocstyle pyparsing setuptools vcstool
     - mkdir -p ~/ros2_install && cd ~/ros2_install && wget https://ci.ros2.org/view/packaging/job/packaging_osx/lastSuccessfulBuild/artifact/ws/ros2-package-osx-x86_64.tar.bz2 && tar xf ros2-package-osx-x86_64.tar.bz2
-    - wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
-    - nvm install v8.11.2
-    - nvm alias default v8.11.2
+    - wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+    - nvm install v8.11.3
+    - nvm alias default v8.11.3
 
   override:
     - node --version && npm --version && rm -rf ./node_modules/


### PR DESCRIPTION
Since the last release of ROS 2.0, the instruction of installing ROS 2.0
has changed a lot. We have to update the configurations of our CIs to
align with the latest WiKi
(https://github.com/ros2/ros2/wiki/Installation) and the next Release,
Bouncy.

Fix #NONE