### PR TITLE
Revert "Use COLCON_PREFIX_PATH to replace AMENT_PREFIX_PATH"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt update && apt install -y \
   python3-colcon-common-extensions \
   python3-pip \
   python-rosdep \
-  python3-vcstool \
   libpython3-dev \
-  libtinyxml2.6.2v5 \
-  libtinyxml2-dev \
   cppcheck
 
 RUN rosdep init

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,6 @@ build_script:
   - git submodule update
   - ps: Install-Product node $env:nodejs_version x64
   - call c:\ros2-windows\local_setup.bat
-  - node -e "console.log(process.env.COLCON_PREFIX_PATH)"
   - "SET PATH=%PYTHON2%;%PYTHON2%\\bin;%PYTHON2%\\Scripts;%PATH%"
   - node --version
   - npm --version

--- a/binding.gyp
+++ b/binding.gyp
@@ -52,10 +52,10 @@
               '-std=c++14'
             ],
             'include_dirs': [
-              "<!@(node -e \"console.log(process.env.COLCON_PREFIX_PATH.replace(/:/, '/include/ ') + '/include/')\")",
+              "<!@(node -e \"console.log(process.env.AMENT_PREFIX_PATH.replace(/:/, '/include/ ') + '/include/')\")",
             ],
             'library_dirs': [
-              "<!@(node -e \"console.log(process.env.COLCON_PREFIX_PATH.replace(/:/, '/lib/ ') + '/lib/')\")",
+              "<!@(node -e \"console.log(process.env.AMENT_PREFIX_PATH.replace(/:/, '/lib/ ') + '/lib/')\")",
             ],
           }
         ],
@@ -70,7 +70,7 @@
             ],
             'include_dirs': [
               './src/third_party/dlfcn-win32/',
-              "<!@(node -e \"console.log(process.env.COLCON_PREFIX_PATH.replace(/;/, '\\\include ').replace(/\\\/g, '/') + '/include')\")",
+              "<!@(node -e \"console.log(process.env.AMENT_PREFIX_PATH.replace(/;/, '\\\include ').replace(/\\\/g, '/') + '/include')\")",
             ],
             'sources': [
               './src/third_party/dlfcn-win32/dlfcn.c',
@@ -81,7 +81,7 @@
               },
               'VCLinkerTool': {
                 'AdditionalDependencies': ['psapi.lib'],
-                'AdditionalLibraryDirectories': ["<!@(node -e \"console.log(process.env.COLCON_PREFIX_PATH.replace(/;/, '\\\lib ').replace(/\\\/g, '/') + '/lib')\")",],
+                'AdditionalLibraryDirectories': ["<!@(node -e \"console.log(process.env.AMENT_PREFIX_PATH.replace(/;/, '\\\lib ').replace(/\\\/g, '/') + '/lib')\")",],
               }
             }
           }
@@ -93,10 +93,10 @@
               'OS_MACOS'
             ],
             'include_dirs': [
-              "<!@(node -e \"console.log(process.env.COLCON_PREFIX_PATH.replace(/:/, '/include/ ') + '/include/')\")",
+              "<!@(node -e \"console.log(process.env.AMENT_PREFIX_PATH.replace(/:/, '/include/ ') + '/include/')\")",
             ],
             'library_dirs': [
-                "<!@(node -e \"console.log(process.env.COLCON_PREFIX_PATH.replace(/:/, '/lib/ ') + '/lib/')\")",
+                "<!@(node -e \"console.log(process.env.AMENT_PREFIX_PATH.replace(/:/, '/lib/ ') + '/lib/')\")",
             ],
             'xcode_settings': {
               'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',


### PR DESCRIPTION
This reverts commit 0c7b59a37af314576d45ecb135e27d29206026cb.

The COLCON_PREFIX_PATH variable is only present when one or more of the
workspaces in your chain is built with colcon. So we are going to use
AMENT_PREFIX_PATH for general ROS 2 development.

See detailed:
https://github.com/RobotWebTools/rclnodejs/commit/0c7b59a37af314576d45ecb135e27d29206026cb

Fix #None