### PR TITLE
Add pollForService feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ project. The next step is to send a pull request (PR) for review. The PR will be
 Special thanks to the people who contribute.
 
 * [martins-mozeiko](https://github.com/martins-mozeiko)
+* [Teo Koon Peng](https://github.com/koonpeng)
 
 ## License
 

--- a/example/client-example.js
+++ b/example/client-example.js
@@ -25,7 +25,7 @@ rclnodejs.init().then(() => {
     b: Math.floor(Math.random() * 100),
   };
 
-  client.pollForService(1000).then(result => {
+  client.waitForService(1000).then(result => {
     if (!result) {
       console.log('Error: service not available');
       rclnodejs.shutdown();

--- a/example/client-example.js
+++ b/example/client-example.js
@@ -25,10 +25,17 @@ rclnodejs.init().then(() => {
     b: Math.floor(Math.random() * 100),
   };
 
-  console.log(`Sending: ${typeof request}`, request);
-  client.sendRequest(request, (response) => {
-    console.log(`Result: ${typeof response}`, response);
-    rclnodejs.shutdown();
+  client.pollForService(1000).then(result => {
+    if (!result) {
+      console.log('Error: service not available');
+      rclnodejs.shutdown();
+      return;
+    }
+    console.log(`Sending: ${typeof request}`, request);
+    client.sendRequest(request, (response) => {
+      console.log(`Result: ${typeof response}`, response);
+      rclnodejs.shutdown();
+    });
   });
 
   rclnodejs.spin(node);

--- a/lib/client.js
+++ b/lib/client.js
@@ -73,6 +73,10 @@ class Client extends Entity {
     this._callback(this._response.toPlainObject(this.typedArrayEnabled));
   }
 
+  /**
+   * Checks if the service is available.
+   * @return {boolean} true if the service is available.
+   */
   isServiceServerAvailable() {
     return rclnodejs.serviceServerIsAvailable(this._nodeHandle, this.handle);
   }
@@ -81,6 +85,7 @@ class Client extends Entity {
    * Poll until the service server is available.
    * @param {number} timeout The maximum amount of time to poll for, if timeout
    * is `undefined` or `< 0`, this will poll indefinitely.
+   * @return {boolean} true if the service is available.
    */
   async pollForService(timeout = undefined) {
     let deadline = Infinity;

--- a/lib/client.js
+++ b/lib/client.js
@@ -24,8 +24,9 @@ const debug = require('debug')('rclnodejs:client');
  */
 
 class Client extends Entity {
-  constructor(handle, serviceName, typeClass, options) {
+  constructor(handle, nodeHandle, serviceName, typeClass, options) {
     super(handle, typeClass, options);
+    this._nodeHandle = nodeHandle;
     this._serviceName = serviceName;
     this._sequenceNumber = 0;
   }
@@ -72,10 +73,38 @@ class Client extends Entity {
     this._callback(this._response.toPlainObject(this.typedArrayEnabled));
   }
 
+  isServiceServerAvailable() {
+    return rclnodejs.serviceServerIsAvailable(this._nodeHandle, this.handle);
+  }
+
+  /**
+   * Poll until the service server is available.
+   * @param {number} timeout The maximum amount of time to poll for, if timeout
+   * is `undefined` or `< 0`, this will poll indefinitely.
+   */
+  async pollForService(timeout = undefined) {
+    let deadline = Infinity;
+    if (timeout !== undefined && timeout >= 0) {
+      deadline = Date.now() + timeout;
+    }
+    let waitMs = 5;
+    let serviceAvailable = this.isServiceServerAvailable();
+    while (!serviceAvailable && Date.now() < deadline) {
+      waitMs *= 2;
+      waitMs = Math.min(waitMs, 1000);
+      if (timeout !== undefined && timeout >= -1) {
+        waitMs = Math.min(waitMs, deadline - Date.now());
+      }
+      await new Promise(resolve => setTimeout(resolve, waitMs));
+      serviceAvailable = this.isServiceServerAvailable();
+    }
+    return serviceAvailable;
+  }
+
   static createClient(nodeHandle, serviceName, typeClass, options) {
     let type = typeClass.type();
     let handle = rclnodejs.createClient(nodeHandle, serviceName, type.interfaceName, type.pkgName, options.qos);
-    return new Client(handle, serviceName, typeClass, options);
+    return new Client(handle, nodeHandle, serviceName, typeClass, options);
   }
 
   /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -82,12 +82,14 @@ class Client extends Entity {
   }
 
   /**
-   * Poll until the service server is available.
-   * @param {number} timeout The maximum amount of time to poll for, if timeout
-   * is `undefined` or `< 0`, this will poll indefinitely.
-   * @return {boolean} true if the service is available.
+   * Wait until the service server is available or a timeout is reached. This
+   * function polls for the service state so it may not return as soon as the
+   * service is available.
+   * @param {number} timeout The maximum amount of time to wait for, if timeout
+   * is `undefined` or `< 0`, this will wait indefinitely.
+   * @return {Promise<boolean>} true if the service is available.
    */
-  async pollForService(timeout = undefined) {
+  async waitForService(timeout = undefined) {
     let deadline = Infinity;
     if (timeout !== undefined && timeout >= 0) {
       deadline = Date.now() + timeout;

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -1221,6 +1221,22 @@ NAN_METHOD(GetServiceNamesAndTypes) {
   info.GetReturnValue().Set(result_list);
 }
 
+NAN_METHOD(ServiceServerIsAvailable) {
+  RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(info[0]->ToObject());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  RclHandle* client_handle = RclHandle::Unwrap<RclHandle>(info[1]->ToObject());
+  rcl_client_t* client = reinterpret_cast<rcl_client_t*>(client_handle->ptr());
+
+  bool is_available;
+  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
+                           rcl_service_server_is_available(
+                               node, client, &is_available),
+                           "Failed to get service state.");
+
+  v8::Isolate* isolate = info.GetIsolate();
+  info.GetReturnValue().Set(v8::Boolean::New(isolate, is_available));
+}
+
 uint32_t GetBindingMethodsCount(BindingMethod* methods) {
   uint32_t count = 0;
   while (methods[count].function) {
@@ -1284,6 +1300,7 @@ BindingMethod binding_methods[] = {
     {"getServiceNamesAndTypesByNode", GetServiceNamesAndTypesByNode},
     {"getTopicNamesAndTypes", GetTopicNamesAndTypes},
     {"getServiceNamesAndTypes", GetServiceNamesAndTypes},
+    {"serviceServerIsAvailable", ServiceServerIsAvailable},
     {"", nullptr}};
 
 }  // namespace rclnodejs

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -1233,8 +1233,8 @@ NAN_METHOD(ServiceServerIsAvailable) {
                                node, client, &is_available),
                            "Failed to get service state.");
 
-  v8::Isolate* isolate = info.GetIsolate();
-  info.GetReturnValue().Set(v8::Boolean::New(isolate, is_available));
+  v8::Local<v8::Boolean> result = Nan::New<v8::Boolean>(is_available);
+  info.GetReturnValue().Set(result);
 }
 
 uint32_t GetBindingMethodsCount(BindingMethod* methods) {

--- a/test/client_setup.js
+++ b/test/client_setup.js
@@ -26,7 +26,7 @@ rclnodejs.init().then(function() {
     b: 2,
   };
   var publisher = node.createPublisher(Int8, 'back_add_two_ints');
-  var timer = node.createTimer(100, () => {
+  client.pollForService().then(() => {
     client.sendRequest(request, (response) => {
       publisher.publish(response.sum);
     });

--- a/test/client_setup.js
+++ b/test/client_setup.js
@@ -26,7 +26,7 @@ rclnodejs.init().then(function() {
     b: 2,
   };
   var publisher = node.createPublisher(Int8, 'back_add_two_ints');
-  client.pollForService().then(() => {
+  client.waitForService().then(() => {
     client.sendRequest(request, (response) => {
       publisher.publish(response.sum);
     });


### PR DESCRIPTION
I notice rclnodejs blocks indefinitely when doing a service call immediately after creating a client. This is possibly because the service is not ready yet.

This PR adds `isServiceServerAvailable` and `pollForService` method. They aim to provide the same functionality as `wait_for_service` in rclpy. (https://github.com/ros2/rclpy/blob/1cf216dd9ecd4359dc93f317e01b7386d5a36c5a/rclpy/rclpy/client.py#L146)