### PR TITLE
Add countPublishers and countSubscribers to Node

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -462,6 +462,30 @@ class Node {
   getNodeNames() {
     return rclnodejs.getNodeNames(this.handle);
   }
+
+  /**
+   * Return the number of publishers on a given topic.
+   * @param {string} topic - The name of the topic.
+   * @returns {number} - Number of publishers on the given topic.
+   */
+  countPublishers(topic) {
+    let expandedTopic = rclnodejs.expandTopicName(topic, this._name, this._namespace);
+    rclnodejs.validateTopicName(expandedTopic);
+
+    return rclnodejs.countPublishers(this.handle, expandedTopic);
+  }
+
+  /**
+   * Return the number of subscribers on a given topic.
+   * @param {string} topic - The name of the topic.
+   * @returns {number} - Number of subscribers on the given topic.
+   */
+  countSubscribers(topic) {
+    let expandedTopic = rclnodejs.expandTopicName(topic, this._name, this._namespace);
+    rclnodejs.validateTopicName(expandedTopic);
+
+    return rclnodejs.countSubscribers(this.handle, expandedTopic);
+  }
 }
 
 module.exports = Node;

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -1262,6 +1262,38 @@ NAN_METHOD(GetNodeNames) {
   info.GetReturnValue().Set(result_list);
 }
 
+NAN_METHOD(CountPublishers) {
+  RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(info[0]->ToObject());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  std::string topic_name = *Nan::Utf8String(info[1]->ToString());
+
+  size_t count = 0;
+  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
+                           rcl_count_publishers(
+                               node, topic_name.c_str(), &count),
+                           "Failed to count publishers.");
+
+  v8::Local<v8::Integer> result
+    = Nan::New<v8::Integer>(static_cast<int32_t>(count));
+  info.GetReturnValue().Set(result);
+}
+
+NAN_METHOD(CountSubscribers) {
+  RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(info[0]->ToObject());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  std::string topic_name = *Nan::Utf8String(info[1]->ToString());
+
+  size_t count = 0;
+  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
+                           rcl_count_subscribers(
+                               node, topic_name.c_str(), &count),
+                           "Failed to count subscribers.");
+
+  v8::Local<v8::Integer> result
+    = Nan::New<v8::Integer>(static_cast<int32_t>(count));
+  info.GetReturnValue().Set(result);
+}
+
 NAN_METHOD(ServiceServerIsAvailable) {
   RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(info[0]->ToObject());
   rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
@@ -1342,6 +1374,8 @@ BindingMethod binding_methods[] = {
     {"getTopicNamesAndTypes", GetTopicNamesAndTypes},
     {"getServiceNamesAndTypes", GetServiceNamesAndTypes},
     {"getNodeNames", GetNodeNames},
+    {"countPublishers", CountPublishers},
+    {"countSubscribers", CountSubscribers},
     {"serviceServerIsAvailable", ServiceServerIsAvailable},
     {"", nullptr}};
 

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -315,6 +315,26 @@ describe('rcl node methods testing', function() {
     assert.ok(currentNode);
     assert.strictEqual(currentNode.namespace, '/my_ns');
   });
+
+  it('node.countPublishers', function() {
+    assert.strictEqual(node.countPublishers('chatter'), 0);
+
+    node.createPublisher(RclString, 'chatter');
+    assert.strictEqual(node.countPublishers('chatter'), 1);
+
+    node.createPublisher(RclString, 'chatter');
+    assert.strictEqual(node.countPublishers('chatter'), 2);
+  });
+
+  it('node.countSubscribers', function() {
+    assert.strictEqual(node.countSubscribers('chatter'), 0);
+
+    node.createSubscription(RclString, 'chatter', () => {});
+    assert.strictEqual(node.countSubscribers('chatter'), 1);
+
+    node.createSubscription(RclString, 'chatter', () => {});
+    assert.strictEqual(node.countSubscribers('chatter'), 2);
+  });
 });
 
 describe('topic & serviceName getter/setter', function() {

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -58,6 +58,12 @@ node.getTopicNamesAndTypes();
 // $ExpectType NodeNamesQueryResult[]
 node.getNodeNames();
 
+// $ExpectType number
+node.countPublishers(TOPIC);
+
+// $ExpectType number
+node.countSubscribers(TOPIC);
+
 
 // ---- Publisher ----
 // $ExpectType Publisher

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -337,7 +337,20 @@ declare module 'rclnodejs' {
 		 *        ]
 		 */
     getNodeNames(): Array<NodeNamesQueryResult>;
-		
+    
+    /**
+     * Return the number of publishers on a given topic.
+     * @param topic - The name of the topic.
+     * @returns Number of publishers on the given topic.
+     */
+    countPublishers(topic: string): number;
+
+    /**
+     * Return the number of subscribers on a given topic.
+     * @param topic - The name of the topic.
+     * @returns Number of subscribers on the given topic.
+     */
+    countSubscribers(topic: string): number;
   }
 
 


### PR DESCRIPTION
Adds countPublishers and countSubscribers which was missing from the Node class. rclpy implementation can be found [here](https://github.com/ros2/rclpy/blob/196669e539dd51bc56f9f4fdf6f0222d99480d0d/rclpy/rclpy/node.py#L1517) for comparison.

Fix #None