### PR TITLE
Remove duplicated message handling logic

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -67,10 +67,8 @@ class Client extends Entity {
   }
 
   processResponse(response) {
-    this._response = new this._typeClass.Response();
-    this._response.deserialize(response);
     debug(`Client has received ${this._serviceName} response from service.`);
-    this._callback(this._response.toPlainObject(this.typedArrayEnabled));
+    this._callback(response.toPlainObject(this.typedArrayEnabled));
   }
 
   /**

--- a/lib/node.js
+++ b/lib/node.js
@@ -67,13 +67,12 @@ class Node {
     });
 
     subscriptionsReady.forEach((subscription) => {
-      let Message = subscription.typeClass;
-      let msg = new Message();
-      let success = rclnodejs.rclTake(subscription.handle, msg.toRawROS());
-      if (success) {
-        subscription.processResponse(msg.refObject);
-      }
-      Message.destoryRawROS(msg);
+      this._runWithMessageType(subscription.typeClass, (message, deserialize) => {
+        let success = rclnodejs.rclTake(subscription.handle, message);
+        if (success) {
+          subscription.processResponse(deserialize());
+        }
+      });
     });
 
     guardsReady.forEach((guard) => {
@@ -81,23 +80,21 @@ class Node {
     });
 
     clientsReady.forEach((client) => {
-      let Response = client.typeClass.Response;
-      let response = new Response();
-      let success = rclnodejs.rclTakeResponse(client.handle, client.sequenceNumber, response.toRawROS());
-      if (success) {
-        client.processResponse(response.refObject);
-      }
-      Response.destoryRawROS(response);
+      this._runWithMessageType(client.typeClass.Response, (message, deserialize) => {
+        let success = rclnodejs.rclTakeResponse(client.handle, client.sequenceNumber, message);
+        if (success) {
+          client.processResponse(deserialize());
+        }
+      });
     });
 
     servicesReady.forEach((service) => {
-      let Request = service.typeClass.Request;
-      let request = new Request();
-      let header = rclnodejs.rclTakeRequest(service.handle, this.handle, request.toRawROS());
-      if (header) {
-        service.processRequest(header, request.refObject);
-      }
-      Request.destoryRawROS(request);
+      this._runWithMessageType(service.typeClass.Request, (message, deserialize) => {
+        let header = rclnodejs.rclTakeRequest(service.handle, this.handle, message);
+        if (header) {
+          service.processRequest(header, deserialize());
+        }
+      });
     });
   }
 
@@ -541,6 +538,27 @@ class Node {
     rclnodejs.validateTopicName(expandedTopic);
 
     return rclnodejs.countSubscribers(this.handle, expandedTopic);
+  }
+
+  /**
+   * Invokes the callback with a raw message of the given type. After the callback completes
+   * the message will be destroyed.
+   * @param {function} Type - Message type to create.
+   * @param {function} callback - Callback to invoke. First parameter will be the raw message,
+   * and the second is a function to retrieve the deserialized message.
+   * @returns {undefined}
+   */
+  _runWithMessageType(Type, callback) {
+    let message = new Type();
+
+    callback(message.toRawROS(), () => {
+      let result = new Type();
+      result.deserialize(message.refObject);
+
+      return result;
+    });
+
+    Type.destoryRawROS(message);
   }
 }
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -70,11 +70,9 @@ class Service extends Entity {
   }
 
   processRequest(headerHandle, request) {
-    this._request = new this._typeClass.Request();
-    this._request.deserialize(request);
     debug(`Service has received a ${this._serviceName} request from client.`);
 
-    const plainObj = this._request.toPlainObject(this.typedArrayEnabled);
+    const plainObj = request.toPlainObject(this.typedArrayEnabled);
     const response = new Response(this, headerHandle);
     let responseToReturn = this._callback(plainObj, response);
 

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -31,10 +31,8 @@ class Subscription extends Entity {
   }
 
   processResponse(msg) {
-    this._message = new this._typeClass();
-    this._message.deserialize(msg);
     debug(`Message of topic ${this._topic} received.`);
-    this._callback(this._message.toPlainObject(this.typedArrayEnabled));
+    this._callback(msg.toPlainObject(this.typedArrayEnabled));
   }
 
   static createSubscription(nodeHandle, typeClass, topic, options, callback) {


### PR DESCRIPTION
Adds a new function to handle `toRawROS`, `destoryRawROS`, and `deserialize(refObject)` internally. Actions need to do this a lot (9 times) so it's becoming very repetitious.

This PR targets the 'actions' branch.