### PR TITLE
use_sim_time parameter support #599

### DIFF
--- a/example/parameter-declaration-example.js
+++ b/example/parameter-declaration-example.js
@@ -16,9 +16,9 @@
 
 const rclnodejs = require('../index.js');
 
-const ParameterType = rclnodejs.Parameters.ParameterType;
-const Parameter = rclnodejs.Parameters.Parameter;
-const ParameterDescriptor = rclnodejs.Parameters.ParameterDescriptor;
+const ParameterType = rclnodejs.ParameterType;
+const Parameter = rclnodejs.Parameter;
+const ParameterDescriptor = rclnodejs.ParameterDescriptor;
 
 async function main() {
   await rclnodejs.init();

--- a/example/parameter-override-example.js
+++ b/example/parameter-override-example.js
@@ -12,9 +12,9 @@
 
 const rclnodejs = require('../index.js');
 
-const ParameterType = rclnodejs.Parameters.ParameterType;
-const Parameter = rclnodejs.Parameters.Parameter;
-const ParameterDescriptor = rclnodejs.Parameters.ParameterDescriptor;
+const ParameterType = rclnodejs.ParameterType;
+const Parameter = rclnodejs.Parameter;
+const ParameterDescriptor = rclnodejs.ParameterDescriptor;
 
 async function main() {
   const NODE_NAME = 'my_node';

--- a/index.js
+++ b/index.js
@@ -14,15 +14,26 @@
 
 'use strict';
 
+const { Clock, ROSClock } = require('./lib/clock.js');
+const ClockType = require('./lib/clock_type.js');
 const compareVersions = require('compare-versions');
+const Context = require('./lib/context.js');
 const debug = require('debug')('rclnodejs');
+const Duration = require('./lib/duration.js');
 const fs = require('fs');
 const generator = require('./rosidl_gen/index.js');
 const loader = require('./lib/interface_loader.js');
 const logging = require('./lib/logging.js');
 const Node = require('./lib/node.js');
 const NodeOptions = require('./lib/node_options.js');
-const Parameters = require('./lib/parameter.js');
+const {
+  FloatingPointRange,
+  IntegerRange,
+  Parameter,
+  ParameterDescriptor,
+  ParameterType,
+  DEFAULT_NUMERIC_RANGE_TOLERANCE,
+} = require('./lib/parameter.js');
 const path = require('path');
 const QoS = require('./lib/qos.js');
 const rclnodejs = require('bindings')('rclnodejs');
@@ -30,10 +41,6 @@ const tsdGenerator = require('./rostsd_gen/index.js');
 const validator = require('./lib/validator.js');
 const Time = require('./lib/time.js');
 const TimeSource = require('./lib/time_source.js');
-const { Clock, ROSClock } = require('./lib/clock.js');
-const ClockType = require('./lib/clock_type.js');
-const Duration = require('./lib/duration.js');
-const Context = require('./lib/context.js');
 
 function inherits(target, source) {
   let properties = Object.getOwnPropertyNames(source.prototype);
@@ -76,17 +83,53 @@ let rcl = {
   _initialized: false,
   _nodes: [],
 
+  /** {@link Clock} class */
+  Clock: Clock,
+
+  /** {@link ClockType} enum */
+  ClockType: ClockType,
+
   /** {@link Context} class */
   Context: Context,
 
-  /** {@link QoS} class */
-  QoS: QoS,
+  /**
+   * @constant {number}
+   * The plus/minus tolerance for determining number equivalence.
+   *
+   *  @see [FloatingPointRange]{@link FloatingPointRange}
+   *  @see [IntegerRange]{@link IntegerRange}
+   */
+  DEFAULT_NUMERIC_RANGE_TOLERANCE: DEFAULT_NUMERIC_RANGE_TOLERANCE,
+
+  /** {@link Duration} class */
+  Duration: Duration,
+
+  /** {@link FloatingPointRange} class */
+  FloatingPointRange: FloatingPointRange,
+
+  /** {@link IntegerRange} class */
+  IntegerRange: IntegerRange,
 
   /** {@link Logging} class */
   logging: logging,
 
-  /** {@link module:validator|validator} object */
-  validator: validator,
+  /** {@link NodeOptions} class */
+  NodeOptions: NodeOptions,
+
+  /** {@link Parameter} */
+  Parameter: Parameter,
+
+  /** {@link ParameterDescriptor} */
+  ParameterDescriptor: ParameterDescriptor,
+
+  /** {@link ParameterType} */
+  ParameterType: ParameterType,
+
+  /** {@link QoS} class */
+  QoS: QoS,
+
+  /** {@link ROSClock} class */
+  ROSClock: ROSClock,
 
   /** {@link Time} class */
   Time: Time,
@@ -94,23 +137,8 @@ let rcl = {
   /** {@link TimeSource} class */
   TimeSource: TimeSource,
 
-  /** {@link Clock} class */
-  Clock: Clock,
-
-  /** {@link ROSClock} class */
-  ROSClock: ROSClock,
-
-  /** {@link ClockType} enum */
-  ClockType: ClockType,
-
-  /** {@link Duration} class */
-  Duration: Duration,
-
-  /** {@link NodeOptions} class */
-  NodeOptions: NodeOptions,
-
-  /** {@link Parameters} */
-  Parameters: Parameters,
+  /** {@link module:validator|validator} object */
+  validator: validator,
 
   /**
    * Create a node.

--- a/lib/node.js
+++ b/lib/node.js
@@ -14,12 +14,12 @@
 
 'use strict';
 
-const rclnodejs = require('bindings')('rclnodejs');
-
 const Client = require('./client.js');
 const Clock = require('./clock.js');
 const Context = require('./context.js');
+const debug = require('debug')('rclnodejs:node');
 const GuardCondition = require('./guard_condition.js');
+const loader = require('./interface_loader.js');
 const Logging = require('./logging.js');
 const NodeOptions = require('./node_options.js');
 const {
@@ -31,13 +31,11 @@ const ParameterService = require('./parameter_service.js');
 const Publisher = require('./publisher.js');
 const QoS = require('./qos.js');
 const Rates = require('./rate.js');
+const rclnodejs = require('bindings')('rclnodejs');
 const Service = require('./service.js');
 const Subscription = require('./subscription.js');
 const TimeSource = require('./time_source.js');
 const Timer = require('./timer.js');
-
-const debug = require('debug')('rclnodejs:node');
-const loader = require('./interface_loader.js');
 
 // Parameter event publisher constants
 const PARAMETER_EVENT_MSG_TYPE = 'rcl_interfaces/msg/ParameterEvent';
@@ -61,6 +59,7 @@ class Node {
     this._parameters = new Map();
     this._parameterService = null;
     this._parameterEventPublisher = null;
+    this._setParametersCallbacks = [];
     this._logger = new Logging(rclnodejs.getNodeLoggerName(this.handle));
     this.spinning = false;
 
@@ -801,6 +800,13 @@ class Node {
    * If a parameter by the same name has already been declared then an Error is thrown.
    * A parameter must be undeclared before attempting to redeclare it.
    *
+   * Prior to declaring the parameters each SetParameterEventCallback registered
+   * using setOnParameterEventCallback() is called in succession with the parameters
+   * list. Any SetParameterEventCallback that retuns does not return a successful
+   * result will cause the entire operation to terminate with no changes to the
+   * parameters. When all SetParameterEventCallbacks return successful then the
+   * list of parameters is updated.
+   *
    * @param {Parameter[]} parameters - The parameters to declare.
    * @param {ParameterDescriptor[]} [descriptors] - Optional descriptors,
    *    a 1-1 correspondence with parameters.
@@ -851,7 +857,7 @@ class Node {
     }
 
     if (declaredParameterCollisions.length > 0) {
-      errorMsg =
+      const errorMsg =
         declaredParameterCollisions.length == 1
           ? `Parameter(${declaredParameterCollisions[0]}) already declared.`
           : `Multiple parameters already declared, e.g., Parameter(${declaredParameterCollisions[0]}).`;
@@ -1042,6 +1048,13 @@ class Node {
    * Declared parameters are replaced in the order they are provided and
    * a ParameterEvent is published for each individual parameter change.
    *
+   * Prior to setting the parameters each SetParameterEventCallback registered
+   * using setOnParameterEventCallback() is called in succession with the parameters
+   * list. Any SetParameterEventCallback that retuns does not return a successful
+   * result will cause the entire operation to terminate with no changes to the
+   * parameters. When all SetParameterEventCallbacks return successful then the
+   * list of parameters is updated.
+   *
    * If an error occurs, the process is stopped and returned. Parameters
    * set before an error remain unchanged.
    *
@@ -1061,6 +1074,13 @@ class Node {
    * A single ParameterEvent is published collectively for all changed
    * parameters.
    *
+   * Prior to setting the parameters each SetParameterEventCallback registered
+   * using setOnParameterEventCallback() is called in succession with the parameters
+   * list. Any SetParameterEventCallback that retuns does not return a successful
+   * result will cause the entire operation to terminate with no changes to the
+   * parameters. When all SetParameterEventCallbacks return successful then the
+   * list of parameters is updated.d
+   *
    * If an error occurs, the process stops immediately. All parameters updated to
    * the point of the error are reverted to their previous state.
    *
@@ -1074,6 +1094,13 @@ class Node {
   /**
    * Internal method for updating parameters atomically.
    *
+   * Prior to setting the parameters each SetParameterEventCallback registered
+   * using setOnParameterEventCallback() is called in succession with the parameters
+   * list. Any SetParameterEventCallback that retuns does not return a successful
+   * result will cause the entire operation to terminate with no changes to the
+   * parameters. When all SetParameterEventCallbacks return successful then the
+   * list of parameters is updated.
+   *
    * @param {Paramerter[]} parameters - The parameters to update.
    * @param {boolean} declareParameterMode - When true parameters are being declared;
    *    otherwise they are being changed.
@@ -1083,6 +1110,15 @@ class Node {
     let result = this._validateParameters(parameters, declareParameterMode);
     if (!result.successful) {
       return result;
+    }
+
+    // give all SetParametersCallbacks a chance to veto this change
+    for (const callback of this._setParametersCallbacks) {
+      result = callback(parameters);
+      if (!result.successful) {
+        // a callback has vetoed a parameter change
+        return result;
+      }
     }
 
     // collectively track updates to parameters for use
@@ -1144,6 +1180,44 @@ class Node {
       successful: true,
       reason: '',
     };
+  }
+
+  /**
+   * This callback is called when declaring a parameter or setting a parameter.
+   * The callback is provided a list of parameters and returns a SetParameterResult
+   * to indicate approval or veto of the operation.
+   *
+   * @callback SetParametersCallback
+   * @param {Parameter[]} parameters - The message published
+   * @returns {rcl_interfaces.msg.SetParameterResult} -
+   *
+   * @see [Node.addOnSetParametersCallback]{@link Node#addOnSetParametersCallback}
+   * @see [Node.removeOnSetParametersCallback]{@link Node#removeOnSetParametersCallback}
+   */
+
+  /**
+   * Add a callback to the front of the list of callbacks invoked for parameter declaration
+   * and setting. No checks are made for duplicate callbacks.
+   *
+   * @param {SetParametersCallback} callback - The callback to add.
+   * @returns {undefined}
+   */
+  addOnSetParametersCallback(callback) {
+    this._setParametersCallbacks.unshift(callback);
+  }
+
+  /**
+   * Remove a callback from the list of SetParametersCallbacks.
+   * If the callback is not found the process is a nop.
+   *
+   * @param {SetParametersCallback} callback - The callback to be removed
+   * @returns {undefined}
+   */
+  removeOnSetParametersCallback(callback) {
+    const idx = this._setParametersCallbacks.indexOf(callback);
+    if (idx > -1) {
+      this._setParametersCallbacks.splice(idx, 1);
+    }
   }
 
   // returns on 1st error or result {successful, reason}

--- a/lib/parameter.js
+++ b/lib/parameter.js
@@ -24,7 +24,15 @@
 const IsClose = require('is-close');
 const rclnodejs = require('bindings')('rclnodejs');
 
-const PARAMETER_REL_TOL = 1e-6;
+/**
+ * @constant {number}
+ * The plus/minus tolerance for determining number equivalence.
+ *
+ *  @see [FloatingPointRange]{@link FloatingPointRange}
+ *  @see [IntegerRange]{@link IntegerRange}
+ */
+const DEFAULT_NUMERIC_RANGE_TOLERANCE = 1e-6;
+
 const PARAMETER_SEPARATOR = '.';
 
 /**
@@ -572,9 +580,20 @@ class FloatingPointRange extends Range {
    * @param {number} fromValue - The lowest inclusive value in range
    * @param {number} toValue - The highest inclusive value in range
    * @param {number} step - The internal unit size.
+   * @param {number} tolerance - The plus/minus tolerance for number equivalence.
    */
-  constructor(fromValue, toValue, step = 1) {
+  constructor(
+    fromValue,
+    toValue,
+    step = 1,
+    tolerance = DEFAULT_NUMERIC_RANGE_TOLERANCE
+  ) {
     super(fromValue, toValue, step);
+    this._tolerance = tolerance;
+  }
+
+  get tolerance() {
+    return this._tolerance;
   }
 
   /**
@@ -604,8 +623,8 @@ class FloatingPointRange extends Range {
     const max = Math.max(this.fromValue, this.toValue);
 
     if (
-      IsClose.isClose(value, min, PARAMETER_REL_TOL) ||
-      IsClose.isClose(value, max, PARAMETER_REL_TOL)
+      IsClose.isClose(value, min, this.tolerance) ||
+      IsClose.isClose(value, max, this.tolerance)
     ) {
       return true;
     }
@@ -618,7 +637,7 @@ class FloatingPointRange extends Range {
         !IsClose.isClose(
           min + distanceInSteps * this.step,
           value,
-          PARAMETER_REL_TOL
+          this.tolerance
         )
       ) {
         return false;
@@ -640,9 +659,20 @@ class IntegerRange extends FloatingPointRange {
    * @param {number} fromValue - The lowest inclusive value in range
    * @param {number} toValue - The highest inclusive value in range
    * @param {number} step - The internal unit size.
+   * @param {number} tolerance - The plus/minus tolerance for number equivalence.
    */
-  constructor(fromValue, toValue, step = 1) {
-    super(Math.trunc(fromValue), Math.trunc(toValue), Math.trunc(step));
+  constructor(
+    fromValue,
+    toValue,
+    step = 1,
+    tolerance = DEFAULT_NUMERIC_RANGE_TOLERANCE
+  ) {
+    super(
+      Math.trunc(fromValue),
+      Math.trunc(toValue),
+      Math.trunc(step),
+      tolerance
+    );
   }
 
   /**
@@ -793,5 +823,5 @@ module.exports = {
   Range,
   FloatingPointRange,
   IntegerRange,
-  PARAMETER_REL_TOL,
+  DEFAULT_NUMERIC_RANGE_TOLERANCE,
 };

--- a/lib/time_source.js
+++ b/lib/time_source.js
@@ -18,7 +18,11 @@ const rclnodejs = require('bindings')('rclnodejs');
 const { Clock, ROSClock } = require('./clock.js');
 const { ClockType } = Clock;
 const Node = require('./node.js');
+const { Parameter, ParameterType } = require('./parameter.js');
 const Time = require('./time.js');
+
+const USE_SIM_TIME_PARAM = 'use_sim_time';
+const CLOCK_TOPIC = 'clock';
 
 /**
  * @class - Class representing a TimeSource in ROS
@@ -38,6 +42,26 @@ class TimeSource {
 
     if (this._node) {
       this.attachNode(this._node);
+    }
+  }
+
+  get isRosTimeActive() {
+    return this._isRosTimeActive;
+  }
+
+  set isRosTimeActive(enabled) {
+    if (this.isRosTimeActive === enabled) return;
+
+    this._isRosTimeActive = enabled;
+    for (const clock in this._associatedClocks) {
+      clock.isRosTimeActive = enabled;
+    }
+
+    if (enabled) {
+      this._subscribeToClockTopic();
+    } else if (this._node && this._clockSubscription) {
+      this._node.destroySubscription(this._clockSubscription);
+      this._node._clockSubscription = null;
     }
   }
 
@@ -78,17 +102,46 @@ class TimeSource {
    * @return {undefined}
    */
   attachNode(node) {
-    if (node instanceof rclnodejs.ShadowNode) {
-      if (this._node) {
-        this.detachNode();
-      }
-      this._node = node;
-      if (this.isRosTimeActive) {
-        this._subscribeToClockTopic();
-      }
-    } else {
+    if (!node instanceof rclnodejs.ShadowNode) {
       throw new TypeError('Invalid argument, must be type of Node');
     }
+
+    if (this._node) {
+      this.detachNode();
+    }
+
+    this._node = node;
+
+    if (!node.hasParameter(USE_SIM_TIME_PARAM)) {
+      node.declareParameter(
+        new Parameter(USE_SIM_TIME_PARAM, ParameterType.PARAMETER_BOOL, false)
+      );
+    }
+
+    const useSimTimeParam = node.getParameter(USE_SIM_TIME_PARAM);
+    if (useSimTimeParam.type !== ParameterType.PARAMETER_NOT_SET) {
+      if (useSimTimeParam.type === ParameterType.PARAMETER_BOOL) {
+        this._isRosTimeActive = useSimTimeParam.value;
+      } else {
+        node
+          .getLogger()
+          .error(
+            `Invalid type for parameter ${USE_SIM_TIME_PARAM} ${useSimTimeParam.type} should be bool`
+          );
+      }
+    } else {
+      node
+        .getLogger()
+        .debug(
+          `${USE_SIM_TIME_PARAM}' parameter not set, using wall time by default`
+        );
+    }
+
+    if (this.isRosTimeActive) {
+      this._subscribeToClockTopic();
+    }
+
+    node.addOnSetParametersCallback(this.onParameterEvent.bind(this));
   }
 
   /**
@@ -133,10 +186,33 @@ class TimeSource {
     if (!this._clockSubscription && this._node) {
       this._clockSubscription = this._node.createSubscription(
         'builtin_interfaces/msg/Time',
-        'clock',
+        CLOCK_TOPIC,
         this._clockCallback.bind(this)
       );
     }
+  }
+
+  onParameterEvent(parameters = []) {
+    for (const parameter of parameters) {
+      if (parameter.name === USE_SIM_TIME_PARAM) {
+        if (parameter.type === ParameterType.PARAMETER_BOOL) {
+          this.isRosTimeActive = parameter.value;
+        } else if (this._node) {
+          this._node
+            .getLogger()
+            .error(
+              `${USE_SIM_TIME_PARAM} parameter set to something besides a bool`
+            );
+        }
+
+        break;
+      }
+    }
+
+    return {
+      successful: true,
+      reason: '',
+    };
   }
 }
 

--- a/test/test-parameter-service.js
+++ b/test/test-parameter-service.js
@@ -121,7 +121,7 @@ describe('Parameter_server tests', function() {
     let success = false;
     client.sendRequest(request, response => {
       const result = response.result;
-      assert.equal(result.names.length, 2);
+      assert.equal(result.names.length, 3); // account for use_sim_time parameter
       assert.ok(result.names.includes('p1'));
       assert.ok(result.names.includes('p2'));
       success = true;

--- a/test/test-rate.js
+++ b/test/test-rate.js
@@ -19,19 +19,14 @@ const isClose = require('is-close');
 const rclnodejs = require('../index.js');
 const assertUtils = require('./utils.js');
 const assertThrowsError = assertUtils.assertThrowsError;
-
 const { performance } = require('perf_hooks');
 
 describe('rclnodejs rate test suite', function() {
   let node;
   this.timeout(60 * 1000);
 
-  before(function() {
-    return rclnodejs.init();
-  });
-
-  after(function() {
-    rclnodejs.shutdown();
+  before(async function() {
+    await rclnodejs.init();
   });
 
   beforeEach(function() {
@@ -40,6 +35,10 @@ describe('rclnodejs rate test suite', function() {
 
   afterEach(function() {
     node.destroy();
+  });
+
+  after(function() {
+    rclnodejs.shutdown();
   });
 
   it('rate constructor tests', function() {

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -1,10 +1,11 @@
-// eslint camelcase: ["error", {ignoreImports: true}]
+/* eslint-disable camelcase */
 
 import { Clock } from 'rclnodejs';
 import { Logging } from 'rclnodejs';
-import { Parameters } from 'rclnodejs';
-import { rcl_interfaces as rclinterfaces } from 'rclnodejs';
+import { Parameter, ParameterDescriptor, ParameterType } from 'rclnodejs';
 import { QoS } from 'rclnodejs';
+import { rcl_interfaces } from 'rclnodejs';
+
 
 declare module 'rclnodejs' {
   /**
@@ -104,6 +105,22 @@ declare module 'rclnodejs' {
    * See {@link Timer}
    */
   type TimerRequestCallback = () => void;
+
+  /**
+   * Callback indicating parameters are about to be declared or set.
+   * The callback is provided a list of parameters and returns a SetParameterResult
+   * to indicate approval or veto of the operation.
+   * 
+   * @param parameters - The parameters to be declared or set
+   * @returns A successful property value of true indicates approval of the operation;
+   *  otherwise indicates a veto of the operation. 
+   * 
+   * @remarks
+   * See {@link Node.addOnSetParametersCallback | Node.addOnSetParametersCallback}
+   * See {@link Node.removeOnSetParametersCallback | Node.removeOnSetParametersCallback}
+   */
+  type SetParametersCallback = 
+    (parameters: Parameter[]) => rcl_interfaces.msg.SetParametersResult;
 
   /**
    * Standard result of Node.getXXXNamesAndTypes() queries
@@ -273,7 +290,7 @@ declare module 'rclnodejs' {
      * Create a guard condition.
      *
      * @param callback - The callback to be called when the guard condition is triggered.
-     * @return An instance of GuardCondition.
+     * @returns An instance of GuardCondition.
      */
     createGuardCondition(callback: () => any): GuardCondition;
 
@@ -337,10 +354,10 @@ declare module 'rclnodejs' {
      * @returns The newly declared parameter.
      */
     declareParameter(
-      parameter: Parameters.Parameter,
-      descriptor?: Parameters.ParameterDescriptor,
+      parameter: Parameter,
+      descriptor?: ParameterDescriptor,
       ignoreOveride?: boolean
-    ): Parameters.Parameter;
+    ): Parameter;
 
     /**
      * Declare a list of parameters.
@@ -369,10 +386,10 @@ declare module 'rclnodejs' {
      * @returns The declared parameters.
      */
     declareParameters(
-      parameters: Array<Parameters.Parameter>,
-      descriptors?: Array<Parameters.ParameterDescriptor>,
+      parameters: Array<Parameter>,
+      descriptors?: Array<ParameterDescriptor>,
       ignoreOverrides?: boolean
-    ): Array<Parameters.Parameter>;
+    ): Array<Parameter>;
 
     /**
      * Undeclare a parameter.
@@ -400,7 +417,7 @@ declare module 'rclnodejs' {
      * @returns The parameter.
      */
 
-    getParameter(name: string): Parameters.Parameter;
+    getParameter(name: string): Parameter;
 
     /**
      * Get a list of parameters.
@@ -417,12 +434,12 @@ declare module 'rclnodejs' {
      * @returns The parameters.
      */
 
-    getParameters(name?: Array<string>): Array<Parameters.Parameter>;
+    getParameters(name?: Array<string>): Array<Parameter>;
 
     /**
      * Get the names of all declared parameters.
      *
-     * @returna The declared parameter names or empty array if
+     * @returns The declared parameter names or empty array if
      *    no parameters have been declared.
      */
     getParameterNames(): Array<string>;
@@ -431,9 +448,9 @@ declare module 'rclnodejs' {
      * Get the list of parameter-overrides found on the commandline and
      * in the NodeOptions.parameter_overrides property.
      *
-     * @return An array of Parameters
+     * @returns An array of Parameters
      */
-    getParameterOverrides(): Array<Parameters.Parameter>;
+    getParameterOverrides(): Array<Parameter>;
 
     /**
      * Determine if a parameter descriptor exists.
@@ -452,7 +469,7 @@ declare module 'rclnodejs' {
      * @param name - The name of the parameter descriptor to find.
      * @returns The parameter descriptor.
      */
-    getParameterDescriptor(name: string): Parameters.ParameterDescriptor;
+    getParameterDescriptor(name: string): ParameterDescriptor;
 
     /**
      * Find a list of declared ParameterDescriptors.
@@ -465,9 +482,9 @@ declare module 'rclnodejs' {
      *
      * @param names - The names of the declared parameter
      *    descriptors to find or null indicating to return all declared descriptors.
-     * @return The parameter descriptors.
+     * @returns The parameter descriptors.
      */
-    getParameterDescriptors(name?: string[]): Parameters.ParameterDescriptor[];
+    getParameterDescriptors(name?: string[]): ParameterDescriptor[];
 
     /**
      * Replace a declared parameter.
@@ -479,8 +496,8 @@ declare module 'rclnodejs' {
      * @returns The result of the operation.
      */
     setParameter(
-      parameter: Parameters.Parameter
-    ): rclinterfaces.msg.SetParametersResult;
+      parameter: Parameter
+    ): rcl_interfaces.msg.SetParametersResult;
 
     /**
      * Replace a list of declared parameters.
@@ -495,8 +512,8 @@ declare module 'rclnodejs' {
      * @returns An array of SetParameterResult, one for each parameter that was set.
      */
     setParameters(
-      parameters: Array<Parameters.Parameter>
-    ): Array<rclinterfaces.msg.SetParametersResult>;
+      parameters: Array<Parameter>
+    ): Array<rcl_interfaces.msg.SetParametersResult>;
 
     /**
      * Repalce a list of declared parameters atomically.
@@ -509,11 +526,27 @@ declare module 'rclnodejs' {
      * the point of the error are reverted to their previous state.
      *
      * @param parameters - The parameters to set.
-     * @returns Describes the result of setting 1 or more parameters.
+     * @returns Describes the result of setting 1 or more 
      */
     setParametersAtomically(
-      parameters: Array<Parameters.Parameter>
-    ): rclinterfaces.msg.SetParametersResult;
+      parameters: Array<Parameter>
+    ): rcl_interfaces.msg.SetParametersResult;
+
+    /**
+     * Add a callback to the front of the list of callbacks invoked for parameter declaration
+     * and setting. No checks are made for duplicate callbacks.
+     * 
+     * @param callback - The callback to add. 
+     */
+    addOnSetParametersCallback(callback: SetParametersCallback): void; 
+
+    /**
+     * Remove a callback from the list of SetParameterCallbacks.
+     * If the callback is not found the process is a nop.
+     * 
+     * @param callback - The callback to be removed
+     */
+    removeOnSetParametersCallback(call: SetParametersCallback): void;
 
     /**
      * Get a remote node's published topics.

--- a/types/node_options.d.ts
+++ b/types/node_options.d.ts
@@ -1,7 +1,5 @@
 // eslint camelcase: ["error", {ignoreImports: true}]
 
-import { Parameters } from 'rclnodejs';
-
 declare module 'rclnodejs' {
   /**
    * NodeOptions specify configuration choices during the
@@ -26,7 +24,7 @@ declare module 'rclnodejs' {
      * An array of Parameters that serve as overrides for a node's default
      * parameters. Default = empty array [].
      */
-    parameterOverrides: Array<Parameters.Parameter>;
+    parameterOverrides: Array<Parameter>;
 
     /**
      * Instructs a node if it should declare parameters from it's 

--- a/types/parameter.d.ts
+++ b/types/parameter.d.ts
@@ -1,303 +1,287 @@
-// eslint camelcase: ["error", {ignoreImports: true}]
+/* eslint-disable camelcase */
 
-import { rcl_interfaces as rclinterfaces } from 'rclnodejs';
+import { rcl_interfaces, rclnodejs } from 'rclnodejs';
 
 declare module 'rclnodejs' {
-  namespace Parameters {
-    /**
-     * Type identifier for a parameter.
-     */
-    export const enum ParameterType {
-      PARAMETER_NOT_SET = 0,
-      PARAMETER_BOOL = 1,
-      PARAMETER_INTEGER = 2,
-      PARAMETER_DOUBLE = 3,
-      PARAMETER_STRING = 4,
-      PARAMETER_BYTE_ARRAY = 5,
-      PARAMETER_BOOL_ARRAY = 6,
-      PARAMETER_INTEGER_ARRAY = 7,
-      PARAMETER_DOUBLE_ARRAY = 8,
-      PARAMETER_STRING_ARRAY = 9,
-    }
 
-    /**
-     * A node parameter.
-     */
-    class Parameter {
-      /**
-       * Create a Parameter instance from an rlc_interfaces/msg/Parameter message.
-       *
-       * @param parameterMsg - The message to convert to a parameter.
-       * @returns The new instance.
-       */
-      static fromParameterMessage(
-        parameterMsg: rclinterfaces.msg.Parameter
-      ): Parameter;
+ /** 
+   * The plus/minus tolerance for determining number equivalence.
 
-      /**
-       * Create new parameter instances.
-       *
-       * @param name - The parameter name, must be a valid name.
-       * @param type - The type identifier.
-       * @param {value - The parameter value.
-       */
-      constructor(name: string, type: ParameterType, value?: any);
+   *  @remarks
+   *  See {@FloatingPointRange | FloatingPointRange}
+   *  See {@IntegerRange | IntegerRange}
+   */
+  export const DEFAULT_NUMERIC_RANGE_TOLERANCE = 1e-6;
 
-      /**
-       * The parameter name.
-       */
-      readonly name: string;
-
-      /**
-       *  The parameter type.
-       */
-      readonly type: ParameterType;
-
-      /**
-       * The parameter value.
-       * Value must be compatible with the type property.
-       */
-      value: any;
-
-      /**
-       * Check the state of this property.
-       * Throw TypeError on first property with invalid type.
-       */
-      validate(): void;
-
-      /**
-       * Create Parameter message from this instance.
-       *
-       * @returns The new instance.
-       */
-      toParameterMessage(): rclinterfaces.msg.Parameter;
-
-      /**
-       * Create a ParameterValue message from this instance.
-       *
-       * @return The new instance.
-       */
-      toParameterValueMessage(): rclinterfaces.msg.ParameterValue;
-    }
-
-    /**
-     * Describes a parameter.
-     */
-    class ParameterDescriptor {
-      /**
-       * Create a new instance from a parameter.
-      
-       * @param parameter - The parameter from which new instance is constructed. 
-       * @return The new instance.
-       */
-      static fromParameter(parameter: Parameter): ParameterDescriptor;
-
-      /**
-       * Create new instances.
-
-       * @param name - The descriptor name, must be a valid name. 
-       * @param type - The type identifier.
-       * @param description - A descriptive string.
-       * @param readOnly - True indicates a parameter of this type can not be modified. Default = false.
-       * @param range - An optional IntegerRange or FloatingPointRange. 
-       */
-      constructor(
-        name: string,
-        type: ParameterType,
-        description?: string,
-        readOnly?: boolean,
-        range?: Range
-      );
-
-      /**
-       * The name property.
-       */
-
-      readonly name: string;
-
-      /**
-       * The type property.
-       */
-      readonly type: ParameterType;
-
-      /**
-       * A descriptive string property.
-       */
-      readonly description: string;
-
-      /**
-       * The readOnly property.
-       */
-      readonly readOnly: boolean;
-
-      /**
-       * Get additionalConstraints property.
-       */
-      additionalConstraints: string;
-
-      /**
-       * Determine if rangeConstraint property has been set.
-       *
-       * @returns True if a range property is defined; falst otherwise.
-       */
-      hasRange(): boolean;
-
-      /**
-       * Get range property.
-       */
-
-      rangeConstraint: Range;
-
-      /**
-       * Check the state and ensure it is valid.
-       * Throw a TypeError if invalid state is detected.
-       */
-      validate(): void;
-
-      /**
-       * Check a parameter for consistency with this descriptor.
-       * Throw an Error if an inconsistent state is detected.
-       *
-       * @param parameter - The parameter to test for consistency.
-       */
-      validateParameter(parameter: Parameter): void;
-
-      /**
-       * Create a ParameterDescriptor message from this descriptor.
-       *
-       * @returns The new message.
-       */
-      toMessage(): rclinterfaces.msg.ParameterDescriptor;
-    }
-
-    /**
-     * An abstract class defining a range of numbers between 2 points inclusively
-     * divided by a step value.
-     * @class
-     */
-    abstract class Range {
-      /**
-       * Create a new instance.
-       *
-       * @param fromValue - The lowest inclusive value in range
-       * @param toValue - The highest inclusive value in range
-       * @param step - The internal unit size.
-       */
-      constructor(from: number, to: number, step?: number);
-
-      /**
-       * The lowest inclusive value in range.
-       */
-      readonly fromValue: number;
-
-      /**
-       * The highest inclusive value in range.
-       */
-      readonly toValue: number;
-
-      /**
-       * The internal unit size.
-       */
-      readonly step: number;
-
-      /**
-       * Determine if a value is within this range.
-       * A TypeError is thrown when value is not a number.
-       * Subclasses should override and call this method for basic type checking.
-       *
-       * @param value - The number to check.
-       * @returns True if value satisfies the range; false otherwise.
-       */
-      inRange(value: number): boolean;
-
-      /**
-       * Abstract method that determines if a ParameterType is compatible.
-       * Subclasses must implement this method.
-       *
-       * @param parameterType - The parameter type to test.
-       * @returns True if parameterType is compatible; otherwise return false.
-       */
-      isValidType(parameterType: ParameterType): boolean;
-    }
-
-    /**
-     * Defines a range for floating point values.
-     */
-    class FloatingPointRange extends Range {
-      /**
-       * Create a new instance.
-       * @constructor
-       * @param {number} fromValue - The lowest inclusive value in range
-       * @param {number} toValue - The highest inclusive value in range
-       * @param {number} step - The internal unit size.
-       */
-      constructor(from: number, to: number, step?: number);
-
-      /**
-       * Determine if a ParameterType is compatible.
-       *
-       * @param parameterType - The parameter type to test.
-       * @returns True if parameterType is compatible; otherwise return false.
-       */
-      isValidType(parameterType: ParameterType): boolean;
-
-      /**
-       * Determine if a value is within this range.
-       * A TypeError is thrown when value is not a number.
-       *
-       * @param value - The number to check.
-       * @returns True if value satisfies the range; false otherwise.
-       */
-      inRange(value: number): boolean;
-    }
-
-    /**
-     *
-     */
-    class IntegerRange extends FloatingPointRange {
-      /**
-       * Create a new instance.
-       * @constructor
-       * @param {number} fromValue - The lowest inclusive value in range
-       * @param {number} toValue - The highest inclusive value in range
-       * @param {number} step - The internal unit size.
-       */
-      constructor(from: number, to: number, step?: number);
-
-      /**
-       * Determine if a ParameterType is compatible.
-       *
-       * @param parameterType - The parameter type to test.
-       * @returns True if parameterType is compatible; otherwise return false.
-       */
-      isValidType(parameterType: ParameterType): boolean;
-    }
-
-    /**
-     * Infer a ParameterType for JS primitive types:
-     * string, boolean, number and arrays of these types.
-     * A TypeError is thrown for a value who's type is not one of
-     * the set listed.
-     * @param value - The value to infer it's ParameterType
-     * @returns The ParameterType that best scribes the value.
-     */
-    function parameterTypeFromValue(value: any): ParameterType;
-
-    /**
-     * Determine if a number maps to is a valid ParameterType.
-     *
-     * @param parameterType - The value to test.
-     * @returns True if value is a valid ParameterType; false otherwise.
-     */
-    export function validType(parameterType: ParameterType): boolean;
-
-    /**
-     * Test if value can be represented by a ParameterType.
-     *
-     * @param value - The value to test.
-     * @param type - The ParameterType to test value against.
-     * @returns True if value can be represented by type.
-     */
-    export function validValue(value: any, type: ParameterType): boolean;
+  /**
+   * Type identifier for a parameter.
+   */
+  export const enum ParameterType {
+    PARAMETER_NOT_SET = 0,
+    PARAMETER_BOOL = 1,
+    PARAMETER_INTEGER = 2,
+    PARAMETER_DOUBLE = 3,
+    PARAMETER_STRING = 4,
+    PARAMETER_BYTE_ARRAY = 5,
+    PARAMETER_BOOL_ARRAY = 6,
+    PARAMETER_INTEGER_ARRAY = 7,
+    PARAMETER_DOUBLE_ARRAY = 8,
+    PARAMETER_STRING_ARRAY = 9,
   }
+
+  /**
+   * A node parameter.
+   */
+  class Parameter {
+    /**
+     * Create a Parameter instance from an rlc_interfaces/msg/Parameter message.
+     *
+     * @param parameterMsg - The message to convert to a parameter.
+     * @returns The new instance.
+     */
+    static fromParameterMessage(
+      parameterMsg: rcl_interfaces.msg.Parameter
+    ): Parameter;
+
+    /**
+     * Create new parameter instances.
+     *
+     * @param name - The parameter name, must be a valid name.
+     * @param type - The type identifier.
+     * @param {value - The parameter value.
+     */
+    constructor(name: string, type: ParameterType, value?: any);
+
+    /**
+     * The parameter name.
+     */
+    readonly name: string;
+
+    /**
+     *  The parameter type.
+     */
+    readonly type: ParameterType;
+
+    /**
+     * The parameter value.
+     * Value must be compatible with the type property.
+     */
+    value: any;
+
+    /**
+     * Check the state of this property.
+     * Throw TypeError on first property with invalid type.
+     */
+    validate(): void;
+
+    /**
+     * Create Parameter message from this instance.
+     *
+     * @returns The new instance.
+     */
+    toParameterMessage(): rcl_interfaces.msg.Parameter;
+
+    /**
+     * Create a ParameterValue message from this instance.
+     *
+     * @return The new instance.
+     */
+    toParameterValueMessage(): rcl_interfaces.msg.ParameterValue;
+  }
+
+  /**
+   * Describes a parameter.
+   */
+  class ParameterDescriptor {
+    /**
+     * Create a new instance from a parameter.
+    
+      * @param parameter - The parameter from which new instance is constructed. 
+      * @return The new instance.
+      */
+    static fromParameter(parameter: Parameter): ParameterDescriptor;
+
+    /**
+     * Create new instances.
+
+      * @param name - The descriptor name, must be a valid name. 
+      * @param type - The type identifier.
+      * @param description - A descriptive string.
+      * @param readOnly - True indicates a parameter of this type can not be modified. Default = false.
+      * @param range - An optional IntegerRange or FloatingPointRange. 
+      */
+    constructor(
+      name: string,
+      type: ParameterType,
+      description?: string,
+      readOnly?: boolean,
+      range?: Range
+    );
+
+    /**
+     * The name property.
+     */
+
+    readonly name: string;
+
+    /**
+     * The type property.
+     */
+    readonly type: ParameterType;
+
+    /**
+     * A descriptive string property.
+     */
+    readonly description: string;
+
+    /**
+     * The readOnly property.
+     */
+    readonly readOnly: boolean;
+
+    /**
+     * Get additionalConstraints property.
+     */
+    additionalConstraints: string;
+
+    /**
+     * Determine if rangeConstraint property has been set.
+     *
+     * @returns True if a range property is defined; falst otherwise.
+     */
+    hasRange(): boolean;
+
+    /**
+     * Get range property.
+     */
+
+    rangeConstraint: Range;
+
+    /**
+     * Check the state and ensure it is valid.
+     * Throw a TypeError if invalid state is detected.
+     */
+    validate(): void;
+
+    /**
+     * Check a parameter for consistency with this descriptor.
+     * Throw an Error if an inconsistent state is detected.
+     *
+     * @param parameter - The parameter to test for consistency.
+     */
+    validateParameter(parameter: Parameter): void;
+
+    /**
+     * Create a ParameterDescriptor message from this descriptor.
+     *
+     * @returns The new message.
+     */
+    toMessage(): rcl_interfaces.msg.ParameterDescriptor;
+  }
+
+  /**
+   * An abstract class defining a range of numbers between 2 points inclusively
+   * divided by a step value.
+   * @class
+   */
+  abstract class Range {
+    /**
+     * Create a new instance.
+     *
+     * @param fromValue - The lowest inclusive value in range
+     * @param toValue - The highest inclusive value in range
+     * @param step - The internal unit size.
+     */
+    constructor(from: number, to: number, step?: number);
+
+    /**
+     * The lowest inclusive value in range.
+     */
+    readonly fromValue: number;
+
+    /**
+     * The highest inclusive value in range.
+     */
+    readonly toValue: number;
+
+    /**
+     * The internal unit size.
+     */
+    readonly step: number;
+
+    /**
+     * Determine if a value is within this range.
+     * A TypeError is thrown when value is not a number.
+     * Subclasses should override and call this method for basic type checking.
+     *
+     * @param value - The number to check.
+     * @returns True if value satisfies the range; false otherwise.
+     */
+    inRange(value: number): boolean;
+
+    /**
+     * Abstract method that determines if a ParameterType is compatible.
+     * Subclasses must implement this method.
+     *
+     * @param parameterType - The parameter type to test.
+     * @returns True if parameterType is compatible; otherwise return false.
+     */
+    isValidType(parameterType: ParameterType): boolean;
+  }
+
+  /**
+   * Defines a range for floating point values.
+   */
+  class FloatingPointRange extends Range {
+    /**
+     * Create a new instance.
+     * @constructor
+     * @param {number} fromValue - The lowest inclusive value in range
+     * @param {number} toValue - The highest inclusive value in range
+     * @param {number} step - The internal unit size.
+     * @param {number} tolerance - The plus/minus tolerance for number equivalence.
+     */
+    constructor(from: number, to: number, step?: number, tolerance?: number);
+
+    /**
+     * Determine if a ParameterType is compatible.
+     *
+     * @param parameterType - The parameter type to test.
+     * @returns True if parameterType is compatible; otherwise return false.
+     */
+    isValidType(parameterType: ParameterType): boolean;
+
+    /**
+     * Determine if a value is within this range.
+     * A TypeError is thrown when value is not a number.
+     *
+     * @param value - The number to check.
+     * @returns True if value satisfies the range; false otherwise.
+     */
+    inRange(value: number): boolean;
+  }
+
+  /**
+   *
+   */
+  class IntegerRange extends FloatingPointRange {
+    /**
+     * Create a new instance.
+     * @constructor
+     * @param {number} fromValue - The lowest inclusive value in range
+     * @param {number} toValue - The highest inclusive value in range
+     * @param {number} step - The internal unit size.
+     * @param {number} tolerance - The plus/minus tolerance for number equivalence.
+     */
+    constructor(from: number, to: number, step?: number, tolerance?: number);
+
+    /**
+     * Determine if a ParameterType is compatible.
+     *
+     * @param parameterType - The parameter type to test.
+     * @returns True if parameterType is compatible; otherwise return false.
+     */
+    isValidType(parameterType: ParameterType): boolean;
+  }
+
 }

--- a/types/time.d.ts
+++ b/types/time.d.ts
@@ -1,5 +1,5 @@
+/* eslint-disable camelcase */
 
-// eslint-disable-next-line camelcase
 import { Message, builtin_interfaces } from 'rclnodejs';
 
 declare module 'rclnodejs' {


### PR DESCRIPTION
See issue #599 for details.

- Adds use_sim_time parameter initialization and reference to
TimeSource#attachNode()

- Adds onSetParametesCallback from TimeSource to node

- Updates test-time-source.js to use_sim_time parameter.

- Adds callback notification for Node declareParameters(parameters) and
setParameters(parameters). Each callback returns a result to either
approve or veto the operation. This feature is required to coordinate
use_sim_time parameter events with a Node's timeSource. Includes new SetParametersCallback definition and
addOnSetParametersCallback(callback) and
removeOnSetParametersCallback(callback).

- There was an inconsistency in parameter.d.ts representation of
parameter.js. To better align the typescript declarations, the Parameters
namespace has been removed as well as 3 internal functions that were
unnecessarily exported.

- Adds index.js properties: Parameter, ParameterDescriptor,
ParameterType, IntegerRange and FloatingPointRange.

- Disables eslint camelcase rule for parameter.js, parameter.d.ts,
time.d.ts

- Improves jsdoc and tsdoc.