### PR TITLE
fix #531 time.secondsAndNanoseconds

### DIFF
--- a/lib/time.js
+++ b/lib/time.js
@@ -97,9 +97,9 @@ class Time {
    */
 
   get secondsAndNanoseconds() {
-    let seconds = this._nanoseconds.divide(1e9).toNumber();
-    let nanoseconds = this._nanoseconds.mod(1e9).toNumber();
-    return {seconds, nanoseconds};
+    const seconds = int64.from(this._nanoseconds).divide(1e9).toNumber();
+    const nanoseconds = int64.from(this._nanoseconds).mod(1e9).toNumber();
+    return { seconds, nanoseconds };
   }
 
   /**

--- a/test/test-time.js
+++ b/test/test-time.js
@@ -148,6 +148,10 @@ describe('rclnodejs Time/Clock testing', function() {
     assert.throws(() => {
       time.add(result);
     }, TypeError);
+
+    let nanos = time._nanoseconds;
+    time.secondsAndNanoseconds;
+    assert.strictEqual(time._nanoseconds,nanos);
   });
 
   it('Test duration functions', function() {

--- a/test/test-time.js
+++ b/test/test-time.js
@@ -151,7 +151,7 @@ describe('rclnodejs Time/Clock testing', function() {
 
     let nanos = time._nanoseconds;
     time.secondsAndNanoseconds;
-    assert.strictEqual(time._nanoseconds,nanos);
+    assert.strictEqual(time._nanoseconds, nanos);
   });
 
   it('Test duration functions', function() {


### PR DESCRIPTION
Revised implementation of Time.secondsAndNanoseconds to avoid Time._nanoseconds being modified. Includes test.