### PR TITLE
Adds Rate class for #564

### DIFF
--- a/example/rate-example.js
+++ b/example/rate-example.js
@@ -1,0 +1,49 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const rclnodejs = require('../index.js');
+
+/**
+ * This example demonstrates a rate limited loop running at
+ * 0.5 hz (once every 2 secs) and a publisher sending messages
+ * every 10 ms from an setInterval(). Thus, the subscriber is
+ * receiving only every 200th published message.
+ *
+ * To see every published message run this from commandline:
+ *   > ros2 topic echo topic 'std_msgs/msg/String'
+ *
+ * @return {undefined}
+ */
+async function main() {
+  await rclnodejs.init();
+  const node = rclnodejs.createNode('test_node');
+  const publisher = node.createPublisher('std_msgs/msg/String', 'topic');
+  const subscriptions = node.createSubscription(
+    'std_msgs/msg/String',
+    'topic',
+    undefined,
+    msg => console.log(`Received(${Date.now()}): ${msg.data}`)
+  );
+  const rate = node.createRate(0.5);
+
+  setInterval(() => publisher.publish(`hello ${Date.now()}`), 10);
+
+  let forever = true;
+  while (forever) {
+    await rate.sleep();
+    rclnodejs.spinOnce(node, 1000);
+  }
+}
+
+main();

