### PR TITLE
Implement getNodeNames from rcl_get_node_names

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -454,6 +454,14 @@ class Node {
   getServiceNamesAndTypes() {
     return rclnodejs.getServiceNamesAndTypes(this.handle);
   }
+
+  /**
+   * Get the list of nodes discovered by the provided node.
+   * @return {array} - An array of the names and namespaces.
+   */
+  getNodeNames() {
+    return rclnodejs.getNodeNames(this.handle);
+  }
 }
 
 module.exports = Node;

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -304,6 +304,17 @@ describe('rcl node methods testing', function() {
       });
     });
   });
+
+  it('node.getNodeNames', function() {
+    var nodeNames = node.getNodeNames();
+
+    var currentNode = nodeNames.find(function(nodeName) {
+      return nodeName.name === 'my_node';
+    });
+
+    assert.ok(currentNode);
+    assert.strictEqual(currentNode.namespace, '/my_ns');
+  });
 });
 
 describe('topic & serviceName getter/setter', function() {

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -55,6 +55,8 @@ node.getSubscriptionNamesAndTypesByNode(NODE_NAME);
 // $ExpectType NamesAndTypesQueryResult[]
 node.getTopicNamesAndTypes();
 
+// $ExpectType NodeNamesQueryResult[]
+node.getNodeNames();
 
 
 // ---- Publisher ----

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -121,6 +121,23 @@ declare module 'rclnodejs' {
   type NamesAndTypesQueryResult = {
     name: string;
     types: Array<string>;
+	}
+	
+	/**
+	 * Result of Node.getNodeNames() query
+	 *
+	 * @example
+	 * ```
+	 * [ 
+	 *   { name: 'gazebo',                namespace: '/' },
+	 *   { name: 'robot_state_publisher', namespace: '/' },
+	 *   { name: 'cam2image',             namespace: '/demo' }
+	 * ]
+	 * ```
+	 */
+  type NodeNamesQueryResult = {
+    name: string;
+    namespace: string;
   }
 
 
@@ -308,7 +325,19 @@ declare module 'rclnodejs' {
 		 *        ]
 		 */
     getServiceNamesAndTypes(): Array<NamesAndTypesQueryResult>
-
+		
+    /**
+		 * Get the list of nodes discovered by the provided node.
+		 * 
+		 * @returns An array of the names and namespaces.
+		 *        [ 
+		 *          { name: 'gazebo',                namespace: '/' },
+		 *          { name: 'robot_state_publisher', namespace: '/' },
+		 *          { name: 'cam2image',             namespace: '/demo' }
+		 *        ]
+		 */
+    getNodeNames(): Array<NodeNamesQueryResult>;
+		
   }
 
 


### PR DESCRIPTION
Exposes the rcl rcl_get_node_names function as part of the rclnodejs Node class. Unlike the rclpy lib which returns an array of tuples, getNodeNames will return an array of objects following the pattern used in the other getXNamesAndTypes functions.

Here's some example output.

```
[
  { name: '_ros2cli_daemon_0', namespace: '/' },
  { name: 'launch_ros_4923', namespace: '/' },
  { name: 'robot_state_publisher', namespace: '/' },
  { name: 'gazebo', namespace: '/' },
  { name: 'turtlebot3_imu', namespace: '/' },
  { name: 'turtlebot3_laserscan', namespace: '/' },
  { name: 'camera_driver', namespace: '/' },
  { name: 'turtlebot3_diff_drive', namespace: '/' },
  { name: 'turtlebot3_joint_state', namespace: '/' }
]
```

Fix #555