### PR TITLE
Add project name and version number to jsdoc

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,2 +1,2 @@
 index.html : ../index.js ../lib/*.js ./jsdoc-template
-	jsdoc ../index.js ../lib/*.js -t ./jsdoc-template -d .
+	jsdoc --package ../package.json ../index.js ../lib/*.js -t ./jsdoc-template -d .


### PR DESCRIPTION
This patch incorporates the package.json to add project's name and
version number on the homepage when generating jsdoc

Fix #None