### PR TITLE
Add timeout parameter for rcl_wait functioin

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,16 +175,17 @@ let rcl = {
   /**
    * Start to spin the node, which triggers the event loop to start to check the incoming events.
    * @param {Node} node - The node to be spun.
+   * @param {number} [timeout=10] - ms to wait, block forever if negative, don't wait if 0, default is 10.
    * @return {undefined}
    */
-  spin(node) {
+  spin(node, timeout = 10) {
     if (!(node instanceof rclnodejs.ShadowNode)) {
       throw new TypeError('Invalid argument.');
     }
     if (node.spinning) {
       throw new Error('The node is already spinning.');
     }
-    node.startSpinning(this._context.handle());
+    node.startSpinning(this._context.handle(), timeout);
   },
 
   /**

--- a/lib/node.js
+++ b/lib/node.js
@@ -86,8 +86,8 @@ class Node {
     });
   }
 
-  startSpinning(context) {
-    this.start(context);
+  startSpinning(context, timeout) {
+    this.start(context, timeout);
     this.spinning = true;
   }
 

--- a/src/executor.hpp
+++ b/src/executor.hpp
@@ -37,8 +37,9 @@ class Executor {
   Executor(HandleManager* handle_manager, Delegate* delegate);
   ~Executor();
 
-  void Start(rcl_context_t* context);
+  void Start(rcl_context_t* context, int32_t time_out);
   void Stop();
+  int32_t time_out() { return time_out_; }
 
   static void DoWork(uv_async_t* handle);
   static void Run(void* arg);
@@ -50,6 +51,7 @@ class Executor {
   HandleManager* handle_manager_;
   Delegate* delegate_;
   rcl_context_t* context_;
+  int32_t time_out_;
 
   std::atomic_bool running_;
 };

--- a/src/handle_manager.cpp
+++ b/src/handle_manager.cpp
@@ -70,8 +70,8 @@ bool HandleManager::AddHandlesToWaitSet(rcl_wait_set_t* wait_set) {
       return false;
   }
   for (auto& subscription : subscriptions_) {
-    if (rcl_wait_set_add_subscription(
-        wait_set, subscription, nullptr) != RCL_RET_OK)
+    if (rcl_wait_set_add_subscription(wait_set, subscription, nullptr) !=
+        RCL_RET_OK)
       return false;
   }
   for (auto& client : clients_) {

--- a/src/rcl_bindings.hpp
+++ b/src/rcl_bindings.hpp
@@ -16,6 +16,8 @@
 #define RCLNODEJS_RCL_BINDINGS_HPP_
 
 #include <nan.h>
+#include <rcl/rcl.h>
+
 #include <string>
 
 namespace rclnodejs {
@@ -26,6 +28,8 @@ typedef struct {
   const char* name;
   JsCFuntcion function;
 } BindingMethod;
+
+extern rcl_guard_condition_t* g_sigint_gc;
 
 uint32_t GetBindingMethodsCount(BindingMethod* methods);
 

--- a/src/rcl_utilities.cpp
+++ b/src/rcl_utilities.cpp
@@ -80,6 +80,8 @@ const rosidl_service_type_support_t* GetServiceTypeSupport(
     return nullptr;
 }
 
-const char* GetErrorMessageAndClear() { return dlerror(); }
+const char* GetErrorMessageAndClear() {
+  return dlerror();
+}
 
 }  // namespace rclnodejs

--- a/src/shadow_node.cpp
+++ b/src/shadow_node.cpp
@@ -24,8 +24,8 @@ namespace rclnodejs {
 
 Nan::Persistent<v8::Function> ShadowNode::constructor;
 
-ShadowNode::ShadowNode() : handle_manager_(std::make_unique<HandleManager>()),
-                           rcl_handle_(nullptr) {
+ShadowNode::ShadowNode()
+    : handle_manager_(std::make_unique<HandleManager>()), rcl_handle_(nullptr) {
   executor_ = std::make_unique<Executor>(handle_manager_.get(), this);
   rcl_handle_.reset(new Nan::Persistent<v8::Object>());
 }
@@ -76,18 +76,19 @@ void ShadowNode::StopRunning() {
   handle_manager_->ClearHandles();
 }
 
-void ShadowNode::StartRunning(rcl_context_t* context) {
+void ShadowNode::StartRunning(rcl_context_t* context, int32_t timeout) {
   handle_manager_->CollectHandles(this->handle());
-  executor_->Start(context);
+  executor_->Start(context, timeout);
 }
 
 NAN_METHOD(ShadowNode::Start) {
   auto* me = Nan::ObjectWrap::Unwrap<ShadowNode>(info.Holder());
   RclHandle* context_handle = RclHandle::Unwrap<RclHandle>(info[0]->ToObject());
+  auto timeout = Nan::To<int32_t>(info[1]).FromJust();
   rcl_context_t* context =
       reinterpret_cast<rcl_context_t*>(context_handle->ptr());
   if (me)
-    me->StartRunning(context);
+    me->StartRunning(context, timeout);
 
   info.GetReturnValue().Set(Nan::Undefined());
 }

--- a/src/shadow_node.hpp
+++ b/src/shadow_node.hpp
@@ -31,7 +31,7 @@ class ShadowNode : public Nan::ObjectWrap,
                    public Executor::Delegate {
  public:
   static void Init(v8::Local<v8::Object> exports);
-  void StartRunning(rcl_context_t* context);
+  void StartRunning(rcl_context_t* context, int32_t timeout);
   void StopRunning();
 
   Nan::Persistent<v8::Object>* rcl_handle() { return rcl_handle_.get(); }


### PR DESCRIPTION
Before this patch, the timeout used for the rcl_wait function is hard
coded which is 10ms. Apparently, this is not reasonable, because it
imposes unnecessary workload on the CPU (We need to lock/unlock the
resources shared between the main thread and the background thread
frequently). Please check the detailed record in the issue.

This patch adds the timeout parameter which developer can customize the
value when starting a node. The default value now is 10ms, negtive value
will block the thread until there is an event.

So you can change your JS code like:
    rclnodejs.spin(node, -1);  // Waits until something happens.

Fix #470