### PR TITLE
Add getNodeNamesAndNamespaces to Node

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -501,9 +501,17 @@ class Node {
 
   /**
    * Get the list of nodes discovered by the provided node.
-   * @return {array} - An array of the names and namespaces.
+   * @return {array} - An array of the names.
    */
   getNodeNames() {
+    return this.getNodeNamesAndNamespaces().map(item => item.name);
+  }
+
+  /**
+   * Get the list of nodes and their namespaces discovered by the provided node.
+   * @return {array} - An array of the names and namespaces.
+   */
+  getNodeNamesAndNamespaces() {
     return rclnodejs.getNodeNames(this.handle);
   }
 

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -308,6 +308,14 @@ describe('rcl node methods testing', function() {
   it('node.getNodeNames', function() {
     var nodeNames = node.getNodeNames();
 
+    var currentNode = nodeNames.indexOf('my_node');
+
+    assert.notStrictEqual(currentNode, -1);
+  });
+
+  it('node.getNodeNamesAndNamespaces', function() {
+    var nodeNames = node.getNodeNamesAndNamespaces();
+
     var currentNode = nodeNames.find(function(nodeName) {
       return nodeName.name === 'my_node';
     });

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -55,8 +55,11 @@ node.getSubscriptionNamesAndTypesByNode(NODE_NAME);
 // $ExpectType NamesAndTypesQueryResult[]
 node.getTopicNamesAndTypes();
 
-// $ExpectType NodeNamesQueryResult[]
+// $ExpectType string[]
 node.getNodeNames();
+
+// $ExpectType NodeNamesQueryResult[]
+node.getNodeNamesAndNamespaces();
 
 // $ExpectType number
 node.countPublishers(TOPIC);

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -337,15 +337,22 @@ declare module 'rclnodejs' {
     /**
 		 * Get the list of nodes discovered by the provided node.
 		 * 
-		 * @returns An array of the names and namespaces.
-		 *        [ 
-		 *          { name: 'gazebo',                namespace: '/' },
-		 *          { name: 'robot_state_publisher', namespace: '/' },
-		 *          { name: 'cam2image',             namespace: '/demo' }
-		 *        ]
+		 * @returns An array of the node names.
 		 */
-    getNodeNames(): Array<NodeNamesQueryResult>;
-    
+    getNodeNames(): string[];
+
+    /**
+     * Get the list of nodes and their namespaces discovered by the provided node.
+     * 
+     * @returns An array of the node names and namespaces.
+     *        [ 
+     *          { name: 'gazebo',                namespace: '/' },
+     *          { name: 'robot_state_publisher', namespace: '/' },
+     *          { name: 'cam2image',             namespace: '/demo' }
+     *        ]
+     */
+    getNodeNamesAndNamespaces(): Array<NodeNamesQueryResult>;
+
     /**
      * Return the number of publishers on a given topic.
      * @param topic - The name of the topic.


### PR DESCRIPTION
Fix getNodeNames return type and adds getNodeNamesAndNamespaces to align with the interface of Node in rclpy more closely.

This should go in before 0.12 release, as it would otherwise be a breaking change to the Node interface.

Fix #None