### PR TITLE
Fix the message template issues

### DIFF
--- a/rosidl_gen/generator.json
+++ b/rosidl_gen/generator.json
@@ -1,6 +1,6 @@
 {
   "name": "rosidl-generator",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Generate JavaScript object from ROS IDL(.msg) files",
   "authors": [
     "Minggang Wang <minggang.wang@intel.com>",

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -452,8 +452,8 @@ class {{=objectWrapper}} {
     this._wrapperFields.{{=field.name}}.data = value;
     {{?? true}}
     {{? it.spec.msgName === 'String'}}
-    this._refObject.size = value.length;
-    this._refObject.capacity = value.length + 1;
+    this._refObject.size = Buffer.byteLength(value);
+    this._refObject.capacity = Buffer.byteLength(value) + 1;
     {{?}}
     this._refObject.{{=field.name}} = value;
     {{?}}
@@ -559,12 +559,16 @@ class {{=arrayWrapper}} {
     this._refObject.size = this._wrappers.length;
     this._refObject.capacity = this._wrappers.length;
 
+    if (this._refObject.capacity === 0) {
+      this._refObject.data = null
+    } else {
     {{? usePlainTypedArray}}
     const buffer = Buffer.from(new Uint8Array(this._wrappers.buffer));
     this._refObject.data = buffer;
     {{?? true}}
     this._refObject.data = this._refArray.buffer;
     {{?}}
+    }
   }
 
   get refObject() {


### PR DESCRIPTION
We are using message.dot to generate the JavaScript messages for
serialization/deserialization. Through testing, we found two problems:

- To calculate the byte size of string, Buffer.byteLength should be
  used.
- If the message has a section of array, we should assign the data of the
  array to null when its capacity is 0.

This patch fixed these problems above.

Fix #391