### PR TITLE
Fix compile errors with node v12

### DIFF
--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -24,12 +24,14 @@
 #endif
 
 void InitModule(v8::Local<v8::Object> exports) {
+  v8::Local<v8::Context> context = exports->GetIsolate()->GetCurrentContext();
+
   for (uint32_t i = 0;
        i < rclnodejs::GetBindingMethodsCount(rclnodejs::binding_methods); i++) {
     exports->Set(
         Nan::New(rclnodejs::binding_methods[i].name).ToLocalChecked(),
         Nan::New<v8::FunctionTemplate>(rclnodejs::binding_methods[i].function)
-            ->GetFunction());
+            ->GetFunction(context).ToLocalChecked());
   }
 
   rclnodejs::ShadowNode::Init(exports);

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -468,13 +468,18 @@ NAN_METHOD(RclTake) {
 }
 
 NAN_METHOD(CreateSubscription) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(
       Nan::To<v8::Object>(info[0]).ToLocalChecked());
   rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
-  std::string package_name(*Nan::Utf8String(info[1]->ToString()));
-  std::string message_sub_folder(*Nan::Utf8String(info[2]->ToString()));
-  std::string message_name(*Nan::Utf8String(info[3]->ToString()));
-  std::string topic(*Nan::Utf8String(info[4]->ToString()));
+  std::string package_name(
+      *Nan::Utf8String(info[1]->ToString(currentContent).ToLocalChecked()));
+  std::string message_sub_folder(
+      *Nan::Utf8String(info[2]->ToString(currentContent).ToLocalChecked()));
+  std::string message_name(
+      *Nan::Utf8String(info[3]->ToString(currentContent).ToLocalChecked()));
+  std::string topic(
+      *Nan::Utf8String(info[4]->ToString(currentContent).ToLocalChecked()));
 
   rcl_subscription_t* subscription =
       reinterpret_cast<rcl_subscription_t*>(malloc(sizeof(rcl_subscription_t)));
@@ -509,14 +514,19 @@ NAN_METHOD(CreateSubscription) {
 }
 
 NAN_METHOD(CreatePublisher) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   // Extract arguments
   RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(
       Nan::To<v8::Object>(info[0]).ToLocalChecked());
   rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
-  std::string package_name(*Nan::Utf8String(info[1]->ToString()));
-  std::string message_sub_folder(*Nan::Utf8String(info[2]->ToString()));
-  std::string message_name(*Nan::Utf8String(info[3]->ToString()));
-  std::string topic(*Nan::Utf8String(info[4]->ToString()));
+  std::string package_name(
+      *Nan::Utf8String(info[1]->ToString(currentContent).ToLocalChecked()));
+  std::string message_sub_folder(
+      *Nan::Utf8String(info[2]->ToString(currentContent).ToLocalChecked()));
+  std::string message_name(
+      *Nan::Utf8String(info[3]->ToString(currentContent).ToLocalChecked()));
+  std::string topic(
+      *Nan::Utf8String(info[4]->ToString(currentContent).ToLocalChecked()));
 
   // Prepare publisher object
   rcl_publisher_t* publisher =
@@ -567,12 +577,16 @@ NAN_METHOD(Publish) {
 }
 
 NAN_METHOD(CreateClient) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(
       Nan::To<v8::Object>(info[0]).ToLocalChecked());
   rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
-  std::string service_name(*Nan::Utf8String(info[1]->ToString()));
-  std::string interface_name(*Nan::Utf8String(info[2]->ToString()));
-  std::string package_name(*Nan::Utf8String(info[3]->ToString()));
+  std::string service_name(
+      *Nan::Utf8String(info[1]->ToString(currentContent).ToLocalChecked()));
+  std::string interface_name(
+      *Nan::Utf8String(info[2]->ToString(currentContent).ToLocalChecked()));
+  std::string package_name(
+      *Nan::Utf8String(info[3]->ToString(currentContent).ToLocalChecked()));
 
   const rosidl_service_type_support_t* ts =
       GetServiceTypeSupport(package_name, interface_name);
@@ -641,12 +655,16 @@ NAN_METHOD(RclTakeResponse) {
 }
 
 NAN_METHOD(CreateService) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(
       Nan::To<v8::Object>(info[0]).ToLocalChecked());
   rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
