### PR TITLE
Time fromMsg() fix #601

### DIFF
--- a/lib/time.js
+++ b/lib/time.js
@@ -251,12 +251,13 @@ class Time {
 
   /**
    * Create a Time object from a message of builtin_interfaces/msg/Time
-   * @param {object} msg - The message to be created from.
-   * @param {ClockType} [clockType=Clock.ClockType.SYSTEM_TIME] - The type of the time object.
+   * @param {object} msg - The builtin_interfaces.msg.Time message to be
+   *  created from.
+   * @param {ClockType} [clockType=Clock.ClockType.ROS_TIME] - The type of the time object.
    * @return {Time} Return the created Time object.
    */
   static fromMsg(msg, clockType = ClockType.ROS_TIME) {
-    return new Time(msg.sec, msg.nanoseconds, clockType);
+    return new Time(msg.sec, msg.nanosec, clockType);
   }
 }
 

--- a/test/test-time.js
+++ b/test/test-time.js
@@ -45,6 +45,10 @@ describe('rclnodejs Time/Clock testing', function() {
     time = new Time(0, '9223372036854775807');
     assert.strictEqual(time.nanoseconds, '9223372036854775807');
 
+    time = Time.fromMsg({ sec: 1, nanosec: 64 });
+    assert.strictEqual(time.nanoseconds, 1000000064);
+    assert.strictEqual(time.clockType, ClockType.ROS_TIME);
+
     assert.throws(() => {
       new Time(1, 1, 'SYSTEM_TIME');
     }, TypeError);

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -203,10 +203,11 @@ duration1.gte(duration2);
 const time1 = new rclnodejs.Time(100, 100);
 
 // $ExpectType Time
-const time2 = rclnodejs.Time.fromMsg(
-  'helloworld',
-  rclnodejs.ClockType.SYSTEM_TIME
-);
+const time2 = rclnodejs.Time.fromMsg({sec: 0, nanosec: 0});
+
+// $ExpectType Time
+const time3 =
+  rclnodejs.Time.fromMsg({sec: 0, nanosec: 0}, rclnodejs.ClockType.ROS_TIME);
 
 // $ExpectType ClockType
 time1.clockType;

--- a/types/time.d.ts
+++ b/types/time.d.ts
@@ -1,4 +1,6 @@
-import { Message } from 'rclnodejs';
+
+// eslint-disable-next-line camelcase
+import { Message, builtin_interfaces } from 'rclnodejs';
 
 declare module 'rclnodejs' {
   /**
@@ -102,10 +104,11 @@ declare module 'rclnodejs' {
     /**
      * Create a Time object from a message of builtin_interfaces/msg/Time
      *
-     * @param msg - The message to be created from.
-     * @param clockType- The type of the time object.
+     * @param msg - The Time message to be created from.
+     * @param clockType - The type of the time object. Default is ClockType.ROS_TIME
      * @returns The new Time.
      */
-    static fromMsg(msg: Message, clockType: ClockType): Time;
+    // eslint-disable-next-line camelcase
+    static fromMsg(msg: builtin_interfaces.msg.Time, clockType?: ClockType): Time;
   }
 }


### PR DESCRIPTION
Fix for issue #601.

time.js fromMsg()
- fixed invalid nanoseconds property access
- improved Time#fromMsg() jsdoc

time.d.ts fromMsg()
- changed msg parameter type to builtin_interfaces.msg.Time
- changed clockType parameter to optional
- improved tsdoc

test-time.js
- enhanced test to include Time#fromMsg()