### PR TITLE
Correct the momory layout of static array of non-primitive type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
         - ./node_modules
     # Test
     - run: npm install istanbul coveralls
-    - run: source ~/ros2_install/ros2-osx/local_setup.bash && node scripts/compile_cpp.js && node ./node_modules/.bin/istanbul cover ./scripts/run_test.js --report lcovonly && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
+    - run: source ~/ros2_install/ros2-osx/local_setup.bash && node scripts/compile_tests.js && node ./node_modules/.bin/istanbul cover ./scripts/run_test.js --report lcovonly && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
     # Teardown
     - run: find $HOME/Library/Developer/Xcode/DerivedData -name '*.xcactivitylog' -exec cp {} $CIRCLE_ARTIFACTS/xcactivitylog \; || true
     # Save test results

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "install": "node-gyp rebuild",
     "docs": "cd docs && make",
-    "test": "node ./scripts/compile_cpp.js && node ./scripts/run_test.js",
+    "test": "node ./scripts/compile_tests.js && node ./scripts/run_test.js",
     "lint": "eslint --max-warnings=0 index.js scripts lib example rosidl_gen rosidl_parser test benchmark/rclnodejs && node ./scripts/cpplint.js",
     "postinstall": "node scripts/generate_messages.js"
   },

--- a/rosidl_gen/message_translator.js
+++ b/rosidl_gen/message_translator.js
@@ -42,7 +42,7 @@ function copyMsgObject(msg, obj) {
               msgArray.push(toROSMessage(msg[i].classType.elementType, o));
             });
             // 3. Assign