-  std::string service_name(*Nan::Utf8String(info[1]->ToString()));
-  std::string interface_name(*Nan::Utf8String(info[2]->ToString()));
-  std::string package_name(*Nan::Utf8String(info[3]->ToString()));
+  std::string service_name(
+      *Nan::Utf8String(info[1]->ToString(currentContent).ToLocalChecked()));
+  std::string interface_name(
+      *Nan::Utf8String(info[2]->ToString(currentContent).ToLocalChecked()));
+  std::string package_name(
+      *Nan::Utf8String(info[3]->ToString(currentContent).ToLocalChecked()));
 
   const rosidl_service_type_support_t* ts =
       GetServiceTypeSupport(package_name, interface_name);
@@ -710,9 +728,11 @@ NAN_METHOD(SendResponse) {
 }
 
 NAN_METHOD(ValidateFullTopicName) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   int validation_result;
   size_t invalid_index;
-  std::string topic_name(*Nan::Utf8String(info[0]->ToString()));
+  std::string topic_name(
+      *Nan::Utf8String(info[0]->ToString(currentContent).ToLocalChecked()));
   rmw_ret_t ret = rmw_validate_full_topic_name(
       topic_name.c_str(), &validation_result, &invalid_index);
 
@@ -743,9 +763,11 @@ NAN_METHOD(ValidateFullTopicName) {
 }
 
 NAN_METHOD(ValidateNodeName) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   int validation_result;
   size_t invalid_index;
-  std::string node_name(*Nan::Utf8String(info[0]->ToString()));
+  std::string node_name(
+      *Nan::Utf8String(info[0]->ToString(currentContent).ToLocalChecked()));
   rmw_ret_t ret = rmw_validate_node_name(node_name.c_str(), &validation_result,
                                          &invalid_index);
 
@@ -776,9 +798,11 @@ NAN_METHOD(ValidateNodeName) {
 }
 
 NAN_METHOD(ValidateTopicName) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   int validation_result;
   size_t invalid_index;
-  std::string topic_name(*Nan::Utf8String(info[0]->ToString()));
+  std::string topic_name(
+      *Nan::Utf8String(info[0]->ToString(currentContent).ToLocalChecked()));
   rmw_ret_t ret = rcl_validate_topic_name(topic_name.c_str(),
                                           &validation_result, &invalid_index);
 
@@ -809,9 +833,11 @@ NAN_METHOD(ValidateTopicName) {
 }
 
 NAN_METHOD(ValidateNamespace) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   int validation_result;
   size_t invalid_index;
-  std::string namespace_name(*Nan::Utf8String(info[0]->ToString()));
+  std::string namespace_name(
+      *Nan::Utf8String(info[0]->ToString(currentContent).ToLocalChecked()));
   rmw_ret_t ret = rmw_validate_namespace(namespace_name.c_str(),
                                          &validation_result, &invalid_index);
 
