### PR TITLE
Add missing action status qos profile

### DIFF
--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -21,6 +21,7 @@
 #include <rcl/node.h>
 #include <rcl/rcl.h>
 #include <rcl/validate_topic_name.h>
+#include <rcl_action/rcl_action.h>
 #include <rcl_yaml_param_parser/types.h>
 #include <rcl_yaml_param_parser/parser.h>
 #include <rmw/error_handling.h>
@@ -1175,6 +1176,8 @@ const rmw_qos_profile_t* GetQoSProfileFromString(const std::string& profile) {
     qos_profile = &rmw_qos_profile_parameters;
   } else if (profile == "qos_profile_parameter_events") {
     qos_profile = &rmw_qos_profile_parameter_events;
+  } else if (profile == "rcl_action_qos_profile_status_default") {
+    qos_profile = &rcl_action_qos_profile_status_default;
   } else {
     return &rmw_qos_profile_default;
   }


### PR DESCRIPTION
Add missed QOS profile used by action status messages.

This PR targets the 'actions' branch.