### PR TITLE
Add actions to the event loop

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -38,6 +38,7 @@
       ],
       'libraries': [
         '-lrcl',
+        '-lrcl_action',
         '-lrcutils',
         '-lrmw',
         '-lrosidl_generator_c',

--- a/lib/node.js
+++ b/lib/node.js
@@ -38,6 +38,8 @@ class Node {
     this._services = [];
     this._timers = [];
     this._guards = [];
+    this._actionClients = [];
+    this._actionServers = [];
     this._name = name;
 
     if (namespace.length === 0) {
@@ -362,6 +364,8 @@ class Node {
     this._clients = [];
     this._services = [];
     this._guards = [];
+    this._actionClients = [];
+    this._actionServers = [];
   }
 
   /**

--- a/src/handle_manager.cpp
+++ b/src/handle_manager.cpp
@@ -290,13 +290,14 @@ bool HandleManager::CollectReadyActionHandles(rcl_wait_set_t* wait_set) {
       return false;
     }
 
-    action_client->SetProperty("isFeedbackReady", is_feedback_ready);
-    action_client->SetProperty("isStatusReady", is_status_ready);
-    action_client->SetProperty("isGoalResponseReady", is_goal_response_ready);
-    action_client->SetProperty("isCancelResponseReady",
-                               is_cancel_response_ready);
-    action_client->SetProperty("isResultResponseReady",
-                               is_result_response_ready);
+    action_client->SetBoolProperty("isFeedbackReady", is_feedback_ready);
+    action_client->SetBoolProperty("isStatusReady", is_status_ready);
+    action_client->SetBoolProperty("isGoalResponseReady",
+                                   is_goal_response_ready);
+    action_client->SetBoolProperty("isCancelResponseReady",
+                                   is_cancel_response_ready);
+    action_client->SetBoolProperty("isResultResponseReady",
+                                   is_result_response_ready);
 
     if (is_feedback_ready || is_status_ready || is_goal_response_ready ||
         is_cancel_response_ready || is_result_response_ready) {
@@ -323,10 +324,12 @@ bool HandleManager::CollectReadyActionHandles(rcl_wait_set_t* wait_set) {
       return false;
     }
 
-    action_server->SetProperty("isGoalRequestReady", is_goal_request_ready);
-    action_server->SetProperty("isCancelRequestReady", is_cancel_request_ready);
-    action_server->SetProperty("isResultRequestReady", is_result_request_ready);
-    action_server->SetProperty("isGoalExpired", is_goal_expired);
+    action_server->SetBoolProperty("isGoalRequestReady", is_goal_request_ready);
+    action_server->SetBoolProperty("isCancelRequestReady",
+                                   is_cancel_request_ready);
+    action_server->SetBoolProperty("isResultRequestReady",
+                                   is_result_request_ready);
+    action_server->SetBoolProperty("isGoalExpired", is_goal_expired);
 
     if (is_goal_request_ready || is_cancel_request_ready ||
         is_result_request_ready || is_goal_expired) {

--- a/src/handle_manager.cpp
+++ b/src/handle_manager.cpp
@@ -14,8 +14,8 @@
 
 #include "handle_manager.hpp"
 
-#include <vector>
 #include <rcl_action/rcl_action.h>
+#include <vector>
 
 #include "spdlog/spdlog.h"
 
@@ -153,7 +153,7 @@ bool HandleManager::CollectReadyHandles(rcl_wait_set_t* wait_set) {
     wait_set->guard_conditions,
     wait_set->size_of_guard_conditions,
     guard_conditions_);
-  
+
   return CollectReadyActionHandles(wait_set);
 }
 

--- a/src/handle_manager.hpp
+++ b/src/handle_manager.hpp
@@ -41,9 +41,15 @@ class HandleManager {
 
   void CollectHandles(const v8::Local<v8::Object> node);
   bool AddHandlesToWaitSet(rcl_wait_set_t* wait_set);
-  void CollectReadyHandles(rcl_wait_set_t* wait_set);
+  bool CollectReadyHandles(rcl_wait_set_t* wait_set);
   void ClearHandles();
   void WaitForSynchronizing() { uv_sem_wait(&sem_); }
+  bool GetEntityCounts(
+      size_t *subscriptions_size,
+      size_t *guard_conditions_size,
+      size_t *timers_size,
+      size_t *clients_size,
+      size_t *services_size);
 
   uint32_t subscription_count() const { return subscriptions_.size(); }
   uint32_t service_count() const { return services_.size(); }
@@ -58,7 +64,9 @@ class HandleManager {
       && services_.size() == 0
       && clients_.size() == 0
       && timers_.size() == 0
-      && guard_conditions_.size() == 0; }
+      && guard_conditions_.size() == 0
+      && action_clients_.size() == 0
+      && action_servers_.size() == 0; }
 
  protected:
   void CollectHandlesByType(const v8::Local<v8::Object>& typeObject,
@@ -67,6 +75,7 @@ class HandleManager {
       const T** struct_ptr,
       size_t size,
       const std::vector<rclnodejs::RclHandle*>& handles);
+  bool CollectReadyActionHandles(rcl_wait_set_t* wait_set);
 
  private:
   std::vector<rclnodejs::RclHandle*> timers_;
@@ -74,6 +83,8 @@ class HandleManager {
   std::vector<rclnodejs::RclHandle*> services_;
   std::vector<rclnodejs::RclHandle*> subscriptions_;
   std::vector<rclnodejs::RclHandle*> guard_conditions_;
+  std::vector<rclnodejs::RclHandle*> action_servers_;
+  std::vector<rclnodejs::RclHandle*> action_clients_;
   std::vector<rclnodejs::RclHandle*> ready_handles_;
 
   uv_mutex_t mutex_;

--- a/src/rcl_handle.cpp
+++ b/src/rcl_handle.cpp
@@ -54,7 +54,7 @@ void RclHandle::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
 void RclHandle::SyncProperties() {
   auto obj = v8::Object::New(v8::Isolate::GetCurrent());
 
-  for (auto& it = properties_.begin(); it != properties_.end(); it++) {
+  for (auto it = properties_.begin(); it != properties_.end(); it++) {
     obj->Set(Nan::New(it->first).ToLocalChecked(), Nan::New(it->second));
   }
 

--- a/src/rcl_handle.cpp
+++ b/src/rcl_handle.cpp
@@ -33,6 +33,9 @@ void RclHandle::Init(v8::Local<v8::Object> exports) {
   tpl->SetClassName(Nan::New("RclHandle").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
+  Nan::SetAccessor(tpl->InstanceTemplate(),
+                   Nan::New("properties").ToLocalChecked(),
+                   PropertiesGetter);
   Nan::SetPrototypeMethod(tpl, "release", Release);
   Nan::SetPrototypeMethod(tpl, "dismiss", Dismiss);
 
@@ -46,6 +49,25 @@ void RclHandle::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     obj->Wrap(info.This());
     info.GetReturnValue().Set(info.This());
   }
+}
+
+void RclHandle::SyncProperties() {
+  auto obj = v8::Object::New(v8::Isolate::GetCurrent());
+
+  for (auto& it = properties_.begin(); it != properties_.end(); it++) {
+    obj->Set(Nan::New(it->first).ToLocalChecked(), Nan::New(it->second));
+  }
+
+  properties_obj_ = obj;
+}
+
+NAN_GETTER(RclHandle::PropertiesGetter) {
+  auto* me = RclHandle::Unwrap<RclHandle>(info.Holder());
+
+  if (!me->properties_obj_.IsEmpty())
+    info.GetReturnValue().Set(me->properties_obj_);
+  else
+    info.GetReturnValue().Set(Nan::Undefined());
 }
 
 NAN_METHOD(RclHandle::Release) {

--- a/src/rcl_handle.hpp
+++ b/src/rcl_handle.hpp
@@ -43,7 +43,7 @@ class RclHandle : public Nan::ObjectWrap {
   void Reset();
   void AddChild(RclHandle* child) { children_.insert(child); }
   void RemoveChild(RclHandle* child) { children_.erase(child); }
-  void SetProperty(const std::string& name, bool value) {
+  void SetBoolProperty(const std::string& name, bool value) {
       properties_[name] = value; }
   void SyncProperties();
 

--- a/src/rcl_handle.hpp
+++ b/src/rcl_handle.hpp
@@ -19,6 +19,7 @@
 
 #include <functional>
 #include <set>
+#include <map>
 
 namespace rclnodejs {
 
@@ -42,6 +43,9 @@ class RclHandle : public Nan::ObjectWrap {
   void Reset();
   void AddChild(RclHandle* child) { children_.insert(child); }
   void RemoveChild(RclHandle* child) { children_.erase(child); }
+  void SetProperty(const std::string& name, bool value) {
+      properties_[name] = value; }
+  void SyncProperties();
 
  private:
   RclHandle();
@@ -51,10 +55,13 @@ class RclHandle : public Nan::ObjectWrap {
   static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
   static NAN_METHOD(Release);
   static NAN_METHOD(Dismiss);
+  static NAN_GETTER(PropertiesGetter);
 
  private:
   void* pointer_;
   RclHandle* parent_;
+  std::map<std::string, bool> properties_;
+  v8::Local<v8::Object> properties_obj_;
 
   std::function<int()> deleter_;
   std::set<RclHandle*> children_;

--- a/src/rcl_handle.hpp
+++ b/src/rcl_handle.hpp
@@ -19,6 +19,7 @@
 
 #include <functional>
 #include <set>
+#include <string>
 #include <map>
 
 namespace rclnodejs {

--- a/src/shadow_node.cpp
+++ b/src/shadow_node.cpp
@@ -133,6 +133,7 @@ void ShadowNode::Execute(const std::vector<rclnodejs::RclHandle*>& handles) {
 
   v8::Local<v8::Array> results = Nan::New<v8::Array>(handles.size());
   for (size_t i = 0; i < handles.size(); ++i) {
+    handles[i]->SyncProperties();
     Nan::Set(results, i, handles[i]->handle());
   }
 


### PR DESCRIPTION
Adds action clients and servers into the event loop. You can't add action client/servers right now so this change essentially does nothing.

Actions present an interesting problem where not only do you need to know if the handle is ready, but you also need to know what to execute within the handle. rclpy abstracts actions with a Waitable base class and lets the sub-class fill in the details of reading from the wait_set. This approach doesn't fit in with the design of rclnodejs, so instead actions are treated as entities, similar to publishers, subscribers, etc, but with some special handling.

To know what part of the action server/client should be processed a property bag has added to RclHandle allowing the event loop to attach arbitrary data to be sent back to the main thread. The property bag could be extended in the future if ever needed by other entity types.

Below is how the property bag would be used in later PRs.

```javascript
// From Node class
execute(handles) {
  let actionServersReady = this._actionServers.filter((actionServer) =>
      handles.indexOf(actionServer.handle) !== -1);

  // ...

  actionServersReady.forEach((actionServer) => {
    // Read the properties from the handle
    let properties = actionServer.handle.properties;

    if (properties.isGoalRequestReady) {
      // process goal request
    }

    if (properties.isCancelRequestReady) {
      // process cancel request
    }

    // process other requests
  }
}
```

Note this PR is targeting the 'actions' branch.