### PR TITLE
[Benchmark]Correct the path for rclnodejs used in benchmark

### DIFF
--- a/benchmark/rclnodejs/service/client-stress-test.js
+++ b/benchmark/rclnodejs/service/client-stress-test.js
@@ -16,7 +16,7 @@
 
 /* eslint-disable camelcase */
 const app = require('commander');
-const rclnodejs = require('../../index.js');
+const rclnodejs = require('../../../index.js');
 
 app
   .option('-r, --run <n>', 'How many times to run')

--- a/benchmark/rclnodejs/service/service-stress-test.js
+++ b/benchmark/rclnodejs/service/service-stress-test.js
@@ -16,7 +16,7 @@
 
 /* eslint-disable camelcase */
 const app = require('commander');
-const rclnodejs = require('../../index.js');
+const rclnodejs = require('../../../index.js');
 
 app
   .option('-s, --size [size_kb]', 'The block size')

--- a/benchmark/rclnodejs/startup/startup-test.js
+++ b/benchmark/rclnodejs/startup/startup-test.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../../index.js');
+const rclnodejs = require('../../../index.js');
 
 rclnodejs.init().then(() => {
   rclnodejs.createNode('startup_node');

--- a/benchmark/rclnodejs/topic/publisher-stress-test.js
+++ b/benchmark/rclnodejs/topic/publisher-stress-test.js
@@ -16,7 +16,7 @@
 
 /* eslint-disable camelcase */
 const app = require('commander');
-const rclnodejs = require('../../index.js');
+const rclnodejs = require('../../../index.js');
 
 app
   .option('-s, --size [size_kb]', 'The block size')

--- a/benchmark/rclnodejs/topic/subscription-stress-test.js
+++ b/benchmark/rclnodejs/topic/subscription-stress-test.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../../index.js');
+const rclnodejs = require('../../../index.js');
 
 rclnodejs.init().then(() => {
   const node = rclnodejs.createNode('stress_subscription_rclnodejs');


### PR DESCRIPTION
As 1183813354 was landed, we have to change the relative path of
rclnodejs to require.

Fix #NONE