### PR TITLE
Add support for guard conditions

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,7 @@ let rcl = {
     node.init(nodeName, namespace);
     debug('Finish initializing node, name = %s and namespace = %s.', nodeName, namespace);
     node.handle = handle;
+    node.context = context;
     this._nodes.push(node);
     return node;
   },

--- a/lib/guard_condition.js
+++ b/lib/guard_condition.js
@@ -1,0 +1,50 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const rclnodejs = require('bindings')('rclnodejs');
+const Entity = require('./entity.js');
+const Context = require('./context.js');
+
+/**
+ * @class - Class representing a guard condition in ROS
+ * @hideconstructor
+ */
+
+class GuardCondition extends Entity {
+  constructor(handle, callback) {
+    super(handle, null, null);
+
+    this._callback = callback;
+
+    // True when the executor sees this has been triggered but has not yet been handled
+    this._executorTriggered = false;
+  }
+
+  get callback() {
+    return this._callback;
+  }
+
+  static createGuardCondition(callback, context = Context.defaultContext()) {
+    let handle = rclnodejs.createGuardCondition(context.handle());
+    return new GuardCondition(handle, callback);
+  }
+
+  trigger() {
+    rclnodejs.triggerGuardCondition(this.handle);
+  }
+}
+
+module.exports = GuardCondition;

--- a/lib/guard_condition.js
+++ b/lib/guard_condition.js
@@ -1,5 +1,3 @@
-// Copyright (c) 2017 Intel Corporation. All rights reserved.
-//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -28,9 +26,6 @@ class GuardCondition extends Entity {
     super(handle, null, null);
 
     this._callback = callback;
