### PR TITLE
Change the ROS2 packaging used for CIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,16 +18,18 @@ jobs:
         # fallback to using the latest cache if no exact match is found
         - v1-dependencies-
     - run: brew update
-    - run: brew install wget cmake cppcheck tinyxml tinyxml2 eigen pcre poco
+    - run: brew install wget cmake cppcheck tinyxml tinyxml2 eigen pcre
+    # Pin poco to 1.9.4
+    - run: brew install https://raw.githubusercontent.com/alebcay/homebrew-core/055f2f99de581160b142c3ccad392766e7b99d28/Formula/poco.rb
     - run: brew install openssl
     - run: brew install asio console_bridge
     - run: python3 -m pip install catkin_pkg empy git+https://github.com/lark-parser/lark.git@0.7d pyparsing pyyaml setuptools argcomplete colcon-common-extensions numpy
-    - run: mkdir -p ~/ros2_install && cd ~/ros2_install && wget https://ci.ros2.org/view/packaging/job/packaging_osx/lastStableBuild/artifact/ws/ros2-package-osx-x86_64.tar.bz2 && tar xf ros2-package-osx-x86_64.tar.bz2
-    - run: wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+    - run: mkdir -p ~/ros2_install && cd ~/ros2_install && wget https://ci.ros2.org/view/packaging/job/packaging_osx/lastSuccessfulBuild/artifact/ws/ros2-package-osx-x86_64.tar.bz2 && tar xf ros2-package-osx-x86_64.tar.bz2
+    - run: wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
     - run: echo "source $HOME/.bashrc" >> ~/.bash_profile
     - run: cat ~/.bash_profile
-    - run: nvm install v10.16.1
-    - run: nvm alias default v10.16.1
+    - run: nvm install v10.19.0
+    - run: nvm alias default v10.19.0
     - run: node --version && npm --version && rm -rf ./node_modules/
     - run: source ~/ros2_install/ros2-osx/local_setup.bash && git submodule init && git submodule update && npm install --python=python2.7
     - run: export PATH="/usr/local/opt/python@2/libexec/bin:$PATH" && npm run lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN git config --global user.name $GIT_USER_NAME \
 ENV ROS2_WS=/root
 WORKDIR $ROS2_WS
 
-RUN wget https://ci.ros2.org/view/packaging/job/packaging_linux/lastStableBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2 \
+RUN wget https://ci.ros2.org/view/packaging/job/packaging_linux/lastSuccessfulBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2 \
     && tar xf ros2-package-linux-x86_64.tar.bz2
 
 # [Ubuntu 18.04]
@@ -41,8 +41,8 @@ RUN rosdep install --from-paths $ROS2_WS/ros2-linux/share --ignore-src --rosdist
 RUN echo "source $ROS2_WS/ros2-linux/local_setup.bash" >> $HOME/.bashrc
 
 # Install nvm, Node.js and node-gyp
-ENV NODE_VERSION v10.16.1
-RUN wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash \
+ENV NODE_VERSION v10.19.0
+RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash \
     && . $HOME/.nvm/nvm.sh \
     && nvm install $NODE_VERSION && nvm alias default $NODE_VERSION
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ before_build:
   - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2019-10-24/tinyxml2.6.0.0.nupkg
   - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2019-10-24/log4cxx.0.10.0.nupkg
   - choco install -y -s c:\download\ asio cunit eigen tinyxml-usestl tinyxml2 log4cxx
-  - appveyor DownloadFile http://ci.ros2.org/view/packaging/job/packaging_windows/lastStableBuild/artifact/ws/ros2-package-windows-AMD64.zip
+  - appveyor DownloadFile https://ci.ros2.org/view/packaging/job/packaging_windows/lastSuccessfulBuild/artifact/ws/ros2-package-windows-AMD64.zip
   - 7z x -y "c:\download\ros2-package-windows-AMD64.zip" -o"c:\" > nul
   - setx -m OPENSSL_CONF C:\OpenSSL-Win64\bin\openssl.cfg
   - set PATH=C:\OpenSSL-Win64\bin;%PATH%


### PR DESCRIPTION
Currently, the ROS2 package (last stable) used on macOS fails consistently
and those packages were built several months ago.

This patch changes to the last successful ones which can reflect the
ROS2 changes in time.

Fix #None