--- a/lib/node.js
+++ b/lib/node.js
@@ -30,6 +30,7 @@ const {
 const ParameterService = require('./parameter_service.js');
 const Publisher = require('./publisher.js');
 const QoS = require('./qos.js');
+const Rates = require('./rate.js');
 const Service = require('./service.js');
 const Subscription = require('./subscription.js');
 const TimeSource = require('./time_source.js');
@@ -55,6 +56,7 @@ class Node {
     this._services = [];
     this._timers = [];
     this._guards = [];
+    this._rateTimerServer = null;
     this._parameterDescriptors = new Map();
     this._parameters = new Map();
     this._parameterService = null;
@@ -264,6 +266,36 @@ class Node {
     this.syncHandles();
 
     return timer;
+  }
+
+  /**
+   * Create a Rate.
+   *
+   * @param {number} hz - The frequency of the rate timer; default is 1 hz.
+   * @returns {Rate} - New instance
+   */
+  createRate(hz = 1) {
+    if (typeof hz !== 'number') {
+      throw new TypeError('Invalid argument');
+    }
+
+    const MAX_RATE_HZ_IN_MILLISECOND = 1000.0;
+    if (hz <= 0.0 || hz > MAX_RATE_HZ_IN_MILLISECOND) {
+      throw new RangeError(
+        `Hz must be between 0.0 and ${MAX_RATE_HZ_IN_MILLISECOND}`
+      );
+    }
+
+    // lazy initialize rateTimerServer
+    if (!this._rateTimerServer) {
+      this._rateTimerServer = new Rates.RateTimerServer(this);
+    }
+
+    const period = Math.round(1000 / hz);
+    const timer = this._rateTimerServer.createTimer(period);
+    const rate = new Rates.Rate(hz, timer);
+
+    return rate;
   }
 
   /**
@@ -485,6 +517,11 @@ class Node {
     this._clients = [];
     this._services = [];
     this._guards = [];
+
+    if (this._rateTimerServer) {
+      this._rateTimerServer.shutdown();
+      this._rateTimerServer = null;
+    }
   }
 
   /**

--- a/lib/rate.js
+++ b/lib/rate.js
@@ -1,0 +1,186 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const rclnodejs = require('bindings')('rclnodejs');
+const Context = require('./context.js');
+const NodeOptions = require('./node_options.js');
+
+const NOP_FN = () => {};
+
+/**
+ * A timer that runs at a regular frequency (hz).
+ *
+ * A client calls Rate#sleep() to block until the end of the current cycle.
+ * This makes Rate useful for looping at a regular frequency (hz). Rate#sleep()
+ * avoids blocking the JS event-loop by returning a Promise that the caller
+ * should block on, e.g. use 'await rate.sleep()'.
+ *
+ * Note that Rate.sleep() does not prevent rclnodejs from invoking callbacks
+ * such as a subscription or client if the entity's node is spinning. Thus
+ * if your intent is to use rate to synchronize when callbacks are invoked
+ * then use a spinOnce() just after rate.sleep() as in the example below.
+ *
+ * Rate runs within it's own private rcl context. This enables it to be
+ * available immediately after construction. That is, unlike Timer, Rate
+ * does not require a spin or spinOnce to be active.
+ *
+ * @example
+ * async function run() {
+ *   await rclnodejs.init();
+ *   const node = rclnodejs.createNode('mynode');
+ *   const rate = node.createRate(1); // 1 hz
+ *   while (true) {
+ *     doSomeStuff();
+ *     await rate.sleep();
+ *     rclnodejs.spinOnce(node);
+ *   }
+ * }
+ */
+class Rate {
+  /**
+   * Create a new instance.
+   * @hideconstructor
+   * @param {number} hz - The frequency (hz) between (0.0,1000] hz,
+   * @param {Timer} timer - The internal timer used by this instance.
+   *   default = 1 hz
+   */
+  constructor(hz, timer) {
+    this._hz = hz;
+    this._timer = timer;
+  }
+
+  /**
+   * Get the frequency in hertz (hz) of this timer.
+   *
+   * @returns {number} - hertz
+   */
+  get frequency() {
+    return this._hz;
+  }
+
+  /**
+   * Returns a Promise that when waited on, will block the sender
+   * until the end of the current timer cycle.
+   *
+   * If the Rate has been cancelled, calling this method will
+   * result in an error.
+   *
+   * @example
+   * (async () => {
+   *   await rate.sleep();
+   * })();
+   *
+   * @returns {Promise} - Waiting on the promise will delay the sender
+   * (not the Node event-loop) until the end of the current timer cycle.
+   */
+  async sleep() {
+    if (this.isCanceled()) {
+      throw new Error('Rate has been cancelled.');
+    }
+
+    return new Promise(resolve => {
+      this._timer.callback = () => {
+        this._timer.callback = NOP_FN;
+        resolve();
+      };
+    });
+  }
+
+  /**
+   * Permanently stops the timing behavior.
+   *
+   * @returns {undefined}
+   */
+  cancel() {
+    this._timer.cancel();
+  }
+
+  /**
+   * Determine if this rate has been cancelled.
+   *
+   * @returns {boolean} - True when cancel() has been called; False otherwise.
+   */
+  isCanceled() {
+    return this._timer.isCanceled();
+  }
+}
+
+/**
+ * Internal class that creates Timer instances in a common private rcl context
+ * for use with Rate. The private rcl context ensures that Rate timers do not
+ * deadlock waiting for spinOnce/spin on the main rcl context.
+ */
+class RateTimerServer {
+  /**
+   * Create a new instance.
+   *
+   * @constructor
+   * @param {Node} parentNode - The parent node for which this server
+   *  supplies timers to.
+   */
+  constructor(parentNode) {
+    this._context = new Context();
+
+    // init rcl environment
+    rclnodejs.init(this._context.handle());
+
+    // create hidden node
+    const nodeName = `_${parentNode.name()}_rate_timer_server`;
+    const nodeNamespace = parentNode.namespace();
+    this._node = new rclnodejs.ShadowNode();
+    this._node.handle = rclnodejs.createNode(
+      nodeName,
+      nodeNamespace,
+      this._context.handle()
+    );
+
+    const options = new NodeOptions();
+    options.startParameterServices = false;
+    options.parameterOverrides = parentNode.getParameters();
+    options.automaticallyDeclareParametersFromOverrides = true;
+
+    this._node.init(nodeName, nodeNamespace, this._context, options);
+
+    // spin node
+    this._node.startSpinning(this._context.handle(), 10);
+  }
+
+  /**
+   * Create a new timer instance with callback set to NOP.
+   *
+   * @param {number} period - The period in milliseconds
+   * @returns {Timer} - The new timer instance.
+   */
+  createTimer(period) {
+    const timer = this._node.createTimer(period, () => {}, this._context);
+    return timer;
+  }
+
+  /**
+   * Permanently cancel all timers produced by this server and discontinue
+   * the ability to create new Timers.
+   *
+   * The private rcl context is shutdown in the process and may not be
+   * restarted.
+   *
+   * @returns {undefined}
+   */
+  shutdown() {
+    this._node.destroy();
+    this._context.shutdown();
+  }
+}
+// module.exports = {Rate, RateTimerServer};
+module.exports = { Rate, RateTimerServer };

--- a/test/test-rate.js
+++ b/test/test-rate.js
@@ -1,0 +1,109 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+
+const isClose = require('is-close');
+const rclnodejs = require('../index.js');
+const assertUtils = require('./utils.js');
+const assertThrowsError = assertUtils.assertThrowsError;
+
+const { performance } = require('perf_hooks');
+
+describe('rclnodejs rate test suite', function() {
+  let node;
+  this.timeout(60 * 1000);
+
+  before(function() {
+    return rclnodejs.init();
+  });
+
+  after(function() {
+    rclnodejs.shutdown();
+  });
+
+  beforeEach(function() {
+    node = rclnodejs.createNode('rate_node');
+  });
+
+  afterEach(function() {
+    node.destroy();
+  });
+
+  it('rate constructor tests', function() {
+    const rate1 = node.createRate();
+    assert.equal(rate1.frequency, 1);
+
+    const rate2 = node.createRate(1000);
+    assert.equal(rate2.frequency, 1000);
+
+    const rate3 = node.createRate(0.001);
+    assert.equal(rate3.frequency, 0.001);
+
+    assertThrowsError(() => {
+      node.createRate(1001);
+    }, RangeError);
+
+    assertThrowsError(() => {
+      node.createRate(0);
+    }, RangeError);
+  });
+
+  it('rate api tests', function() {
+    const rate = node.createRate();
+    assert.equal(rate.frequency, 1);
+    assert.equal(rate.isCanceled(), false);
+  });
+
+  it('rate sleep cancel tests', async function() {
+    const rate = node.createRate();
+    assert.equal(rate.isCanceled(), false);
+
+    rate.cancel();
+    assert.ok(rate.isCanceled());
+
+    rate.cancel(); // redundant cancel is a nop
+  });
+
+  it('rate server node naming test', async function() {
+    const rate = node.createRate();
+    const rateTimerServerName = `_${node.name()}_rate_timer_server`;
+    assert.ok(node.getNodeNames().includes(rateTimerServerName));
+  });
+
+  it('rate sleep accuracy test, 1000 hz for 3 seconds', async function() {
+    // run 3 * hz,
+    //   collect and average the sleep intervals
+    //   compare average sleep interval with the period of the timer
+    const hz = 1000;
+    const rate = node.createRate(hz);
+
+    const dataSize = hz * 3;
+    const arr = new Array(dataSize).fill(0);
+    for (let i = 0; i < dataSize; i++) {
+      const start = performance.now();
+      await rate.sleep();
+      rclnodejs.spinOnce(node, 0);
+      const end = performance.now();
+      arr[i] = end - start;
+    }
+
+    const avg =
+      arr.reduce((prev, cur) => {
+        return prev + cur;
+      }, 0) / dataSize;
+    // console.log('data avg: ', avg);
+  });
+});

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -171,6 +171,22 @@ timer.isCanceled();
 // $ExpectType void
 timer.cancel();
 
+// ---- Rate ----
+// $ExpectType Rate
+const rate = node.createRate(1);
+
+// $ExpectType number
+rate.frequency;
+
+// $ExpectType boolean
+rate.isCanceled();
+
+// $ExpectType Promise<void>
+rate.sleep();
+
+// $ExpectType void
+rate.cancel();
+
 // ---- Duration ----
 // $ExpectType Duration
 const duration1: rclnodejs.Duration = new rclnodejs.Duration();

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -13,6 +13,7 @@
 /// <reference path="parameter.d.ts" />
 /// <reference path="publisher.d.ts" />
 /// <reference path="qos.d.ts" />
+/// <reference path="rate.d.ts" />
 /// <reference path="service.d.ts" />
 /// <reference path="subscription.d.ts" />
 /// <reference path="time_source.d.ts" />

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -193,6 +193,14 @@ declare module 'rclnodejs' {
     ): Timer;
 
     /**
+     * Create a Rate.
+     *
+     * @param hz - The frequency of the rate timer; default is 1 hz.
+     * @returns New instance of Rate.
+     */
+    createRate(hz: number): Rate;
+
+    /**
      * Create a Publisher.
      *
      * @param typeClass - Type of message that will be published.

--- a/types/rate.d.ts
+++ b/types/rate.d.ts
@@ -1,0 +1,71 @@
+declare module 'rclnodejs' {
+
+  /**
+   * A timer that runs at a regular frequency (hz).
+   *
+   * A client calls Rate#sleep() to block until the end of the current cycle.
+   * This makes Rate useful for looping at a regular frequency (hz). Rate#sleep()
+   * avoids blocking the JS event-loop by returning a Promise that the caller 
+   * should block on, e.g. use 'await rate.sleep()'. 
+   * 
+   * Note that Rate.sleep() does not prevent rclnodejs from invoking callbacks 
+   * such as a subscription or client if the entity's node is spinning. Thus
+   * if your intent is to use rate to synchronize when callbacks are invoked 
+   * then use a spinOnce() just after rate.sleep() as in the example below. 
+   * 
+   * Rate runs within it's own private rcl context. This enables it to be 
+   * available immediately after construction. That is, unlike Timer, Rate 
+   * does not require a spin or spinOnce to be active.
+   *
+   * @example
+   * async function run() {
+   *   await rclnodejs.init();
+   *   const node = rclnodejs.createNode('mynode');
+   *   const rate = node.createRate(1); // 1 hz
+   *   while (true) {
+   *     doSomeStuff();
+   *     await rate.sleep();
+   *     rclnodejs.spinOnce(node);
+   *   }
+   * }
+   */
+  export class Rate {
+
+  /**
+   * Get the frequency in hertz (hz) of this timer.
+   * 
+   * @returns hertz
+   */
+  readonly frequency: number;
+
+  /**
+   * Returns a Promise that when waited on, will block the sender
+   * until the end of the current timer cycle.
+   * 
+   * If this Rate has been cancelled, calling this sleep() will
+   * result in an error.
+   * 
+   * Note that the Node event-loop is not blocked when a rate is sleep()'ing.
+   * 
+   * @example
+   * (async () => {
+   *   await rate.sleep();
+   * })();
+   * 
+   * @returns A promise
+   */
+  sleep(): Promise<void>;
+
+  /**
+   * Permanently stops the rate's timer.
+   */
+  cancel(): void;
+
+  /**
+   * Determine if this rate has been cancelled.
+   * 
+   * @returns True when cancel() has been called; False otherwise.
+   */
+  isCanceled(): boolean;
+  }
+}


### PR DESCRIPTION
Implements a Rate timer based on the rclpy Rate timer. See issue #564.
Includes:
* update node, added node#createRate(hz)
* lib/rate.js
* types/rate.d.ts
* test/test-rate.js
* updated test/types/main.ts

Note for reviewers:
* See RateTimer in rate.js. This class runs a Timer in private rcl context. 