-
-    // True when the executor sees this has been triggered but has not yet been handled
-    this._executorTriggered = false;
   }
 
   get callback() {
@@ -42,6 +37,10 @@ class GuardCondition extends Entity {
     return new GuardCondition(handle, callback);
   }
 
+  /**
+   * Triggers the guard condition.
+   * @returns {undefined}
+   */
   trigger() {
     rclnodejs.triggerGuardCondition(this.handle);
   }

--- a/lib/node.js
+++ b/lib/node.js
@@ -57,16 +57,6 @@ class Node {
     let clientsReady = this._clients.filter((client) => handles.indexOf(client.handle) !== -1);
     let servicesReady = this._services.filter((service) => handles.indexOf(service.handle) !== -1);
 
-    // Retrigger a guard condition that was triggered but not handled
-    this._guards.forEach((guard) => {
-      if (guard._executorTriggered) {
-        guard.trigger();
-      }
-    });
-
-    // Mark all guards as triggered before processing any handlers since they're auto-taken
-    guardsReady.forEach((guard) => guard._executorTriggered = true);
-
     timersReady.forEach((timer) => {
       if (timer.isReady()) {
         rclnodejs.callTimer(timer.handle);
@@ -85,10 +75,7 @@ class Node {
     });
 
     guardsReady.forEach((guard) => {
-      if (guard._executorTriggered) {
-        guard._executorTriggered = false;
-        guard.callback();
-      }
+      guard.callback();
     });
 
     clientsReady.forEach((client) => {

--- a/lib/node.js
+++ b/lib/node.js
@@ -24,6 +24,7 @@ const QoS = require('./qos.js');
 const debug = require('debug')('rclnodejs:node');
 const loader = require('./interface_loader.js');
 const Context = require('./context.js');
+const GuardCondition = require('./guard_condition.js');
 /**
  * @class - Class representing a Node in ROS
  * @hideconstructor
@@ -36,6 +37,7 @@ class Node {
     this._clients = [];
     this._services = [];
     this._timers = [];
+    this._guards = [];
     this._name = name;
 
     if (namespace.length === 0) {
@@ -47,15 +49,32 @@ class Node {
     this.spinning = false;
   }
 
-  execute() {
-    this._timers.forEach((timer) => {
+  execute(handles) {
+    let timersReady = this._timers.filter((timer) => handles.indexOf(timer.handle) !== -1);
+    let guardsReady = this._guards.filter((guard) => handles.indexOf(guard.handle) !== -1);
+    let subscriptionsReady = this._subscriptions.filter((subscription) =>
+      handles.indexOf(subscription.handle) !== -1);
+    let clientsReady = this._clients.filter((client) => handles.indexOf(client.handle) !== -1);
+    let servicesReady = this._services.filter((service) => handles.indexOf(service.handle) !== -1);
+
+    // Retrigger a guard condition that was triggered but not handled
+    this._guards.forEach((guard) => {
+      if (guard._executorTriggered) {
+        guard.trigger();
+      }
+    });
+
+    // Mark all guards as triggered before processing any handlers since they're auto-taken
+    guardsReady.forEach((guard) => guard._executorTriggered = true);
+
+    timersReady.forEach((timer) => {
       if (timer.isReady()) {
         rclnodejs.callTimer(timer.handle);
         timer.callback();
       }
     });
 
-    this._subscriptions.forEach((subscription) => {
+    subscriptionsReady.forEach((subscription) => {
       let Message = subscription.typeClass;
       let msg = new Message();
       let success = rclnodejs.rclTake(subscription.handle, msg.toRawROS());
@@ -65,7 +84,14 @@ class Node {
       Message.destoryRawROS(msg);
     });
 
-    this._clients.forEach((client) => {
+    guardsReady.forEach((guard) => {
+      if (guard._executorTriggered) {
+        guard._executorTriggered = false;
+        guard.callback();
+      }
+    });
+
+    clientsReady.forEach((client) => {
       let Response = client.typeClass.Response;
       let response = new Response();
       let success = rclnodejs.rclTakeResponse(client.handle, client.sequenceNumber, response.toRawROS());
@@ -75,7 +101,7 @@ class Node {
       Response.destoryRawROS(response);
     });
 
-    this._services.forEach((service) => {
+    servicesReady.forEach((service) => {
       let Request = service.typeClass.Request;
       let request = new Request();
       let header = rclnodejs.rclTakeRequest(service.handle, this.handle, request.toRawROS());
@@ -314,6 +340,24 @@ class Node {
   }
 
   /**
+   * Create a guard condition.
+   * @param {Function} callback - The callback to be called when the guard condition is triggered.
+   * @return {GuardCondition} - An instance of GuardCondition.
+   */
+  createGuardCondition(callback) {
+    if (typeof (callback) !== 'function') {
+      throw new TypeError('Invalid argument');
+    }
+
+    let guard = GuardCondition.createGuardCondition(callback, this.context);
+    debug('Finish creating guard condition');
+    this._guards.push(guard);
+    this.syncHandles();
+
+    return guard;
+  }
+
+  /**
    * Destroy all resource allocated by this node, including
    * <code>Timer</code>s/<code>Publisher</code>s/<code>Subscription</code>s
    * /<code>Client</code>s/<code>Service</code>s
@@ -330,6 +374,7 @@ class Node {
     this._subscriptions = [];
     this._clients = [];
     this._services = [];
+    this._guards = [];
   }
 
   /**
@@ -390,6 +435,18 @@ class Node {
       throw new TypeError('Invalid argument');
     }
     this._destroyEntity(timer, this._timers);
+  }
+
+  /**
+   * Destroy a guard condition.
+   * @param {GuardCondition} guard - The guard condition to be destroyed.
+   * @return {undefined}
+   */
+  destroyGuardCondition(guard) {
+    if (!(guard instanceof GuardCondition)) {
+      throw new TypeError('Invalid argument');
+    }
+    this._destroyEntity(guard, this._guards);
   }
 
   /* Get the name of the node.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dtslint": "^2.0.2",
     "eslint": "^5.14.1",
     "mocha": "^6.0.1",
+    "sinon": "^8.1.1",
     "tree-kill": "^1.2.1",
     "typescript": "^3.7.2"
   },

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -118,7 +118,7 @@ void Executor::Run(void* arg) {
           continue;
 
         if (rcl_wait_set_resize(&wait_set, handle_manager->subscription_count(),
-                                handle_manager->guard_contition_count() + 1u,
+                                handle_manager->guard_condition_count() + 1u,
                                 handle_manager->timer_count(),
                                 handle_manager->client_count(),
                                 handle_manager->service_count(),

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -89,7 +89,7 @@ void Executor::DoWork(uv_async_t* handle) {
       g_exception_ptr = nullptr;
     }
     executor->delegate_->Execute(
-        executor->handle_manager_->get_filtered_handles());
+        executor->handle_manager_->get_ready_handles());
   }
 }
 
@@ -149,7 +149,7 @@ void Executor::Run(void* arg) {
             executor->running_.store(false);
           }
 
-          handle_manager->FilterHandles(&wait_set);
+          handle_manager->CollectReadyHandles(&wait_set);
 
           if (!uv_is_closing(
                   reinterpret_cast<uv_handle_t*>(executor->async_))) {

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -88,7 +88,8 @@ void Executor::DoWork(uv_async_t* handle) {
       rcl_reset_error();
       g_exception_ptr = nullptr;
     }
-    executor->delegate_->Execute();
+    executor->delegate_->Execute(
+        executor->handle_manager_->get_filtered_handles());
   }
 }
 
@@ -117,8 +118,8 @@ void Executor::Run(void* arg) {
           continue;
 
         if (rcl_wait_set_resize(&wait_set, handle_manager->subscription_count(),
-                                // TODO(minggang): support guard conditions
-                                1u, handle_manager->timer_count(),
+                                handle_manager->guard_contition_count() + 1u,
+                                handle_manager->timer_count(),
                                 handle_manager->client_count(),
                                 handle_manager->service_count(),
                                 // TODO(minggang): support events.
@@ -147,6 +148,9 @@ void Executor::Run(void* arg) {
               wait_set.guard_conditions[0]) {
             executor->running_.store(false);
           }
+
+          handle_manager->FilterHandles(&wait_set);
+
           if (!uv_is_closing(
                   reinterpret_cast<uv_handle_t*>(executor->async_))) {
             uv_async_send(executor->async_);

--- a/src/executor.hpp
+++ b/src/executor.hpp
@@ -19,6 +19,9 @@
 
 #include <atomic>
 #include <exception>
+#include <vector>
+
+#include "rcl_handle.hpp"
 
 struct rcl_context_t;
 
@@ -30,7 +33,8 @@ class Executor {
  public:
   class Delegate {
    public:
-    virtual void Execute() = 0;
+    virtual void Execute(
+        const std::vector<rclnodejs::RclHandle *> &handles) = 0;
     virtual void CatchException(std::exception_ptr e_ptr) = 0;
   };
 

--- a/src/executor.hpp
+++ b/src/executor.hpp
@@ -34,7 +34,7 @@ class Executor {
   class Delegate {
    public:
     virtual void Execute(
-        const std::vector<rclnodejs::RclHandle *> &handles) = 0;
+        const std::vector<rclnodejs::RclHandle *>& handles) = 0;
     virtual void CatchException(std::exception_ptr e_ptr) = 0;
   };
 

--- a/src/handle_manager.hpp
+++ b/src/handle_manager.hpp
@@ -41,7 +41,7 @@ class HandleManager {
 
   void CollectHandles(const v8::Local<v8::Object> node);
   bool AddHandlesToWaitSet(rcl_wait_set_t* wait_set);
-  void FilterHandles(rcl_wait_set_t* wait_set);
+  void CollectReadyHandles(rcl_wait_set_t* wait_set);
   void ClearHandles();
   void WaitForSynchronizing() { uv_sem_wait(&sem_); }
 
@@ -51,7 +51,7 @@ class HandleManager {
   uint32_t timer_count() const { return  timers_.size(); }
   uint32_t guard_contition_count() const { return guard_conditions_.size(); }
   std::vector<rclnodejs::RclHandle*>
-      get_filtered_handles() const { return filtered_handles_; }
+      get_ready_handles() const { return ready_handles_; }
   uv_mutex_t* mutex() { return &mutex_; }
   bool is_synchronizing() const { return is_synchronizing_.load(); }
   bool is_empty() const { return subscriptions_.size() == 0
@@ -63,6 +63,10 @@ class HandleManager {
  protected:
   void CollectHandlesByType(const v8::Local<v8::Object>& typeObject,
                             std::vector<rclnodejs::RclHandle*>* vec);
+  template<typename T> void CollectReadyHandlesByType(
+      const T** struct_ptr,
+      size_t size,
+      const std::vector<rclnodejs::RclHandle*>& handles);
 
  private:
   std::vector<rclnodejs::RclHandle*> timers_;
@@ -70,7 +74,7 @@ class HandleManager {
   std::vector<rclnodejs::RclHandle*> services_;
   std::vector<rclnodejs::RclHandle*> subscriptions_;
   std::vector<rclnodejs::RclHandle*> guard_conditions_;
-  std::vector<rclnodejs::RclHandle*> filtered_handles_;
+  std::vector<rclnodejs::RclHandle*> ready_handles_;
 
   uv_mutex_t mutex_;
   uv_sem_t sem_;

--- a/src/handle_manager.hpp
+++ b/src/handle_manager.hpp
@@ -49,7 +49,7 @@ class HandleManager {
   uint32_t service_count() const { return services_.size(); }
   uint32_t client_count() const { return clients_.size(); }
   uint32_t timer_count() const { return  timers_.size(); }
-  uint32_t guard_contition_count() const { return guard_conditions_.size(); }
+  uint32_t guard_condition_count() const { return guard_conditions_.size(); }
   std::vector<rclnodejs::RclHandle*>
       get_ready_handles() const { return ready_handles_; }
   uv_mutex_t* mutex() { return &mutex_; }

--- a/src/handle_manager.hpp
+++ b/src/handle_manager.hpp
@@ -21,6 +21,8 @@
 #include <atomic>
 #include <vector>
 
+#include "rcl_handle.hpp"
+
 namespace rclnodejs {
 
 class ScopedMutex {
@@ -39,6 +41,7 @@ class HandleManager {
 
   void CollectHandles(const v8::Local<v8::Object> node);
   bool AddHandlesToWaitSet(rcl_wait_set_t* wait_set);
+  void FilterHandles(rcl_wait_set_t* wait_set);
   void ClearHandles();
   void WaitForSynchronizing() { uv_sem_wait(&sem_); }
 
@@ -46,23 +49,28 @@ class HandleManager {
   uint32_t service_count() const { return services_.size(); }
   uint32_t client_count() const { return clients_.size(); }
   uint32_t timer_count() const { return  timers_.size(); }
+  uint32_t guard_contition_count() const { return guard_conditions_.size(); }
+  std::vector<rclnodejs::RclHandle*>
+      get_filtered_handles() const { return filtered_handles_; }
   uv_mutex_t* mutex() { return &mutex_; }
   bool is_synchronizing() const { return is_synchronizing_.load(); }
   bool is_empty() const { return subscriptions_.size() == 0
       && services_.size() == 0
       && clients_.size() == 0
-      && timers_.size() == 0; }
+      && timers_.size() == 0
+      && guard_conditions_.size() == 0; }
 
  protected:
-  template<typename T> void CollectHandlesByType(
-      const v8::Local<v8::Object>& typeObject, std::vector<const T*>* vec);
+  void CollectHandlesByType(const v8::Local<v8::Object>& typeObject,
+                            std::vector<rclnodejs::RclHandle*>* vec);
 
  private:
-  std::vector<const rcl_timer_t*> timers_;
-  std::vector<const rcl_client_t*> clients_;
-  std::vector<const rcl_service_t*> services_;
-  std::vector<const rcl_subscription_t*> subscriptions_;
-  std::vector<const rcl_guard_condition_t*> guard_conditions_;
+  std::vector<rclnodejs::RclHandle*> timers_;
+  std::vector<rclnodejs::RclHandle*> clients_;
+  std::vector<rclnodejs::RclHandle*> services_;
+  std::vector<rclnodejs::RclHandle*> subscriptions_;
+  std::vector<rclnodejs::RclHandle*> guard_conditions_;
+  std::vector<rclnodejs::RclHandle*> filtered_handles_;
 
   uv_mutex_t mutex_;
   uv_sem_t sem_;

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -104,6 +104,38 @@ NAN_METHOD(CreateNode) {
   info.GetReturnValue().Set(handle);
 }
 
+NAN_METHOD(CreateGuardCondition) {
+  RclHandle* context_handle = RclHandle::Unwrap<RclHandle>(info[0]->ToObject());
+  rcl_context_t* context =
+      reinterpret_cast<rcl_context_t*>(context_handle->ptr());
+
+  rcl_guard_condition_t* gc = reinterpret_cast<rcl_guard_condition_t*>(
+      malloc(sizeof(rcl_guard_condition_t)));
+
+  *gc = rcl_get_zero_initialized_guard_condition();
+  rcl_guard_condition_options_t gc_options =
+      rcl_guard_condition_get_default_options();
+
+  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
+                           rcl_guard_condition_init(gc, context, gc_options),
+                           rcl_get_error_string().str);
+
+  auto handle = RclHandle::NewInstance(gc, nullptr, [gc] {
+    return rcl_guard_condition_fini(gc);
+  });
+  info.GetReturnValue().Set(handle);
+}
+
+NAN_METHOD(TriggerGuardCondition) {
+  RclHandle* gc_handle = RclHandle::Unwrap<RclHandle>(info[0]->ToObject());
+  rcl_guard_condition_t* gc =
+      reinterpret_cast<rcl_guard_condition_t*>(gc_handle->ptr());
+
+  rcl_ret_t ret = rcl_trigger_guard_condition(gc);
+  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, rcl_trigger_guard_condition(gc),
+                           rcl_get_error_string().str);
+}
+
 NAN_METHOD(CreateTimer) {
   int64_t period_ms = info[0]->IntegerValue();
   RclHandle* context_handle = RclHandle::Unwrap<RclHandle>(info[1]->ToObject());
@@ -1289,6 +1321,8 @@ uint32_t GetBindingMethodsCount(BindingMethod* methods) {
 BindingMethod binding_methods[] = {
     {"init", Init},
     {"createNode", CreateNode},
+    {"createGuardCondition", CreateGuardCondition},
+    {"triggerGuardCondition", TriggerGuardCondition},
     {"createTimer", CreateTimer},
     {"isTimerReady", IsTimerReady},
     {"callTimer", CallTimer},

--- a/src/shadow_node.cpp
+++ b/src/shadow_node.cpp
@@ -109,7 +109,7 @@ NAN_METHOD(ShadowNode::SyncHandles) {
   }
 }
 
-void ShadowNode::Execute(const std::vector<rclnodejs::RclHandle*> &handles) {
+void ShadowNode::Execute(const std::vector<rclnodejs::RclHandle*>& handles) {
   Nan::HandleScope scope;
   Nan::AsyncResource res("shadow_node");
 

--- a/src/shadow_node.cpp
+++ b/src/shadow_node.cpp
@@ -15,6 +15,7 @@
 #include "shadow_node.hpp"
 
 #include <memory>
+#include <vector>
 
 #include "executor.hpp"
 #include "handle_manager.hpp"
@@ -108,11 +109,18 @@ NAN_METHOD(ShadowNode::SyncHandles) {
   }
 }
 
-void ShadowNode::Execute() {
+void ShadowNode::Execute(const std::vector<rclnodejs::RclHandle*> &handles) {
   Nan::HandleScope scope;
-  v8::Local<v8::Value> argv[1];
   Nan::AsyncResource res("shadow_node");
-  res.runInAsyncScope(Nan::New(this->persistent()), "execute", 0, argv);
+
+  v8::Local<v8::Array> results = Nan::New<v8::Array>(handles.size());
+  for (size_t i = 0; i < handles.size(); ++i) {
+    Nan::Set(results, i, handles[i]->handle());
+  }
+
+  v8::Local<v8::Value> argv[] = { results };
+
+  res.runInAsyncScope(Nan::New(this->persistent()), "execute", 1, argv);
 }
 
 void ShadowNode::CatchException(std::exception_ptr e_ptr) {

--- a/src/shadow_node.hpp
+++ b/src/shadow_node.hpp
@@ -39,7 +39,7 @@ class ShadowNode : public Nan::ObjectWrap,
   HandleManager* handle_manager() { return handle_manager_.get(); }
 
   // Executor::Delegate overrides:
-  void Execute(const std::vector<rclnodejs::RclHandle*> &handles) override;
+  void Execute(const std::vector<rclnodejs::RclHandle*>& handles) override;
   void CatchException(std::exception_ptr e_ptr) override;
 
  private:

--- a/src/shadow_node.hpp
+++ b/src/shadow_node.hpp
@@ -19,6 +19,7 @@
 
 #include <exception>
 #include <memory>
+#include <vector>
 
 #include "executor.hpp"
 
@@ -38,7 +39,7 @@ class ShadowNode : public Nan::ObjectWrap,
   HandleManager* handle_manager() { return handle_manager_.get(); }
 
   // Executor::Delegate overrides:
-  void Execute() override;
+  void Execute(const std::vector<rclnodejs::RclHandle*> &handles) override;
   void CatchException(std::exception_ptr e_ptr) override;
 
  private:

--- a/test/test-guard-condition.js
+++ b/test/test-guard-condition.js
@@ -1,0 +1,96 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const rclnodejs = require('../index.js');
+const utils = require('./utils.js');
+
+describe('rclnodejs guard condition test suite', function() {
+  var node;
+  var timeout = 10;
+  this.timeout(60 * 1000);
+
+  before(function() {
+    return rclnodejs.init();
+  });
+
+  after(function() {
+    rclnodejs.shutdown();
+  });
+
+  beforeEach(function() {
+    node = rclnodejs.createNode('guard_node');
+    rclnodejs.spin(node, timeout);
+  });
+
+  afterEach(function() {
+    node.destroy();
+  });
+
+  it('Test trigger', async function() {
+    let called = false;
+
+    function func() {
+      called = true;
+    }
+
+    const gc = node.createGuardCondition(func);
+
+    await utils.delay(timeout);
+    assert.strictEqual(called, false);
+
+    gc.trigger();
+    await utils.delay(timeout);
+    assert.strictEqual(called, true);
+
+    node.destroyGuardCondition(gc);
+  });
+
+  it('Test double trigger', async function() {
+    let called1 = false;
+    let called2 = false;
+
+    function func1() {
+      called1 = true;
+    }
+
+    function func2() {
+      called2 = true;
+    }
+
+    const gc1 = node.createGuardCondition(func1);
+    const gc2 = node.createGuardCondition(func2);
+
+    await utils.delay(timeout);
+    assert.strictEqual(called1, false);
+    assert.strictEqual(called2, false);
+
+    gc1.trigger();
+    gc2.trigger();
+    await utils.delay(timeout);
+    assert.strictEqual(called1, true);
+    assert.strictEqual(called2, true);
+
+    called1 = false;
+    called2 = false;
+    await utils.delay(timeout);
+    assert.strictEqual(called1, false);
+    assert.strictEqual(called2, false);
+
+    node.destroyGuardCondition(gc1);
+    node.destroyGuardCondition(gc2);
+  });
+});

--- a/test/test-guard-condition.js
+++ b/test/test-guard-condition.js
@@ -44,11 +44,11 @@ describe('rclnodejs guard condition test suite', function() {
 
     const gc = node.createGuardCondition(callback);
 
-    await utils.delay(timeout);
+    await utils.delay(timeout + 1);
     assert(callback.notCalled);
 
     gc.trigger();
-    await utils.delay(timeout);
+    await utils.delay(timeout + 1);
     assert(callback.calledOnce);
 
     node.destroyGuardCondition(gc);
@@ -61,17 +61,17 @@ describe('rclnodejs guard condition test suite', function() {
     const gc1 = node.createGuardCondition(callback1);
     const gc2 = node.createGuardCondition(callback2);
 
-    await utils.delay(timeout);
+    await utils.delay(timeout + 1);
     assert(callback1.notCalled);
     assert(callback2.notCalled);
 
     gc1.trigger();
     gc2.trigger();
-    await utils.delay(timeout);
+    await utils.delay(timeout + 1);
     assert(callback1.calledOnce);
     assert(callback2.calledOnce);
 
-    await utils.delay(timeout);
+    await utils.delay(timeout + 1);
     assert(callback1.calledOnce);
     assert(callback2.calledOnce);
 

--- a/test/test-guard-condition.js
+++ b/test/test-guard-condition.js
@@ -1,5 +1,3 @@
-// Copyright (c) 2017 Intel Corporation. All rights reserved.
-//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,6 +13,7 @@
 'use strict';
 
 const assert = require('assert');
+const sinon = require('sinon');
 const rclnodejs = require('../index.js');
 const utils = require('./utils.js');
 
@@ -41,54 +40,40 @@ describe('rclnodejs guard condition test suite', function() {
   });
 
   it('Test trigger', async function() {
-    let called = false;
+    let callback = sinon.spy();
 
-    function func() {
-      called = true;
-    }
-
-    const gc = node.createGuardCondition(func);
+    const gc = node.createGuardCondition(callback);
 
     await utils.delay(timeout);
-    assert.strictEqual(called, false);
+    assert(callback.notCalled);
 
     gc.trigger();
     await utils.delay(timeout);
-    assert.strictEqual(called, true);
+    assert(callback.calledOnce);
 
     node.destroyGuardCondition(gc);
   });
 
   it('Test double trigger', async function() {
-    let called1 = false;
-    let called2 = false;
+    let callback1 = sinon.spy();
+    let callback2 = sinon.spy();
 
-    function func1() {
-      called1 = true;
-    }
-
-    function func2() {
-      called2 = true;
-    }
-
-    const gc1 = node.createGuardCondition(func1);
-    const gc2 = node.createGuardCondition(func2);
+    const gc1 = node.createGuardCondition(callback1);
+    const gc2 = node.createGuardCondition(callback2);
 
     await utils.delay(timeout);
-    assert.strictEqual(called1, false);
-    assert.strictEqual(called2, false);
+    assert(callback1.notCalled);
+    assert(callback2.notCalled);
 
     gc1.trigger();
     gc2.trigger();
     await utils.delay(timeout);
-    assert.strictEqual(called1, true);
-    assert.strictEqual(called2, true);
+    assert(callback1.calledOnce);
+    assert(callback2.calledOnce);
 
-    called1 = false;
-    called2 = false;
     await utils.delay(timeout);
-    assert.strictEqual(called1, false);
-    assert.strictEqual(called2, false);
+    assert(callback1.calledOnce);
+    assert(callback2.calledOnce);
 
     node.destroyGuardCondition(gc1);
     node.destroyGuardCondition(gc2);

--- a/test/utils.js
+++ b/test/utils.js
@@ -74,9 +74,14 @@ function getAvailablePath(amentPrefixPath, otherDirs) {
   return availablePath;
 }
 
+function delay(ms) {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
 module.exports = {
   assertMember: assertMember,
   assertThrowsError: assertThrowsError,
   launchPythonProcess: launchPythonProcess,
-  getAvailablePath: getAvailablePath
+  getAvailablePath: getAvailablePath,
+  delay: delay
 };

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -5,6 +5,7 @@
 /// <reference path="context.d.ts" />
 /// <reference path="duration.d.ts" />
 /// <reference path="entity.d.ts" />
+/// <reference path="guard_condition.d.ts" />
 /// <reference path="interfaces.d.ts" />
 /// <reference path="logging.d.ts" />
 /// <reference path="node.d.ts" />

--- a/types/guard_condition.d.ts
+++ b/types/guard_condition.d.ts
@@ -1,0 +1,17 @@
+
+declare module 'rclnodejs' {
+
+  /**
+   * A ROS guard condition containing a callback executed when the
+   * guard condition is triggered.
+   */
+  class GuardCondition extends Entity {
+
+    /**
+     * Triggers the guard condition.
+     */
+    trigger(): void;
+
+  }
+
+}

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -214,7 +214,15 @@ declare module 'rclnodejs' {
 		 * @returns An instance of Service.
 		 */
     createService(typeClass: TypeClass, serviceName: string,
-      options: Options, callback: ServiceRequestCallback): Service;
+			options: Options, callback: ServiceRequestCallback): Service;
+
+    /**
+		 * Create a guard condition.
+		 * 
+		 * @param callback - The callback to be called when the guard condition is triggered.
+		 * @return An instance of GuardCondition.
+		 */
+    createGuardCondition(callback: () => any): GuardCondition;
 
 
     /**


### PR DESCRIPTION
Implements guard conditions in rclnodejs. In addition, now only entities that are ready to be handled will be executed. This was initially needed since guard conditions should only run when triggered, but was extended to all entities. The approach taken was passing all RclHandles that are ready to be executed back to the main process.

All changes to the .cpp files should be carefully reviewed for quality, thread safety, and alignment with future needs. There's a lot of looping occurring now, but this is not much different than the  rclpy implementation.

Fix #315