### PR TITLE
Add getClock to Node object

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ const validator = require('./lib/validator.js');
 const Time = require('./lib/time.js');
 const TimeSource = require('./lib/time_source.js');
 const { Clock, ROSClock } = require('./lib/clock.js');
+const ClockType = require('./lib/clock_type.js');
 const Duration = require('./lib/duration.js');
 const Context = require('./lib/context.js');
 
@@ -98,6 +99,9 @@ let rcl = {
 
   /** {@link ROSClock} class */
   ROSClock: ROSClock,
+
+  /** {@link ClockType} enum */
+  ClockType: ClockType,
 
   /** {@link Duration} class */
   Duration: Duration,

--- a/lib/clock.js
+++ b/lib/clock.js
@@ -33,6 +33,13 @@ class Clock {
   }
 
   /**
+   * @ignore
+   */
+  get handle() {
+    return this._handle;
+  }
+
+  /**
    * Get ClockType of this Clock object.
    * @return {ClockType} Return the type of the clock.
    */

--- a/lib/node.js
+++ b/lib/node.js
@@ -32,6 +32,7 @@ const Publisher = require('./publisher.js');
 const QoS = require('./qos.js');
 const Service = require('./service.js');
 const Subscription = require('./subscription.js');
+const TimeSource = require('./time_source.js');
 const Timer = require('./timer.js');
 
 const debug = require('debug')('rclnodejs:node');
@@ -90,6 +91,13 @@ class Node {
         this._parameterDescriptors.set(parameter.name, descriptor);
       }
     }
+
+    // Clock that has support for ROS time.
+    // Note: parameter overrides and parameter event publisher need to be ready at this point
+    // to be able to declare 'use_sim_time' if it was not declared yet.
+    this._clock = new Clock.ROSClock();
+    this._timeSource = new TimeSource(this);
+    this._timeSource.attachClock(this._clock);
 
     if (options.startParameterServices) {
       this._parameterService = new ParameterService(this);
@@ -217,9 +225,15 @@ class Node {
    * @param {number} period - The number representing period in millisecond.
    * @param {function} callback - The callback to be called when timeout.
    * @param {Context} context - The context, default is Context.defaultContext().
+   * @param {Clock} clock - The clock which the timer gets time from.
    * @return {Timer} - An instance of Timer.
    */
-  createTimer(period, callback, context = Context.defaultContext()) {
+  createTimer(
+    period,
+    callback,
+    context = Context.defaultContext(),
+    clock = null
+  ) {
     if (typeof period !== 'number' || typeof callback !== 'function') {
       throw new TypeError('Invalid argument');
     }
@@ -237,7 +251,13 @@ class Node {
       );
     }
 
-    let timerHandle = rclnodejs.createTimer(period, context.handle());
+    const timerClock = clock || this._clock;
+
+    let timerHandle = rclnodejs.createTimer(
+      timerClock.handle,
+      context.handle(),
+      period
+    );
     let timer = new Timer(timerHandle, period, callback);
     debug('Finish creating timer, period = %d.', period);
     this._timers.push(timer);
@@ -458,6 +478,7 @@ class Node {
     }
 
     this.handle.release();
+    this._clock.handle.release();
     this._timers = [];
     this._publishers = [];
     this._subscriptions = [];
@@ -558,6 +579,14 @@ class Node {
    */
   getLogger() {
     return this._logger;
+  }
+
+  /**
+   * Get the clock used by the node.
+   * @returns {Clock} - The nodes clock.
+   */
+  getClock() {
+    return this._clock;
   }
 
   /**
@@ -1036,7 +1065,7 @@ class Node {
       PARAMETER_EVENT_MSG_TYPE
     ))();
 
-    const secondsAndNanos = new Clock.ROSClock().now().secondsAndNanoseconds;
+    const secondsAndNanos = this._clock.now().secondsAndNanoseconds;
     parameterEvent.stamp = {
       sec: secondsAndNanos.seconds,
       nanosec: secondsAndNanos.nanoseconds,

--- a/lib/node.js
+++ b/lib/node.js
@@ -478,7 +478,7 @@ class Node {
     }
 
     this.handle.release();
-    this._clock.handle.release();
+    this._clock = null;
     this._timers = [];
     this._publishers = [];
     this._subscriptions = [];

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -359,6 +359,12 @@ describe('rcl node methods testing', function() {
     assert.equal(logger.fatal('message fatal'), true);
   });
 
+  it('node.getClock', function() {
+    var clock = node.getClock();
+    assert.ok(clock);
+    assert.strictEqual(clock.clockType, rclnodejs.ClockType.ROS_TIME);
+  });
+
   it('node.getNodeNames', function() {
     var nodeNames = node.getNodeNames();
 

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -48,6 +48,9 @@ node.namespace();
 // $ExpectType Logging
 node.getLogger();
 
+// $ExpectType Clock
+node.getClock();
+
 // $ExpectType void
 rclnodejs.spin(node);
 

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -1,5 +1,6 @@
 // eslint camelcase: ["error", {ignoreImports: true}]
 
+import { Clock } from 'rclnodejs';
 import { Logging } from 'rclnodejs';
 import { Parameters } from 'rclnodejs';
 import { rcl_interfaces as rclinterfaces } from 'rclnodejs';
@@ -164,6 +165,13 @@ declare module 'rclnodejs' {
      * @returns The logger for the node.
      */
     getLogger(): Logging;
+
+    /**
+     * Get the clock used by the node.
+     * 
+     * @returns The nodes clock.
+     */
+    getClock(): Clock;
 
     /**
      * Get the nodeOptions provided through the constructor.


### PR DESCRIPTION
Adds an internal clock to rclnodejs nodes. In addition this also makes the following changes:

- Timer handles will now be children of the clock handle. This matches rclpy's implementation.
- Parameter events will use the node's clock instead of creating a new one each time.
- Exposes `ClockType` publicly.

Actions will also require use of the node's clock.

Fix #None