### PR TITLE
Remove dependency on tests_msgs

### DIFF
--- a/test/rclnodejs_test_msgs/CMakeLists.txt
+++ b/test/rclnodejs_test_msgs/CMakeLists.txt
@@ -19,8 +19,12 @@ find_package(rosidl_default_generators REQUIRED)
 set(msg_files
   "msg/StaticArrayNonPrimitives.msg"
 )
+set(action_files
+  "action/Fibonacci.action"
+)
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
+  ${action_files}
   DEPENDENCIES builtin_interfaces
 )
 

--- a/test/rclnodejs_test_msgs/action/Fibonacci.action
+++ b/test/rclnodejs_test_msgs/action/Fibonacci.action
@@ -1,0 +1,8 @@
+#goal definition
+int32 order
+---
+#result definition
+int32[] sequence
+---
+#feedback
+int32[] sequence

--- a/test/rclnodejs_test_msgs/package.xml
+++ b/test/rclnodejs_test_msgs/package.xml
@@ -13,6 +13,8 @@
 
   <build_depend>builtin_interfaces</build_depend>
 
+  <depend>action_msgs</depend>
+
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/test/test-action-client.js
+++ b/test/test-action-client.js
@@ -24,7 +24,7 @@ describe('rclnodejs action client', function() {
   let node;
   let server;
   this.timeout(60 * 1000);
-  let fibonacci = 'test_msgs/action/Fibonacci';
+  let fibonacci = 'rclnodejs_test_msgs/action/Fibonacci';
   let Fibonacci;
 
   let publishFeedback = null;

--- a/test/test-action-server.js
+++ b/test/test-action-server.js
@@ -24,7 +24,7 @@ describe('rclnodejs action server', function() {
   let node;
   let client;
   this.timeout(60 * 1000);
-  let fibonacci = 'test_msgs/action/Fibonacci';
+  let fibonacci = 'rclnodejs_test_msgs/action/Fibonacci';
   let Fibonacci;
   let GoalStatus;
 


### PR DESCRIPTION
Removes the need to manually install `ros-<distro>-test-msgs` package to run unit tests.

This PR targets the 'actions' branch.