### PR TITLE
fix new/delete mismatch

### DIFF
--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -62,7 +62,7 @@ void Executor::Stop() {
                  // Important Notice:
                  //  This might be called after Executor::~Executor()
                  //  Don't free Executor::async_ in Executor's dtor
-                 free(async);
+                 delete async;
                  handle_closed = true;
                });
       while (!handle_closed)

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -669,8 +669,7 @@ const rmw_qos_profile_t* GetQosProfileFromObject(v8::Local<v8::Object> object) {
 }
 
 rmw_qos_profile_t* GetQoSProfile(v8::Local<v8::Value> qos) {
-  rmw_qos_profile_t* qos_profile =
-      reinterpret_cast<rmw_qos_profile_t*>(malloc(sizeof(rmw_qos_profile_t)));
+  rmw_qos_profile_t* qos_profile = new rmw_qos_profile_t();
 
   if (qos->IsString()) {
     *qos_profile = *GetQoSProfileFromString(


### PR DESCRIPTION
Memory allocated with `new` must be deallocated with `delete`, not `free`.