@@ -842,9 +868,13 @@ NAN_METHOD(ValidateNamespace) {
 }
 
 NAN_METHOD(ExpandTopicName) {
-  std::string topic_name(*Nan::Utf8String(info[0]->ToString()));
-  std::string node_name(*Nan::Utf8String(info[1]->ToString()));
-  std::string node_namespace(*Nan::Utf8String(info[2]->ToString()));
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
+  std::string topic_name(
+      *Nan::Utf8String(info[0]->ToString(currentContent).ToLocalChecked()));
+  std::string node_name(
+      *Nan::Utf8String(info[1]->ToString(currentContent).ToLocalChecked()));
+  std::string node_namespace(
+      *Nan::Utf8String(info[2]->ToString(currentContent).ToLocalChecked()));
 
   char* expanded_topic = nullptr;
   rcl_allocator_t allocator = rcl_get_default_allocator();
@@ -954,6 +984,7 @@ const rmw_qos_profile_t* GetQoSProfileFromString(const std::string& profile) {
 
 std::unique_ptr<rmw_qos_profile_t> GetQosProfileFromObject(
     v8::Local<v8::Object> object) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   std::unique_ptr<rmw_qos_profile_t> qos_profile =
       std::make_unique<rmw_qos_profile_t>();
 
@@ -971,18 +1002,19 @@ std::unique_ptr<rmw_qos_profile_t> GetQosProfileFromObject(
           object->Get(Nan::New("durability").ToLocalChecked())).FromJust());
   qos_profile->avoid_ros_namespace_conventions =
       object->Get(Nan::New("avoidRosNameSpaceConventions").ToLocalChecked())
-          ->BooleanValue();
+          ->BooleanValue(currentContent).FromJust();
 
   return qos_profile;
 }
 
 std::unique_ptr<rmw_qos_profile_t> GetQoSProfile(v8::Local<v8::Value> qos) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   std::unique_ptr<rmw_qos_profile_t> qos_profile =
       std::make_unique<rmw_qos_profile_t>();
 
   if (qos->IsString()) {
-    *qos_profile = *GetQoSProfileFromString(
-        std::string(*Nan::Utf8String(qos->ToString())));
+    *qos_profile = *GetQoSProfileFromString(std::string(
+        *Nan::Utf8String(qos->ToString(currentContent).ToLocalChecked())));
   } else if (qos->IsObject()) {
     qos_profile = GetQosProfileFromObject(
         Nan::To<v8::Object>(qos).ToLocalChecked());
@@ -1079,7 +1111,9 @@ NAN_METHOD(CreateArrayBufferCleaner) {
 }
 
 NAN_METHOD(setLoggerLevel) {
-  std::string name(*Nan::Utf8String(info[0]->ToString()));
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
+  std::string name(
+      *Nan::Utf8String(info[0]->ToString(currentContent).ToLocalChecked()));
   int level = Nan::To<int64_t>(info[1]).FromJust();
 
   rcutils_ret_t ret = rcutils_logging_set_logger_level(name.c_str(), level);
@@ -1091,7 +1125,9 @@ NAN_METHOD(setLoggerLevel) {
 }
 
 NAN_METHOD(GetLoggerEffectiveLevel) {
-  std::string name(*Nan::Utf8String(info[0]->ToString()));
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
+  std::string name(
+      *Nan::Utf8String(info[0]->ToString(currentContent).ToLocalChecked()));
   int logger_level = rcutils_logging_get_logger_effective_level(name.c_str());
 
   if (logger_level < 0) {
@@ -1104,12 +1140,17 @@ NAN_METHOD(GetLoggerEffectiveLevel) {
 }
 
 NAN_METHOD(Log) {
-  std::string name(*Nan::Utf8String(info[0]->ToString()));
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
+  std::string name(
+      *Nan::Utf8String(info[0]->ToString(currentContent).ToLocalChecked()));
   int severity = Nan::To<int64_t>(info[1]).FromJust();
-  std::string message(*Nan::Utf8String(info[2]->ToString()));
-  std::string function_name(*Nan::Utf8String(info[3]->ToString()));
+  std::string message(
+      *Nan::Utf8String(info[2]->ToString(currentContent).ToLocalChecked()));
+  std::string function_name(
+      *Nan::Utf8String(info[3]->ToString(currentContent).ToLocalChecked()));
   size_t line_number = Nan::To<int64_t>(info[4]).FromJust();
-  std::string file_name(*Nan::Utf8String(info[5]->ToString()));
+  std::string file_name(
+      *Nan::Utf8String(info[5]->ToString(currentContent).ToLocalChecked()));
   bool enabled = rcutils_logging_logger_is_enabled_for(name.c_str(), severity);
 
   if (enabled) {
@@ -1122,7 +1163,9 @@ NAN_METHOD(Log) {
 }
 
 NAN_METHOD(IsEnableFor) {
-  std::string name(*Nan::Utf8String(info[0]->ToString()));
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
+  std::string name(
+      *Nan::Utf8String(info[0]->ToString(currentContent).ToLocalChecked()));
   int severity = Nan::To<int64_t>(info[1]).FromJust();
   bool enabled = rcutils_logging_logger_is_enabled_for(name.c_str(), severity);
   info.GetReturnValue().Set(Nan::New(enabled));
@@ -1167,11 +1210,14 @@ void ExtractNamesAndTypes(rcl_names_and_types_t names_and_types,
 }
 
 NAN_METHOD(GetPublisherNamesAndTypesByNode) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(
       Nan::To<v8::Object>(info[0]).ToLocalChecked());
   rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
-  std::string node_name = *Nan::Utf8String(info[1]->ToString());
-  std::string node_namespace = *Nan::Utf8String(info[2]->ToString());
+  std::string node_name =
+      *Nan::Utf8String(info[1]->ToString(currentContent).ToLocalChecked());
+  std::string node_namespace =
+      *Nan::Utf8String(info[2]->ToString(currentContent).ToLocalChecked());
   bool no_demangle = Nan::To<bool>(info[3]).FromJust();
 
   rcl_names_and_types_t topic_names_and_types =
@@ -1195,11 +1241,14 @@ NAN_METHOD(GetPublisherNamesAndTypesByNode) {
 }
 
 NAN_METHOD(GetSubscriptionNamesAndTypesByNode) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(
       Nan::To<v8::Object>(info[0]).ToLocalChecked());
   rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
-  std::string node_name = *Nan::Utf8String(info[1]->ToString());
-  std::string node_namespace = *Nan::Utf8String(info[2]->ToString());
+  std::string node_name =
+      *Nan::Utf8String(info[1]->ToString(currentContent).ToLocalChecked());
+  std::string node_namespace =
+      *Nan::Utf8String(info[2]->ToString(currentContent).ToLocalChecked());
   bool no_demangle = Nan::To<bool>(info[3]).FromJust();
 
   rcl_names_and_types_t topic_names_and_types =
@@ -1223,11 +1272,14 @@ NAN_METHOD(GetSubscriptionNamesAndTypesByNode) {
 }
 
 NAN_METHOD(GetServiceNamesAndTypesByNode) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(
       Nan::To<v8::Object>(info[0]).ToLocalChecked());
   rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
-  std::string node_name = *Nan::Utf8String(info[1]->ToString());
-  std::string node_namespace = *Nan::Utf8String(info[2]->ToString());
+  std::string node_name =
+      *Nan::Utf8String(info[1]->ToString(currentContent).ToLocalChecked());
+  std::string node_namespace =
+      *Nan::Utf8String(info[2]->ToString(currentContent).ToLocalChecked());
 
   rcl_names_and_types_t service_names_and_types =
       rcl_get_zero_initialized_names_and_types();
@@ -1343,10 +1395,12 @@ NAN_METHOD(GetNodeNames) {
 }
 
 NAN_METHOD(CountPublishers) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(
       Nan::To<v8::Object>(info[0]).ToLocalChecked());
   rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
-  std::string topic_name = *Nan::Utf8String(info[1]->ToString());
+  std::string topic_name =
+      *Nan::Utf8String(info[1]->ToString(currentContent).ToLocalChecked());
 
   size_t count = 0;
   THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
@@ -1360,10 +1414,12 @@ NAN_METHOD(CountPublishers) {
 }
 
 NAN_METHOD(CountSubscribers) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(
       Nan::To<v8::Object>(info[0]).ToLocalChecked());
   rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
-  std::string topic_name = *Nan::Utf8String(info[1]->ToString());
+  std::string topic_name =
+      *Nan::Utf8String(info[1]->ToString(currentContent).ToLocalChecked());
 
   size_t count = 0;
   THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,

--- a/src/rcl_handle.cpp
+++ b/src/rcl_handle.cpp
@@ -36,8 +36,11 @@ void RclHandle::Init(v8::Local<v8::Object> exports) {
   Nan::SetPrototypeMethod(tpl, "release", Release);
   Nan::SetPrototypeMethod(tpl, "dismiss", Dismiss);
 
-  constructor.Reset(tpl->GetFunction());
-  exports->Set(Nan::New("RclHandle").ToLocalChecked(), tpl->GetFunction());
+  v8::Local<v8::Context> context = exports->GetIsolate()->GetCurrentContext();
+
+  constructor.Reset(tpl->GetFunction(context).ToLocalChecked());
+  exports->Set(Nan::New("RclHandle").ToLocalChecked(),
+               tpl->GetFunction(context).ToLocalChecked());
 }
 
 void RclHandle::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {

--- a/test/test-array-data.js
+++ b/test/test-array-data.js
@@ -16,6 +16,7 @@
 
 const assert = require('assert');
 const childProcess = require('child_process');
+const deepEqual = require('deep-equal');
 const rclnodejs = require('../index.js');
 const translator = require('../rosidl_gen/message_translator.js');
 const arrayGen = require('./array_generator.js');
@@ -157,7 +158,7 @@ describe('rclnodejs message communication', function() {
           if (isTypedArray(v.data)) {
             assert.deepStrictEqual(msg.data, v.data);
           } else {
-            assert.deepEqual(msg.data, v.data);
+            assert.ok(deepEqual(msg.data, v.data));
           }
         }
 

--- a/test/test-msg-type-cpp-node.js
+++ b/test/test-msg-type-cpp-node.js
@@ -19,6 +19,7 @@
 const assert = require('assert');
 const path = require('path');
 const childProcess = require('child_process');
+const deepEqual = require('deep-equal');
 const rclnodejs = require('../index.js');
 const utils = require('./utils.js');
 
@@ -333,7 +334,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
 
       var publisher = node.createPublisher(ColorRGBA, 'ColorRGBA_js_cpp_channel');
       var subscription = node.createSubscription(ColorRGBA, 'back_ColorRGBA_js_cpp_channel', (backMsg) => {
-        assert.deepEqual(msg, backMsg);
+        assert.ok(deepEqual(msg, backMsg));
 
         timer.cancel();
         node.destroy();
@@ -366,7 +367,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
 
       var publisher = node.createPublisher(ByteMultiArray, 'Array_js_cpp_channel');
       var subscription = node.createSubscription(ByteMultiArray, 'back_ByteMultiArray_js_cpp_channel', (backMsg) => {
-        assert.deepEqual(msg, backMsg);
+        assert.ok(deepEqual(msg, backMsg));
 
         timer.cancel();
         node.destroy();
@@ -392,7 +393,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
 
       var publisher = node.createPublisher(Header, 'Header_js_cpp_channel');
       var subscription = node.createSubscription(Header, 'back_Header_js_cpp_channel', (backMsg) => {
-        assert.deepEqual(msg, backMsg);
+        assert.ok(deepEqual(msg, backMsg));
 
         timer.cancel();
         node.destroy();
@@ -426,7 +427,7 @@ describe('Rclnodejs - Cpp message type testing', function() {
       var destroy = false;
       var publisher = node.createPublisher(JointState, 'JointState_js_cpp_channel');
       var subscription = node.createSubscription(JointState, 'back_JointState_js_cpp_channel', (backMsg) => {
-        assert.deepEqual(msg, backMsg);
+        assert.ok(deepEqual(msg, backMsg));
 
         timer.cancel();
         node.destroy();

--- a/test/test-msg-type-py-node.js
+++ b/test/test-msg-type-py-node.js
@@ -18,6 +18,7 @@
 
 const assert = require('assert');
 const childProcess = require('child_process');
+const deepEqual = require('deep-equal');
 const rclnodejs = require('../index.js');
 const utils = require('./utils.js');
 
@@ -355,7 +356,7 @@ describe('Rclnodejs - Python message type testing', function() {
       var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'Array']);
       var publisher = node.createPublisher(ByteMultiArray, 'Array_js_py_channel');
       var subscription = node.createSubscription(ByteMultiArray, 'Array_js_py_back_channel', (backMsg) => {
-        assert.deepEqual(msg, backMsg);
+        assert.ok(deepEqual(msg, backMsg));
         timer.cancel();
         node.destroy();
         pySubscription.kill('SIGINT');
@@ -381,7 +382,7 @@ describe('Rclnodejs - Python message type testing', function() {
       var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'ColorRGBA']);
       var publisher = node.createPublisher(ColorRGBA, 'ColorRGBA_js_py_channel');
       var subscription = node.createSubscription(ColorRGBA, 'ColorRGBA_js_py_back_channel', (backMsg) => {
-        assert.deepEqual(msg, backMsg);
+        assert.ok(deepEqual(msg, backMsg));
         timer.cancel();
         node.destroy();
         pySubscription.kill('SIGINT');
@@ -443,7 +444,7 @@ describe('Rclnodejs - Python message type testing', function() {
       var pySubscription = utils.launchPythonProcess([`${__dirname}/py/subscription_msg.py`, 'JointState']);
       var publisher = node.createPublisher(JointState, 'JointState_js_py_channel');
       var subscription = node.createSubscription(JointState, 'JointState_js_py_back_channel', (backMsg) => {
-        assert.deepEqual(msg, backMsg);
+        assert.ok(deepEqual(msg, backMsg));
         timer.cancel();
         node.destroy();
         pySubscription.kill('SIGINT');


### PR DESCRIPTION
Fixes all compiler errors with NodeJS v12. Also switches from using the deprecated assert.deepEqual to deep-equal in unit tests.