### PR TITLE
Fix format script on Windows and include subfolders

### DIFF
--- a/lib/actions/action_client_interface.js
+++ b/lib/actions/action_client_interface.js
@@ -29,23 +29,39 @@ class ActionClientInterface extends EventEmitter {
     this._actionServer = options.actionServer;
     this._node = this._rclnodejs.createNode(`${this._actionServer}_client`);
 
-    this._goalPublisher = this._node.createPublisher(this._actionType + 'ActionGoal',
-      this._actionServer + '/goal');
+    this._goalPublisher = this._node.createPublisher(
+      this._actionType + 'ActionGoal',
+      this._actionServer + '/goal'
+    );
 
-    this._cancelPublisher = this._node.createPublisher('actionlib_msgs/msg/GoalID',
-      this._actionServer + '/cancel');
+    this._cancelPublisher = this._node.createPublisher(
+      'actionlib_msgs/msg/GoalID',
+      this._actionServer + '/cancel'
+    );
 
-    this._statusSubscription = this._node.createSubscription('actionlib_msgs/msg/GoalStatusArray',
+    this._statusSubscription = this._node.createSubscription(
+      'actionlib_msgs/msg/GoalStatusArray',
       this._actionServer + '/status',
-      (msg) => { this._handleStatus(msg); });
+      msg => {
+        this._handleStatus(msg);
+      }
+    );
 
-    this._feedbackSubscription = this._node.createSubscription(this._actionType + 'ActionFeedback',
+    this._feedbackSubscription = this._node.createSubscription(
+      this._actionType + 'ActionFeedback',
       this._actionServer + '/feedback',
-      (msg) => { this._handleFeedback(msg); });
+      msg => {
+        this._handleFeedback(msg);
+      }
+    );
 
-    this._resultSubscription = this._node.createSubscription(this._actionType + 'ActionResult',
+    this._resultSubscription = this._node.createSubscription(
+      this._actionType + 'ActionResult',
       this._actionServer + '/result',
-      (msg) => { this._handleResult(msg); });
+      msg => {
+        this._handleResult(msg);
+      }
+    );
 
     this._goals = {};
     this._goalSeqNum = 0;
@@ -59,7 +75,7 @@ class ActionClientInterface extends EventEmitter {
 
   _handleFeedback(msg) {
     const goalId = msg.status.goal_id.id;
-    if  (this._goals.hasOwnProperty(goalId)) {
+    if (this._goals.hasOwnProperty(goalId)) {
       this.emit('feedback', msg.feedback);
     }
   }
@@ -74,12 +90,11 @@ class ActionClientInterface extends EventEmitter {
 
   cancel(goalId) {
     const cancelGoal = {
-      stamp: time.now()
+      stamp: time.now(),
     };
     if (!goalId) {
       this._cancelPublisher.publish(cancelGoal);
-    }
-    else if (this._goals.hasOwnProperty(goalId)) {
+    } else if (this._goals.hasOwnProperty(goalId)) {
       cancelGoal.id = goalId;
       this._cancelPublisher.publish(cancelGoal);
     }
@@ -89,14 +104,14 @@ class ActionClientInterface extends EventEmitter {
     if (!goal.goal_id) {
       goal.goal_id = {
         stamp: time.now(),
-        id: this.generateGoalId()
+        id: this.generateGoalId(),
       };
     }
     if (!goal.header) {
       goal.header = {
         seq: this._goalSeqNum++,
         stamp: goal.goal_id.stamp,
-        frame_id: 'auto-generated'
+        frame_id: 'auto-generated',
       };
     }
 

--- a/lib/actions/action_server_interface.js
+++ b/lib/actions/action_server_interface.js
@@ -28,22 +28,36 @@ class ActionServerInterface extends EventEmitter {
 
     this._node = this._rclnodejs.createNode(`${this._actionServer}_server`);
 
-    this._goalSubscription = this._node.createSubscription(this._actionType + 'ActionGoal',
+    this._goalSubscription = this._node.createSubscription(
+      this._actionType + 'ActionGoal',
       this._actionServer + '/goal',
-      (msg) => { this._handleGoal(msg); });
+      msg => {
+        this._handleGoal(msg);
+      }
+    );
 
-    this._cancelSubscription = this._node.createSubscription('actionlib_msgs/msg/GoalID',
+    this._cancelSubscription = this._node.createSubscription(
+      'actionlib_msgs/msg/GoalID',
       this._actionServer + '/cancel',
-      (msg) => { this._handleCancel(msg); });
+      msg => {
+        this._handleCancel(msg);
+      }
+    );
 
-    this._statusPublisher = this._node.createPublisher('actionlib_msgs/msg/GoalStatusArray',
-      this._actionServer + '/status');
+    this._statusPublisher = this._node.createPublisher(
+      'actionlib_msgs/msg/GoalStatusArray',
+      this._actionServer + '/status'
+    );
 
-    this._feedbackPublisher = this._node.createPublisher(this._actionType + 'ActionFeedback',
-      this._actionServer + '/feedback');
+    this._feedbackPublisher = this._node.createPublisher(
+      this._actionType + 'ActionFeedback',
+      this._actionServer + '/feedback'
+    );
 
-    this._resultPublisher = this._node.createPublisher(this._actionType + 'ActionResult',
-      this._actionServer + '/result');
+    this._resultPublisher = this._node.createPublisher(
+      this._actionType + 'ActionResult',
+      this._actionServer + '/result'
+    );
     this._rclnodejs.spin(this._node);
   }
 
@@ -54,7 +68,7 @@ class ActionServerInterface extends EventEmitter {
   generateGoalId() {
     return {
       id: uuidv4(),
-      stamp: time.now()
+      stamp: time.now(),
     };
   }
 

--- a/lib/actions/time_utils.js
+++ b/lib/actions/time_utils.js
@@ -22,14 +22,16 @@ module.exports = {
   rosTimeToDate(rosTime) {
     let date = new Date();
     // setTime takes in ms since epoch
-    date.setTime(rosTime.sec * 1000 + Math.floor(rosTime.nanosec * USEC_TO_SEC));
+    date.setTime(
+      rosTime.sec * 1000 + Math.floor(rosTime.nanosec * USEC_TO_SEC)
+    );
     return date;
   },
 
   dateToRosTime(date) {
     let sec = Math.floor(date * MSEC_TO_SEC);
-    let nanosec = date % 1000 * 1000000;
-    return {sec, nanosec};
+    let nanosec = (date % 1000) * 1000000;
+    return { sec, nanosec };
   },
 
   now() {
@@ -39,7 +41,7 @@ module.exports = {
   epoch() {
     return {
       sec: 0,
-      nanosec: 0
+      nanosec: 0,
     };
   },
 
@@ -57,5 +59,5 @@ module.exports = {
 
   timeComp(left, right) {
     return Math.sign(this.toNumber(left) - this.toNumber(right));
-  }
+  },
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "node ./scripts/compile_tests.js && node ./scripts/run_test.js && dtslint test/types",
     "lint": "eslint --max-warnings=0 index.js types/*.d.ts scripts lib example rosidl_gen rosidl_parser test benchmark/rclnodejs && node ./scripts/cpplint.js",
     "postinstall": "node scripts/generate_messages.js",
-    "format": "prettier --trailing-comma es5 --single-quote --write '{.,lib,rosidl_gen,rostsd_gen,rosidl_parser,types,example,test}/*.{js,md,ts}'"
+    "format": "prettier --trailing-comma es5 --single-quote --write \"{.,{lib,rosidl_gen,rostsd_gen,rosidl_parser,types,example,test}/**}/*.{js,md,ts}\""
   },
   "authors": [
     "Minggang Wang <minggang.wang@intel.com>",

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -1,10 +1,9 @@
 /// <reference path='../../types/index.d.ts' />
 import * as rclnodejs from 'rclnodejs';
 
-const NODE_NAME = "test_node";
-const TYPE_CLASS = "std_msgs/msg/String";
-const TOPIC = "topic";
-
+const NODE_NAME = 'test_node';
+const TYPE_CLASS = 'std_msgs/msg/String';
+const TOPIC = 'topic';
 
 // ---- rclnodejs -----
 // $ExpectType Promise<void>
@@ -20,9 +19,6 @@ rclnodejs.isShutdown();
 rclnodejs.shutdown();
 
 // ---- Context -----
-
-
-
 
 // ---- Node -----
 // $ExpectType Node
@@ -67,7 +63,6 @@ node.countPublishers(TOPIC);
 // $ExpectType number
 node.countSubscribers(TOPIC);
 
-
 // ---- Publisher ----
 // $ExpectType Publisher
 const publisher = node.createPublisher(TYPE_CLASS, TOPIC);
@@ -88,28 +83,34 @@ publisher.typeClass;
 publisher.typedArrayEnabled;
 
 // $ExpectType void
-publisher.publish("");
-
+publisher.publish('');
 
 // ---- Subscription ----
 // $ExpectType Subscription
-const subscription = node.createSubscription(TYPE_CLASS, TOPIC, {}, (msg: rclnodejs.Message) => {});
+const subscription = node.createSubscription(
+  TYPE_CLASS,
+  TOPIC,
+  {},
+  (msg: rclnodejs.Message) => {}
+);
 
 // $ExpectType string
 subscription.topic;
 
-
 // ---- Service ----
 // $ExpectType Service
-const service = node.createService(TYPE_CLASS, 'abc', {},
-	(request: rclnodejs.Message, response: rclnodejs.ServiceResponse) => {});
+const service = node.createService(
+  TYPE_CLASS,
+  'abc',
+  {},
+  (request: rclnodejs.Message, response: rclnodejs.ServiceResponse) => {}
+);
 
 // $ExpectType string
 service.serviceName;
 
 // $ExpectType object
 service.options;
-
 
 // ---- Client ----
 // $ExpectType Client
@@ -124,10 +125,9 @@ client.isServiceServerAvailable();
 // $ExpectType Promise<boolean>
 client.waitForService();
 
-
 // ---- Timer ----
 // ExpectType rclnodejs.TimerRequestCallback
-const timerCallback = () => { };
+const timerCallback = () => {};
 
 // $ExpectType Timer
 const timer = node.createTimer(100, timerCallback);
@@ -150,13 +150,11 @@ timer.isCanceled();
 // $ExpectType void
 timer.cancel();
 
-
 // ---- Duration ----
 // $ExpectType Duration
 const duration1: rclnodejs.Duration = new rclnodejs.Duration();
 
-const duration2: rclnodejs.Duration =
-	new rclnodejs.Duration(100, '1000');
+const duration2: rclnodejs.Duration = new rclnodejs.Duration(100, '1000');
 
 // $ExpectType string | number
 duration1.nanoseconds;
@@ -179,14 +177,15 @@ duration1.gt(duration2);
 // $ExpectType boolean
 duration1.gte(duration2);
 
-
 // ---- Time ----
 // $ExpectType Time
 const time1 = new rclnodejs.Time(100, 100);
 
 // $ExpectType Time
-const time2 = rclnodejs.Time.fromMsg('helloworld',
-	rclnodejs.ClockType.SYSTEM_TIME);
+const time2 = rclnodejs.Time.fromMsg(
+  'helloworld',
+  rclnodejs.ClockType.SYSTEM_TIME
+);
 
 // $ExpectType ClockType
 time1.clockType;
@@ -224,7 +223,6 @@ time1.gt(time2);
 // $ExpectType boolean
 time1.gte(time2);
 
-
 // ---- Clock -----
 // $ExpectType Clock
 const clock = new rclnodejs.Clock(rclnodejs.ClockType.SYSTEM_TIME);
@@ -235,10 +233,7 @@ clock.clockType;
 // $ExpectType Time
 clock.now();
 
-
 // ---- ROS Clock -----
-
-
 
 // ---- Logging -----
 // $ExpectType Logging
@@ -267,4 +262,3 @@ logger.error('test msg');
 
 // $ExpectType boolean
 logger.fatal('test msg');
-


### PR DESCRIPTION
Files within sub-folders were skipped by the `format` script and Windows doesn't seem to like single quoted strings.

All changes in this PR aside from the package.json are from Prettier.