### PR TITLE
Adds test for --log-level cmdline arg usage

### DIFF
--- a/test/test-logging.js
+++ b/test/test-logging.js
@@ -16,6 +16,7 @@
 
 const assert = require('assert');
 const rclnodejs = require('../index.js');
+const Context = require('../lib/context.js');
 
 describe('Rclnodejs - Test logging util', function() {
   it('Test setting severity level', function() {
@@ -40,5 +41,82 @@ describe('Rclnodejs - Test logging util', function() {
     assert.equal(logger.info('message info'), true);
     assert.equal(logger.warn('message warn'), true);
     assert.equal(logger.fatal('message fatal'), true);
+  });
+
+  it('Test logger name', function() {
+    let logger = rclnodejs.logging.getLogger('logger');
+    assert.equal(logger.name, 'logger');
+  });
+
+  it('Test commandline parameter configuration', async function() {
+    let argv, logger;
+
+    argv = ['--ros-args', '--log-level', 'debug'];
+    await rclnodejs.init(rclnodejs.Context.defaultContext(), argv);
+    logger = rclnodejs.logging.getLogger('test_logger1');
+    assert.deepStrictEqual(
+      logger.loggerEffectiveLevel,
+      logger.LoggingSeverity.DEBUG
+    );
+    rclnodejs.shutdown();
+
+    argv = ['--ros-args', '--log-level', 'info'];
+    await rclnodejs.init(rclnodejs.Context.defaultContext(), argv);
+    logger = rclnodejs.logging.getLogger('test_logger2');
+    assert.deepStrictEqual(
+      logger.loggerEffectiveLevel,
+      logger.LoggingSeverity.INFO
+    );
+    rclnodejs.shutdown();
+
+    argv = ['--ros-args', '--log-level', 'warn'];
+    await rclnodejs.init(rclnodejs.Context.defaultContext(), argv);
+    logger = rclnodejs.logging.getLogger('test_logger3');
+    assert.deepStrictEqual(
+      logger.loggerEffectiveLevel,
+      logger.LoggingSeverity.WARN
+    );
+    rclnodejs.shutdown();
+
+    argv = ['--ros-args', '--log-level', 'error'];
+    await rclnodejs.init(rclnodejs.Context.defaultContext(), argv);
+    logger = rclnodejs.logging.getLogger('test_logger4');
+    assert.deepStrictEqual(
+      logger.loggerEffectiveLevel,
+      logger.LoggingSeverity.ERROR
+    );
+    rclnodejs.shutdown();
+
+    argv = ['--ros-args', '--log-level', 'fatal'];
+    await rclnodejs.init(rclnodejs.Context.defaultContext(), argv);
+    logger = rclnodejs.logging.getLogger('test_logger5');
+    assert.deepStrictEqual(
+      logger.loggerEffectiveLevel,
+      logger.LoggingSeverity.FATAL
+    );
+    rclnodejs.shutdown();
+
+    argv = ['--ros-args', '--log-level', 'fatal'];
+    await rclnodejs.init(rclnodejs.Context.defaultContext(), argv);
+    logger = rclnodejs.logging.getLogger('test_logger6');
+    logger.setLoggerLevel(logger.LoggingSeverity.DEBUG);
+    assert.deepStrictEqual(
+      logger.loggerEffectiveLevel,
+      logger.LoggingSeverity.DEBUG
+    );
+    rclnodejs.shutdown();
+
+    // reset rcl's default log level to 'info'
+    argv = ['--ros-args', '--log-level', 'info'];
+    await rclnodejs.init(rclnodejs.Context.defaultContext(), argv);
+    rclnodejs.shutdown();
+
+    await rclnodejs.init();
+    let node = rclnodejs.createNode('test_node');
+    assert.deepStrictEqual(
+      node.getLogger().loggerEffectiveLevel,
+      logger.LoggingSeverity.INFO
+    );
+    rclnodejs.shutdown();
   });
 });


### PR DESCRIPTION
test-logging.js
- added test to confirm --log-level commandline arg works across the range of LoggingSeverities 

Fixes #607 