### PR TITLE
Add support information of Eloquent Elusor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,7 @@ jobs:
     - run: brew update
     - run: brew uninstall python
     - run: brew install python
-    - run: brew install wget cmake cppcheck tinyxml tinyxml2 eigen pcre
-    - run: brew install https://raw.githubusercontent.com/alebcay/homebrew-core/419873be053a08233d9fd3952f2615c139902434/Formula/poco.rb
+    - run: brew install wget cmake cppcheck tinyxml tinyxml2 eigen pcre poco
     - run: brew install openssl
     - run: brew install asio console_bridge
     - run: python3 -m pip install catkin_pkg empy git+https://github.com/lark-parser/lark.git@0.7d pyparsing pyyaml setuptools argcomplete colcon-common-extensions numpy

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rclnodejs - ROS Client Library for JavaScript language[![npm](https://img.shields.io/npm/v/rclnodejs.svg)](https://www.npmjs.com/package/rclnodejs)[![Coverage Status](https://coveralls.io/repos/github/RobotWebTools/rclnodejs/badge.svg?branch=develop)](https://coveralls.io/github/RobotWebTools/rclnodejs?branch=develop)[![npm](https://img.shields.io/npm/dt/rclnodejs.svg)](https://www.npmjs.com/package/rclnodejs)[![GitHub license](https://img.shields.io/github/license/RobotWebTools/rclnodejs.svg)](https://github.com/RobotWebTools/rclnodejs/blob/develop/LICENSE)[![node](https://img.shields.io/node/v/rclnodejs.svg)](https://nodejs.org/en/download/releases/)[![dependencies Status](https://david-dm.org/RobotWebTools/rclnodejs/status.svg)](https://david-dm.org/RobotWebTools/rclnodejs)
+# rclnodejs - ROS Client Library for JavaScript language[![npm](https://img.shields.io/npm/v/rclnodejs.svg)](https://www.npmjs.com/package/rclnodejs)[![Coverage Status](https://coveralls.io/repos/github/RobotWebTools/rclnodejs/badge.svg?branch=develop)](https://coveralls.io/github/RobotWebTools/rclnodejs?branch=develop)[![npm](https://img.shields.io/npm/dm/rclnodejs)](https://www.npmjs.com/package/rclnodejs)[![GitHub license](https://img.shields.io/github/license/RobotWebTools/rclnodejs.svg)](https://github.com/RobotWebTools/rclnodejs/blob/develop/LICENSE)[![node](https://img.shields.io/node/v/rclnodejs.svg)](https://nodejs.org/en/download/releases/)[![dependencies Status](https://david-dm.org/RobotWebTools/rclnodejs/status.svg)](https://david-dm.org/RobotWebTools/rclnodejs)
 
 Branch | Linux Build | macOS Build | Windows Build |
 ------------ |  :-------------: | :-------------: | :-------------: |
@@ -11,7 +11,7 @@ If you want to select a stable release of ROS 2.0 as your platform, please check
 
 ROS 2.0 release | NPM version |
 :------------: |  :-------------: |
-Dashing Diademata Patch Release [4](https://github.com/ros2/ros2/releases/tag/release-dashing-20191018) | [0.10.3](https://github.com/RobotWebTools/rclnodejs/releases/tag/0.10.3) |
+Dashing Diademata Patch Release [4](https://github.com/ros2/ros2/releases/tag/release-dashing-20191018) / [Eloquent Elusor](https://github.com/ros2/ros2/releases/tag/release-eloquent-20191122) | [0.10.3](https://github.com/RobotWebTools/rclnodejs/releases/tag/0.10.3) |
 Dashing Diademata Patch Release [3](https://github.com/ros2/ros2/releases/tag/release-dashing-20190910) | [0.10.2](https://github.com/RobotWebTools/rclnodejs/releases/tag/0.10.2) |
 Dashing Diademata Patch Release [2](https://github.com/ros2/ros2/releases/tag/release-dashing-20190806) | [0.10.1](https://github.com/RobotWebTools/rclnodejs/releases/tag/0.10.1) |
 Dashing Diademata Patch Release [1](https://github.com/ros2/ros2/releases/tag/release-dashing-20190614) | [0.10.0](https://www.npmjs.com/package/rclnodejs/v/0.10.0) |


### PR DESCRIPTION
As ROS 2.0 has a new stable release, Eloquent Elusor. We are going to
verify rclnodejs on it. This patch includes:

- Support information of Eloquent Elusor: verified at
https://github.com/RobotWebTools/rclnodejs/pull/538
- Change the statistics of npm downloads to be monthly.
- Change the poco version on macOS platform.

Fix #539