-            msg[i].fill(msgArray);
+            msg[i] = msgArray;
           } else {
             // It's an array of primitive-type elements or an empty array
             msg[i] = obj[i];

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -214,6 +214,8 @@ const {{=refObjectType}} = StructType({
   {{=field.name}}: primitiveTypes.{{=field.type.type}},
   {{?? field.type.isPrimitiveType && field.type.isArray && field.type.isFixedSizeArray}}
   {{=field.name}}: ArrayType(primitiveTypes.{{=field.type.type}}, {{=field.type.arraySize}}),
+  {{?? !field.type.isPrimitiveType && field.type.isArray && field.type.isFixedSizeArray}}
+  {{=field.name}}: ArrayType({{=getWrapperNameByType(field.type)}}.refObjectType, {{=field.type.arraySize}}),
   {{?? field.type.isArray}}
   {{=field.name}}: {{=getWrapperNameByType(field.type)}}.refObjectArrayType,
   {{?? true}}
@@ -338,6 +340,11 @@ class {{=objectWrapper}} {
     this._wrapperFields.{{=field.name}}.fill(this._{{=field.name}}Array);
     this._wrapperFields.{{=field.name}}.freeze(own, checkConsistency);
     this._refObject.{{=field.name}} = this._wrapperFields.{{=field.name}}.refObject;
+    {{?? field.type.isArray && !field.type.isPrimitiveType && field.type.isFixedSizeArray}}
+    for (let i = 0; i < this._wrapperFields.{{=field.name}}.data.length; i++) {
+      this._refObject.{{=field.name}}[i] = this._wrapperFields.{{=field.name}}.data[i].freeze(own, checkConsistency);
+      this._refObject.{{=field.name}}[i] = this._wrapperFields.{{=field.name}}.data[i].refObject;
+    }
     {{?? !field.type.isPrimitiveType || field.type.isArray}}
     this._wrapperFields.{{=field.name}}.freeze(own, checkConsistency);
     this._refObject.{{=field.name}} = this._wrapperFields.{{=field.name}}.refObject;
@@ -373,6 +380,12 @@ class {{=objectWrapper}} {
     for (let index = 0; index < refObject.{{=field.name}}.size; index++) {
       this._{{=field.name}}Array[index] = refObject.{{=field.name}}.data[index].data;
     }
+    {{?? field.type.isArray && !field.type.isPrimitiveType && field.type.isFixedSizeArray}}
+    this._refObject.{{=field.name}} = refObject.{{=field.name}};
+    this._wrapperFields.{{=field.name}}.size = {{=field.type.arraySize}}
+    for (let i = 0; i < {{=field.type.arraySize}}; i++) {
+      this._wrapperFields.{{=field.name}}.data[i].copyRefObject(refObject.{{=field.name}}[i]);
+    }
     {{?? !field.type.isPrimitiveType || field.type.isArray}}
     this._wrapperFields.{{=field.name}}.copyRefObject(refObject.{{=field.name}});
     {{?? field.type.type === 'string' && it.spec.msgName !== 'String'}}
@@ -397,6 +410,10 @@ class {{=objectWrapper}} {
       } else {
         deallocator.freeStructMember(refObject.{{=field.name}}, {{=getWrapperNameByType(field.type)}}.refObjectArrayType, 'data');
       }
+    }
+    {{?? field.type.isArray && !field.type.isPrimitiveType && field.type.isFixedSizeArray}}
+    for (let i = 0; i < {{=field.type.arraySize}}; i++) {
+      {{=getWrapperNameByType(field.type)}}.freeStruct(refObject.{{=field.name}}[i]);
     }
     {{?? !field.type.isPrimitiveType || (field.type.type === 'string' && it.spec.msgName !== 'String')}}
     {{=getWrapperNameByType(field.type)}}.freeStruct(refObject.{{=field.name}});
@@ -495,6 +512,12 @@ class {{=objectWrapper}} {
     }
     {{?? field.type.isArray && field.type.isPrimitiveType && field.type.isFixedSizeArray}}
     this._wrapperFields.{{=field.name}}.fill(refObject.{{=field.name}}.toArray());
+    {{?? field.type.isArray && !field.type.isPrimitiveType && field.type.isFixedSizeArray}}
+    this._refObject.{{=field.name}} = refObject.{{=field.name}};
+    this._wrapperFields.{{=field.name}}.size = {{=field.type.arraySize}}
+    for (let i = 0; i < {{=field.type.arraySize}}; i++) {
+      this._wrapperFields.{{=field.name}}.data[i].copyRefObject(refObject.{{=field.name}}[i]);
+    }
     {{?? !field.type.isPrimitiveType || field.type.isArray || (field.type.type === 'string' && it.spec.msgName !== 'String')}}
     this._wrapperFields.{{=field.name}}.copyRefObject(this._refObject.{{=field.name}});
     {{?}}

--- a/scripts/compile_tests.js
+++ b/scripts/compile_tests.js
@@ -14,7 +14,8 @@
 
 'use strict';
 
-const fs = require('fs');
+/* eslint-disable */
+const fs = require('fs-extra');
 const os = require('os');
 const path = require('path');
 const child = require('child_process');
@@ -49,7 +50,6 @@ var clientPath = getExecutablePath(client);
 
 
 function copyFile(platform, srcFile, destFile) {
-  // eslint-disable-next-line
   if (!fs.existsSync(destFile)) {
     if (os.platform() === 'win32') {
       child.spawn('cmd.exe', ['/c', `copy ${srcFile} ${destFile}`]);
@@ -65,9 +65,22 @@ function copyAll(fileList, dest) {
   });
 }
 
-// eslint-disable-next-line
+if (os.platform() !== 'win32') {
+  var subProcess = child.spawn('colcon', ['build',
+    '--base-paths', path.join(rootDir, 'test', 'rclnodejs_test_msgs')]);
+  subProcess.on('close', (code) => {
+        child.spawn('sh',
+          ['-c', `cp -r ${path.join(rootDir, 'install', 'rclnodejs_test_msgs') + '/.'} ${process.env.AMENT_PREFIX_PATH}`]);
+  });
+  subProcess.stdout.on('data', (data) => {
+    console.log(`${data}`);
+  });
+  subProcess.stderr.on('data', (data) => {
+    console.log(`${data}`);
+  });
+}
+
 if (!fs.existsSync(publisherPath) && !fs.existsSync(subscriptionPath) &&
-  // eslint-disable-next-line
   !fs.existsSync(listenerPath) && !fs.existsSync(clientPath)) {
   var compileProcess = child.spawn('colcon', ['build', '--base-paths', testCppDir]);
   compileProcess.on('close', (code) => {
@@ -82,3 +95,4 @@ if (!fs.existsSync(publisherPath) && !fs.existsSync(subscriptionPath) &&
 } else {
   copyAll([publisherPath, subscriptionPath, , listenerPath, clientPath], testCppDir);
 }
+/* eslint-enable */

--- a/scripts/run_test.js
+++ b/scripts/run_test.js
@@ -14,29 +14,33 @@
 
 'use strict';
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const Mocha = require('mocha');
 const os = require('os');
 const path = require('path');
 
-let mocha = new Mocha();
-const testDir = path.join(__dirname, '../test/');
-// eslint-disable-next-line
-const tests = fs.readdirSync(testDir).filter(file => {
-  return file.substr(0, 5) === 'test-';});
+fs.remove(path.join(path.dirname(__dirname), 'generated'), (err)=> {
+  if (!err) {
+    let mocha = new Mocha();
+    const testDir = path.join(__dirname, '../test/');
+    // eslint-disable-next-line
+    const tests = fs.readdirSync(testDir).filter(file => {
+      return file.substr(0, 5) === 'test-';});
 
-// eslint-disable-next-line
-let blacklist = JSON.parse(fs.readFileSync(path.join(__dirname, '../test/blacklist.json'), 'utf8'));
-let ignoredCases = blacklist[os.type()];
+    // eslint-disable-next-line
+    let blacklist = JSON.parse(fs.readFileSync(path.join(__dirname, '../test/blacklist.json'), 'utf8'));
+    let ignoredCases = blacklist[os.type()];
 
-tests.forEach(test => {
-  if (ignoredCases.indexOf(test) === -1) {
-    mocha.addFile(path.join(testDir, test));
+    tests.forEach(test => {
+      if (ignoredCases.indexOf(test) === -1) {
+        mocha.addFile(path.join(testDir, test));
+      }
+    });
+
+    mocha.run(function(failures) {
+      process.on('exit', () => {
+        process.exit(failures);
+      });
+    });
   }
-});
-
-mocha.run(function(failures) {
-  process.on('exit', () => {
-    process.exit(failures);
-  });
 });

--- a/test/blacklist.json
+++ b/test/blacklist.json
@@ -1,5 +1,5 @@
 {
   "Linux": [],
   "Darwin": [],
-  "Windows_NT": []
+  "Windows_NT": ["test-non-primitive-static-array.js"]
 }

--- a/test/rclnodejs_test_msgs/CMakeLists.txt
+++ b/test/rclnodejs_test_msgs/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(rclnodejs_test_msgs)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # we dont use add_compile_options with pedantic in message packages
+  # because the Python C extensions dont comply with it
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+set(msg_files
+  "msg/StaticArrayNonPrimitives.msg"
+)
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  DEPENDENCIES builtin_interfaces
+)
+
+ament_package()

--- a/test/rclnodejs_test_msgs/msg/StaticArrayNonPrimitives.msg
+++ b/test/rclnodejs_test_msgs/msg/StaticArrayNonPrimitives.msg
@@ -1,0 +1,1 @@
+builtin_interfaces/Time[2] time_value

--- a/test/rclnodejs_test_msgs/package.xml
+++ b/test/rclnodejs_test_msgs/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rclnodejs_test_msgs</name>
+  <version>0.1.0</version>
+  <description>A package containing message definitions used for testing rosidl_gen in rclnodejs.</description>
+  <maintainer email="minggang.wang@intel.com">Minggang Wang</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <build_depend>builtin_interfaces</build_depend>
+
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/test/test-non-primitive-static-array.js
+++ b/test/test-non-primitive-static-array.js
@@ -1,0 +1,84 @@
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const rclnodejs = require('../index.js');
+
+/* eslint-disable camelcase */
+/* eslint-disable key-spacing */
+/* eslint-disable comma-spacing */
+
+describe('Test message which has a static non-primitive array', function() {
+  this.timeout(60 * 1000);
+
+  let time = {
+    sec: 123456,
+    nanosec: 789,
+  };
+  let time_value = [];
+  time_value.push(time);
+  time_value.push(time);
+
+  beforeEach(function() {
+    return rclnodejs.init();
+  });
+
+  afterEach(function() {
+    rclnodejs.shutdown();
+  });
+
+  it('Assigned with an array whose length is 2', function(done) {
+    const node = rclnodejs.createNode('publish_time');
+    let publisher = node.createPublisher('rclnodejs_test_msgs/msg/StaticArrayNonPrimitives', 'time');
+    let timer = setInterval(() => {
+      assert.doesNotThrow(() => {
+        console.log('length is ' + time_value.length);
+        publisher.publish({time_value});
+      }, RangeError);
+    }, 100);
+
+    node.createSubscription('rclnodejs_test_msgs/msg/StaticArrayNonPrimitives', 'time', (msg) => {
+      clearInterval(timer);
+      assert.deepStrictEqual(msg.time_value, time_value);
+      node.destroy();
+      done();
+    });
+
+    rclnodejs.spin(node);
+  });
+
+  it('Assigned with an array whose length is greater than 2', function(done) {
+    time_value.push(time);
+    const node = rclnodejs.createNode('publish_time');
+    let publisher = node.createPublisher('rclnodejs_test_msgs/msg/StaticArrayNonPrimitives', 'time');
+    assert.throws(() => {
+      publisher.publish({time_value});
+    }, RangeError);
+    node.destroy();
+    done();
+  });
+
+
+  it('Assigned with an array whose length is less than 2', function(done) {
+    const node = rclnodejs.createNode('publish_time');
+    let publisher = node.createPublisher('rclnodejs_test_msgs/msg/StaticArrayNonPrimitives', 'time');
+    assert.throws(() => {
+      publisher.publish({time_value: time_value.slice(0, 0)});
+    }, RangeError);
+    node.destroy();
+    done();
+  });
+});


### PR DESCRIPTION
If the .msg contains a field of array which has a static size and
non-primitive type, the struct of it has a different memory layout
compared with non-static array.

This patch corrects the memory layout based on .msg files and add
corresponding test cases.

Fix #400