### PR TITLE
Correct the memory layout of fixed array

### DIFF
--- a/rosidl_gen/generator.json
+++ b/rosidl_gen/generator.json
@@ -1,6 +1,6 @@
 {
   "name": "rosidl-generator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Generate JavaScript object from ROS IDL(.msg) files",
   "authors": [
     "Minggang Wang <minggang.wang@intel.com>",

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -212,6 +212,8 @@ const {{=refObjectType}} = StructType({
 {{~ it.spec.fields :field}}
   {{? field.type.isPrimitiveType && !field.type.isArray}}
   {{=field.name}}: primitiveTypes.{{=field.type.type}},
+  {{?? field.type.isPrimitiveType && field.type.isArray && field.type.isFixedSizeArray}}
+  {{=field.name}}: ArrayType(primitiveTypes.{{=field.type.type}}, {{=field.type.arraySize}}),
   {{?? field.type.isArray}}
   {{=field.name}}: {{=getWrapperNameByType(field.type)}}.refObjectArrayType,
   {{?? true}}
@@ -328,7 +330,11 @@ class {{=objectWrapper}} {
     }
 
     {{~ it.spec.fields :field}}
-    {{? field.type.isArray && field.type.isPrimitiveType && !isTypedArrayType(field.type)}}
+    {{? field.type.isArray && field.type.isPrimitiveType && field.type.isFixedSizeArray}}
+    for (let i = 0; i < this._wrapperFields.{{=field.name}}.data.length; i++) {
+      this._refObject.{{=field.name}}[i] = this._wrapperFields.{{=field.name}}.data[i];
+    }
+    {{?? field.type.isArray && field.type.isPrimitiveType && !isTypedArrayType(field.type)}}
     this._wrapperFields.{{=field.name}}.fill(this._{{=field.name}}Array);
     this._wrapperFields.{{=field.name}}.freeze(own, checkConsistency);
     this._refObject.{{=field.name}} = this._wrapperFields.{{=field.name}}.refObject;
@@ -359,7 +365,10 @@ class {{=objectWrapper}} {
     this._{{=field.name}}Intialized = true;
     {{?}}
 
-    {{? field.type.isArray && field.type.isPrimitiveType && !isTypedArrayType(field.type)}}
+    {{? field.type.isArray && field.type.isPrimitiveType && field.type.isFixedSizeArray}}
+    this._refObject.{{=field.name}} = refObject.{{=field.name}};
+    this._wrapperFields.{{=field.name}}.fill(refObject.{{=field.name}}.toArray());
+    {{?? field.type.isArray && field.type.isPrimitiveType && !isTypedArrayType(field.type)}}
     refObject.{{=field.name}}.data.length = refObject.{{=field.name}}.size;
     for (let index = 0; index < refObject.{{=field.name}}.size; index++) {
       this._{{=field.name}}Array[index] = refObject.{{=field.name}}.data[index].data;
@@ -380,7 +389,7 @@ class {{=objectWrapper}} {
 
   static freeStruct(refObject) {
   {{~ it.spec.fields :field}}
-    {{? field.type.isArray}}
+    {{? field.type.isArray && !field.type.isFixedSizeArray}}
     if (refObject.{{=field.name}}.size != 0) {
       {{=getWrapperNameByType(field.type)}}.ArrayType.freeArray(refObject.{{=field.name}});
       if ({{=getWrapperNameByType(field.type)}}.ArrayType.useTypedArray) {
@@ -445,6 +454,12 @@ class {{=objectWrapper}} {
     this._{{=field.name}}Intialized = true;
     {{?}}
 
+    {{?field.type.isArray && field.type.isFixedSizeArray}}
+    if (value.length !== {{=field.type.arraySize}}) {
+      throw new RangeError('The length of the array must be {{=field.type.arraySize}}.');
+    }
+    {{?}}
+
     {{? field.type.isArray && isTypedArrayType(field.type)}}
     this._wrapperFields['{{=field.name}}'].fill(value);
     {{?? field.type.isArray && field.type.isPrimitiveType}}
@@ -478,6 +493,8 @@ class {{=objectWrapper}} {
     for (let index = 0; index < refObject.{{=field.name}}.size; index++) {
       this._{{=field.name}}Array[index] = refObject.{{=field.name}}.data[index].data;
     }
+    {{?? field.type.isArray && field.type.isPrimitiveType && field.type.isFixedSizeArray}}
+    this._wrapperFields.{{=field.name}}.fill(refObject.{{=field.name}}.toArray());
     {{?? !field.type.isPrimitiveType || field.type.isArray || (field.type.type === 'string' && it.spec.msgName !== 'String')}}
     this._wrapperFields.{{=field.name}}.copyRefObject(this._refObject.{{=field.name}});
     {{?}}

--- a/test/test-fixed-array.js
+++ b/test/test-fixed-array.js
@@ -1,0 +1,124 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const rclnodejs = require('../index.js');
+
+/* eslint-disable camelcase */
+/* eslint-disable key-spacing */
+/* eslint-disable comma-spacing */
+
+describe('Test message which has a fixed array of 36', function() {
+  this.timeout(60 * 1000);
+
+  const mapData = {
+    map: {
+      header: {
+        stamp: {
+          sec: 123456,
+          nanosec: 789,
+        },
+        frame_id: 'main_frame'
+      },
+      info: {
+        map_load_time: {
+          sec: 123456,
+          nanosec: 789,
+        },
+        resolution: 1.0,
+        width: 1024,
+        height: 768,
+        origin: {
+          position: {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0
+          },
+          orientation: {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            w: 0.0
+          }
+        }
+      },
+      data: Int8Array.from([1, 2, 3])
+    },
+    initial_pose: {
+      header: {
+        stamp: {
+          sec: 123456,
+          nanosec: 789,
+        },
+        frame_id: 'main frame',
+      },
+      pose: {
+        pose: {
+          position:    {x: 11.5, y: 112.75, z: 9.0, },
+          orientation: {x: 31.5, y: 21.5,   z: 7.5, w: 1.5, },
+        },
+        covariance: Float64Array.from({length: 36}, (v, k) => k)
+      }
+    }
+  };
+
+  before(function() {
+    return rclnodejs.init();
+  });
+
+  after(function() {
+    rclnodejs.shutdown();
+  });
+
+  it('Assigned with an array of 36', function(done) {
+    const node = rclnodejs.createNode('set_map_client');
+    node.createService('nav_msgs/srv/SetMap', 'set_map', (request, response) => {
+      assert.deepStrictEqual(request, mapData);
+      response.success = true;
+      return response;
+    });
+
+    rclnodejs.spin(node);
+    const client = node.createClient('nav_msgs/srv/SetMap', 'set_map');
+    client.sendRequest(mapData, (response) => {
+      assert.deepStrictEqual(response.success, true);
+      node.destroy();
+      done();
+    });
+  });
+
+  it('Assigned with a longer array', function(done) {
+    mapData.initial_pose.pose.covariance = Float64Array.from({length: 37}, (v, k) => k);
+    const node = rclnodejs.createNode('set_map_client');
+    const client = node.createClient('nav_msgs/srv/SetMap', 'set_map');
+    assert.throws(() => {
+      client.sendRequest(mapData, (response) => {});
+    }, RangeError);
+    node.destroy();
+    done();
+  });
+
+  it('Assigned with a shorter array', function(done) {
+    mapData.initial_pose.pose.covariance = Float64Array.from({length: 35}, (v, k) => k);
+    const node = rclnodejs.createNode('set_map_client');
+    const client = node.createClient('nav_msgs/srv/SetMap', 'set_map');
+    assert.throws(() => {
+      client.sendRequest(mapData, (response) => {});
+    }, RangeError);
+    node.destroy();
+    done();
+  });
+});


### PR DESCRIPTION
If the .msg contains a field of array which has a fixed size, the struct
of it is different from the one which has a variable array. The struct
holds the pointer of the array when it's variable, and holds the array
itself directly when it's fixed. e.g.

/// Struct of message geometry_msgs/PoseWithCovariance
typedef struct geometry_msgs__msg__PoseWithCovariance
{
  geometry_msgs__msg__Pose pose;
    double covariance[36];

} geometry_msgs__msg__PoseWithCovariance;

The change of this patch differentiates the arrays which have fixed
size to have the right memory layout for primitive type, and patch for
non-primitive arrays of fixed size will be following.

Fix #400