### PR TITLE
Add getLogger to Node object

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -20,6 +20,7 @@ const Client = require('./client.js');
 const Clock = require('./clock.js');
 const Context = require('./context.js');
 const GuardCondition = require('./guard_condition.js');
+const Logging = require('./logging.js');
 const NodeOptions = require('./node_options.js');
 const {
   ParameterType,
@@ -57,6 +58,7 @@ class Node {
     this._parameters = new Map();
     this._parameterService = null;
     this._parameterEventPublisher = null;
+    this._logger = new Logging(rclnodejs.getNodeLoggerName(this.handle));
     this.spinning = false;
 
     this._parameterEventPublisher = this.createPublisher(
@@ -548,6 +550,14 @@ class Node {
    */
   namespace() {
     return rclnodejs.getNamespace(this.handle);
+  }
+
+  /**
+   * Get the nodes logger.
+   * @returns {Logger} - The logger for the node.
+   */
+  getLogger() {
+    return this._logger;
   }
 
   /**

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -1345,6 +1345,21 @@ NAN_METHOD(GetLoggerEffectiveLevel) {
   info.GetReturnValue().Set(Nan::New(logger_level));
 }
 
+NAN_METHOD(GetNodeLoggerName) {
+  RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(
+      Nan::To<v8::Object>(info[0]).ToLocalChecked());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+
+  const char* node_logger_name = rcl_node_get_logger_name(node);
+  if (!node_logger_name) {
+    info.GetReturnValue().Set(Nan::Undefined());
+    return;
+  }
+
+  info.GetReturnValue().Set(
+      Nan::New<v8::String>(node_logger_name).ToLocalChecked());
+}
+
 NAN_METHOD(Log) {
   v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
   std::string name(
@@ -1715,6 +1730,7 @@ BindingMethod binding_methods[] = {
     {"createArrayBufferCleaner", CreateArrayBufferCleaner},
     {"setLoggerLevel", setLoggerLevel},
     {"getLoggerEffectiveLevel", GetLoggerEffectiveLevel},
+    {"getNodeLoggerName", GetNodeLoggerName},
     {"log", Log},
     {"isEnableFor", IsEnableFor},
     {"createContext", CreateContext},

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -349,6 +349,16 @@ describe('rcl node methods testing', function() {
     });
   });
 
+  it('node.getLogger', function() {
+    var logger = node.getLogger();
+    assert.ok(logger);
+    assert.equal(logger.debug('message debug'), false);
+    assert.equal(logger.info('message info'), true);
+    assert.equal(logger.warn('message warn'), true);
+    assert.equal(logger.error('message error'), true);
+    assert.equal(logger.fatal('message fatal'), true);
+  });
+
   it('node.getNodeNames', function() {
     var nodeNames = node.getNodeNames();
 

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -45,6 +45,9 @@ node.name();
 // $ExpectType string
 node.namespace();
 
+// $ExpectType Logging
+node.getLogger();
+
 // $ExpectType void
 rclnodejs.spin(node);
 

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -1,5 +1,6 @@
 // eslint camelcase: ["error", {ignoreImports: true}]
 
+import { Logging } from 'rclnodejs';
 import { Parameters } from 'rclnodejs';
 import { rcl_interfaces as rclinterfaces } from 'rclnodejs';
 import { QoS } from 'rclnodejs';
@@ -156,6 +157,13 @@ declare module 'rclnodejs' {
      * @returns The node namespace.
      */
     namespace(): string;
+
+    /**
+     * Get the nodes logger.
+     * 
+     * @returns The logger for the node.
+     */
+    getLogger(): Logging;
 
     /**
      * Get the nodeOptions provided through the constructor.


### PR DESCRIPTION
Adds getLogger function to the Node class. Both rclcpp and rclpy provide a get_logger function on the Node class, but it was missing in rclnodejs.

Actions make use of this, but it's a really a separate feature.

Fix #None