### PR TITLE
Do not check the consistency if message is empty

### DIFF
--- a/benchmark/rclnodejs/service/client-stress-test.js
+++ b/benchmark/rclnodejs/service/client-stress-test.js
@@ -31,7 +31,7 @@ rclnodejs.init().then(() => {
   console.log('The client will send a GetMap request continuously' +
     ` until receiving response ${totalTimes} times.`);
   let sendRequest = function() {
-    client.sendRequest({_dummy: true}, (response) => {
+    client.sendRequest({}, (response) => {
       if (++receivedTimes > totalTimes) {
         rclnodejs.shutdown();
         const diff = process.hrtime(time);

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -15,6 +15,7 @@ let refArrayType = it.spec.msgName + 'RefArray';
 const compactMsgDefJSON = JSON.stringify(JSON.parse(it.json));
 
 if (it.spec.fields.length === 0) {
+  it.spec.isEmpty = true;
   /* Following rosidl_generator_c style, put a bool member named '_dummy' */
   it.spec.fields.push({
     "type": {
@@ -270,6 +271,9 @@ class {{=objectWrapper}} {
   _initMembers() {
     this._refObject = new {{=refObjectType}}();
     {{~ it.spec.fields :field}}
+    {{? it.spec.isEmpty}}
+    this._{{=field.name}}Intialized = true;
+    {{??}}
     {{? field.type.isPrimitiveType && !field.type.isArray}}
     this._{{=field.name}}Intialized = false;
     {{?}}
@@ -280,6 +284,7 @@ class {{=objectWrapper}} {
     this._wrapperFields.{{=field.name}} = new {{=getWrapperNameByType(field.type)}}();
     {{?? it.spec.msgName === 'String'}}
     primitiveTypes.initString(this._refObject);
+    {{?}}
     {{?}}
     {{~}}
   }


### PR DESCRIPTION
Currently, we have to assign the _dummy member of the JavaScript message
explicity if the message itself is empty. e.g. the request of a GetMap
service.

This patch implements that not checking the consistency when the message
does not have a field.

Fix #393