### PR TITLE
Fixes create client from string

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -246,8 +246,10 @@ class Node {
    * @return {Client} - An instance of Client.
    */
   createClient(typeClass, serviceName, options) {
-    if (typeof (typeClass) === 'string' || typeof (typeClass) === 'object') {
-      typeClass = loader.loadInterface(typeClass);
+    if (typeof (typeClass) === 'string') {
+      typeClass = loader.loadInterfaceByString(typeClass);
+    }else if( typeof (typeClass) === 'object') {
+      typeClass = loader.loadInterface(typeClass);//FIXME : This call seems doomed (see loadInterface prototype)
     }
     options = this._validateOptions(options);
 


### PR DESCRIPTION
node.createClient should work when it's first parameter is of type : "{package}/{ type (oneOf[ 'msg', 'srv', ...])}/{Message or service Name}/"

partly fixes #481