### PR TITLE
Add action TypeScript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "install": "node-gyp rebuild",
     "docs": "cd docs && make",
-    "test": "node ./scripts/compile_tests.js && node ./scripts/run_test.js && dtslint test/types",
+    "test": "node ./scripts/compile_tests.js && node ./scripts/run_test.js && node ./scripts/generate_tsd.js && dtslint test/types",
     "lint": "eslint --max-warnings=0 index.js types/*.d.ts scripts lib example rosidl_gen rosidl_parser test benchmark/rclnodejs && node ./scripts/cpplint.js",
     "postinstall": "node scripts/generate_messages.js",
     "format": "prettier --trailing-comma es5 --single-quote --write \"{.,{lib,rosidl_gen,rostsd_gen,rosidl_parser,types,example,test}/**}/*.{js,md,ts}\""

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -97,7 +97,7 @@ publisher.qos;
 // $ExpectType string
 publisher.topic;
 
-// $ExpectType TypeClass
+// $ExpectType TypeClass<TypeClassName>
 publisher.typeClass;
 
 // $ExpectType boolean
@@ -283,3 +283,89 @@ logger.error('test msg');
 
 // $ExpectType boolean
 logger.fatal('test msg');
+
+// $ExpectType FibonacciConstructor
+const Fibonacci = rclnodejs.require('rclnodejs_test_msgs/action/Fibonacci');
+
+// ---- ActionClient -----
+// $ExpectType ActionClient<"rclnodejs_test_msgs/action/Fibonacci">
+const actionClient = new rclnodejs.ActionClient(node, 'rclnodejs_test_msgs/action/Fibonacci', 'fibonnaci');
+
+// $ExpectType boolean
+client.isServiceServerAvailable();
+
+// $ExpectType Promise<boolean>
+actionClient.waitForServer();
+
+// $ExpectType Promise<ClientGoalHandle<"rclnodejs_test_msgs/action/Fibonacci">>
+const goalHandlePromise = actionClient.sendGoal(new Fibonacci.Goal());
+
+goalHandlePromise.then(goalHandle => {
+  // $ExpectType boolean
+  goalHandle.accepted;
+
+  // $ExpectType UUID
+  goalHandle.goalId;
+
+  // $ExpectType Time
+  goalHandle.stamp;
+
+  // $ExpectType string
+  goalHandle.status;
+
+  // $ExpectType Promise<CancelGoal_Response>
+  goalHandle.cancelGoal();
+
+  // $ExpectType Promise<Fibonacci_Result>
+  goalHandle.getResult();
+});
+
+// ---- ActionServer -----
+// $ExpectType ActionServer<"rclnodejs_test_msgs/action/Fibonacci">
+const actionServer = new rclnodejs.ActionServer(node, 'rclnodejs_test_msgs/action/Fibonacci', 'fibonnaci', executeCallback);
+
+// $ExpectType void
+actionServer.registerHandleAcceptedCallback();
+
+// $ExpectType void
+actionServer.registerGoalCallback();
+
+// $ExpectType void
+actionServer.registerCancelCallback();
+
+// $ExpectType void
+actionServer.registerExecuteCallback(() => new Fibonacci.Result());
+
+function executeCallback(goalHandle: rclnodejs.ServerGoalHandle<"rclnodejs_test_msgs/action/Fibonacci">) {
+  // $ExpectType UUID
+  goalHandle.goalId;
+
+  // $ExpectType boolean
+  goalHandle.isActive;
+
+  // $ExpectType boolean
+  goalHandle.isCancelRequested;
+
+  // $ExpectType Fibonacci_Goal
+  goalHandle.request;
+
+  // $ExpectType string
+  goalHandle.status;
+
+  // $ExpectType void
+  goalHandle.abort();
+
+  // $ExpectType void
+  goalHandle.canceled();
+
+  // $ExpectType void
+  goalHandle.execute();
+
+  // $ExpectType void
+  goalHandle.publishFeedback(new Fibonacci.Feedback());
+
+  // $ExpectType void
+  goalHandle.succeed();
+
+  return new Fibonacci.Result();
+}

--- a/types/action_client.d.ts
+++ b/types/action_client.d.ts
@@ -1,0 +1,125 @@
+/* eslint-disable camelcase */
+declare module 'rclnodejs' {
+  type ActionGoal<T> = T extends ActionTypeClassName ? InstanceType<ActionsMap[T]['Goal']> : object;
+  type ActionFeedback<T> = T extends ActionTypeClassName ? InstanceType<ActionsMap[T]['Feedback']> : object;
+  type ActionResult<T> = T extends ActionTypeClassName ? InstanceType<ActionsMap[T]['Result']> : object;
+
+  /**
+   * Goal handle for working with Action Clients.
+   */
+  class ClientGoalHandle<T extends TypeClass<ActionTypeClassName>> {
+    /**
+     * Gets the goal Id.
+     */
+    get goalId(): unique_identifier_msgs.msg.UUID;
+
+    /**
+     * Gets the goal response timestamp.
+     */
+    get stamp(): builtin_interfaces.msg.Time;
+
+    /**
+     * Gets if the goal response was accepted.
+     */
+    get accepted(): boolean;
+
+    /**
+     * Gets the goal status.
+     */
+    get status(): string;
+
+    /**
+     * Send a cancel request for the goal.
+     * 
+     * @returns The cancel response.
+     */
+    cancelGoal(): Promise<action_msgs.srv.CancelGoal_Response>;
+
+    /**
+     * Request the result for the goal.
+     * 
+     * @returns The result response.
+     */
+    getResult(): Promise<ActionResult<T>>;
+  }
+
+  /**
+   * ROS Middleware "quality of service" options for action clients.
+   */
+  interface ActionQoS {
+    /**
+     * Quality of service option for the goal service, default: QoS.profileServicesDefault.
+     */
+    goalServiceQosProfile?: QoS | QoS.ProfileRef;
+
+    /**
+     * Quality of service option for the result service, default: QoS.profileServicesDefault.
+     */
+    resultServiceQosProfile?: QoS | QoS.ProfileRef;
+
+    /**
+     * Quality of service option for the cancel service, default: QoS.profileServicesDefault.
+     */
+    cancelServiceQosProfile?: QoS | QoS.ProfileRef;
+
+    /**
+     * Quality of service option for the feedback subscription, default: new QoS(QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT, 10).
+     */
+    feedbackSubQosProfile?: QoS | QoS.ProfileRef;
+
+    /**
+     * Quality of service option for the status subscription, default: QoS.profileActionStatusDefault.
+     */
+    statusSubQosProfile?: QoS | QoS.ProfileRef
+  }
+
+  /**
+   * ROS Action client.
+   */
+  class ActionClient<T extends TypeClass<ActionTypeClassName>> {
+    /**
+     * Creates a new action client.
+     *
+     * @param node - The ROS node to add the action client to.
+     * @param typeClass - Type of the action.
+     * @param actionName - Name of the action.
+     * @param options - The topic will use TypedArray if necessary, default: true.
+     */
+    constructor(node: Node, typeClass: T, actionName: string, options?: Options<ActionQoS>);
+
+    /**
+     * Send a goal and asynchronously get the result.
+     *
+     * The result of the returned Promise is set to a ClientGoalHandle when receipt of the goal
+     * is acknowledged by an action server.
+     *
+     * @param goal - The goal request.
+     * @param feedbackCallback - Callback function for feedback associated with the goal.
+     * @param goalUuid - Universally unique identifier for the goal. If None, then a random UUID is generated.
+     * @returns A Promise to a goal handle that resolves when the goal request has been accepted or rejected.
+     */
+    sendGoal(
+      goal: ActionGoal<T>,
+      feedbackCallback?: (feedbackMessage: ActionFeedback<T>) => void,
+      goalUuid?: unique_identifier_msgs.msg.UUID
+    ): Promise<ClientGoalHandle<T>>;
+
+    /**
+     * Check if there is an action server ready to process requests from this client.
+     * 
+     * @returns True if an action server is ready; otherwise, false.
+     */
+    isActionServerAvailable(): boolean;
+
+    /**
+     * Wait until the action server is available or a timeout is reached. This
+     * function polls for the server state so it may not return as soon as the
+     * server is available.
+     * 
+     * @param timeout The maximum amount of time to wait for, if timeout
+     * is `undefined` or `< 0`, this will wait indefinitely.
+     * @returns True if the service is available.
+     */
+    waitForServer(timeout?: number): Promise<boolean>;
+  }
+}

--- a/types/action_server.d.ts
+++ b/types/action_server.d.ts
@@ -1,0 +1,171 @@
+/* eslint-disable camelcase */
+declare module 'rclnodejs' {
+  /**
+   * Goal handle for working with Action Servers.
+   */
+  class ServerGoalHandle<T extends TypeClass<ActionTypeClassName>> {
+    /**
+     * Gets the goal request.
+     */
+    get request(): ActionGoal<T>;
+
+    /**
+     * Gets the goal Id.
+     */
+    get goalId(): unique_identifier_msgs.msg.UUID;
+
+    /**
+     * Gets if the goal handle is active.
+     */
+    get isActive(): boolean;
+
+    /**
+     * Gets if cancellation was requested.
+     */
+    get isCancelRequested(): boolean;
+
+    /**
+     * Gets the status of the goal.
+     */
+    get status(): string;
+
+    /**
+     * Updates the goal handle with the execute status and begins exection.
+     * 
+     * @param callback - An optional callback to use instead of the one provided to the action server.
+     */
+    execute(callback?: ExecuteCallback<T>): void;
+
+    /**
+     * Sends feedback back to the client.
+     * 
+     * @param feedback - The feedback to send back.
+     */
+    publishFeedback(feedback: ActionFeedback<T>): void;
+
+    /**
+     * Updates the goal handle with the succeed status.
+     */
+    succeed(): void;
+
+    /**
+     * Updates the goal handle with the abort status.
+     */
+    abort(): void;
+
+    /**
+     * Updates the goal handle with the canceled status.
+     */
+    canceled(): void;
+  }
+
+  /**
+   * Possible goal responses.
+   */
+  enum GoalResponse {
+    REJECT = 1,
+    ACCEPT = 2,
+  }
+
+  /**
+   * Possible cancel responses.
+   */
+  enum CancelResponse {
+    REJECT = 1,
+    ACCEPT = 2,
+  }
+
+  type ExecuteCallback<T extends TypeClass<ActionTypeClassName>> = (goalHandle: ServerGoalHandle<T>) => ActionResult<T>;
+  type GoalCallback = () => GoalResponse;
+  type HandleAcceptedCallback<T extends TypeClass<ActionTypeClassName>> = (goalHandle: ServerGoalHandle<T>) => void;
+  type CancelCallback = () => CancelResponse;
+
+  interface ActionServerOptions extends Options<ActionQoS> {
+    /**
+     * How long in seconds a result is kept by the server after a goal reaches a terminal state in seconds, default: 900.
+     */
+    resultTimeout?: number;
+  }
+
+  /**
+   * ROS Action server.
+   */
+  class ActionServer<T extends TypeClass<ActionTypeClassName>> {
+    /**
+     * Creates a new action server.
+     *
+     * @param node - The ROS node to add the action server to.
+     * @param typeClass - Type of the action.
+     * @param actionName - Name of the action. Used as part of the underlying topic and service names.
+     * @param executeCallback - Callback function for processing accepted goals.
+     * @param goalCallback - Callback function for handling new goal requests.
+     * @param handleAcceptedCallback - Callback function for handling newly accepted goals.
+     * @param cancelCallback - Callback function for handling cancel requests.
+     * @param options - Action server options.
+     */
+    constructor(
+      node: Node,
+      typeClass: T,
+      actionName: string,
+      executeCallback: ExecuteCallback<T>,
+      goalCallback?: GoalCallback,
+      handleAcceptedCallback?: HandleAcceptedCallback<T>,
+      cancelCallback?: CancelCallback,
+      options?: ActionServerOptions
+    );
+
+    /**
+     * Register a callback for handling newly accepted goals.
+     *
+     * The provided function is called whenever a new goal has been accepted by this action server.
+     * The function should expect an instance of {@link ServerGoalHandle} as an argument,
+     * which represents a handle to the goal that was accepted.
+     * The goal handle can be used to interact with the goal, e.g. publish feedback,
+     * update the status, or execute a deferred goal.
+     *
+     * There can only be one handle accepted callback per {@link ActionServer},
+     * therefore calling this function will replace any previously registered callback.
+     *
+     * @param handleAcceptedCallback - Callback function, if not provided, then unregisters any previously registered callback.
+     */
+    registerHandleAcceptedCallback(handleAcceptedCallback?: HandleAcceptedCallback<T>): void;
+
+    /**
+     * Register a callback for handling new goal requests.
+     *
+     * The purpose of the goal callback is to decide if a new goal should be accepted or rejected.
+     * The callback should take the goal request message as a parameter and must return a {@link GoalResponse} value.
+     *
+     * @param goalCallback - Callback function, if not provided, then unregisters any previously registered callback.
+     */
+    registerGoalCallback(goalCallback?: GoalCallback): void;
+
+    /**
+     * Register a callback for handling cancel requests.
+     *
+     * The purpose of the cancel callback is to decide if a request to cancel an on-going
+     * (or queued) goal should be accepted or rejected.
+     * The callback should take one parameter containing the cancel request and must return a
+     * {@link CancelResponse} value.
+     *
+     * There can only be one cancel callback per {@link ActionServer}, therefore calling this
+     * function will replace any previously registered callback.
+     * @param cancelCallback - Callback function, if not provided, then unregisters any previously registered callback.
+     */
+    registerCancelCallback(cancelCallback?: CancelCallback): void;
+
+    /**
+     * Register a callback for executing action goals.
+     *
+     * The purpose of the execute callback is to execute the action goal and return a result when finished.
+     * The callback should take one parameter containing goal request and must return a
+     * result instance (i.e. `action_type.Result`).
+     *
+     * There can only be one execute callback per {@link ActionServer}, therefore calling this
+     * function will replace any previously registered callback.
+     *
+     * @param executeCallback - Callback function.
+     */
+    registerExecuteCallback(executeCallback: ExecuteCallback<T>): void;
+  }
+}

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -1,4 +1,6 @@
 /* eslint-disable spaced-comment */
+/// <reference path="action_client.d.ts" />
+/// <reference path="action_server.d.ts" />
 /// <reference path="client.d.ts" />
 /// <reference path="clock_type.d.ts" />
 /// <reference path="clock.d.ts" />

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -66,9 +66,9 @@ declare module 'rclnodejs' {
    * @param  name - The name of interface to be required.
    * @returns The object of the required package/interface.
    */
-  function require<T extends MessageTypeClassName>(
+  function require<T extends TypeClassName>(
     name: T
-  ): MessageWrapperType<T>;
+  ): InterfaceType<T>;
   function require(name: string): object;
 
   /**

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -10,9 +10,9 @@ declare module 'rclnodejs' {
   /**
    * Identifies type of ROS message such as msg or srv.
    */
-  type TypeClass =
+  type TypeClass<T = TypeClassName> =
     | (() => any)
-    | TypeClassName // a string representing the message class, e.g. 'std_msgs/msg/String',
+    | T // a string representing the message class, e.g. 'std_msgs/msg/String',
     | {
         // object representing a message class, e.g. {package: 'std_msgs', type: 'msg', name: 'String'}
         package: string;
@@ -26,10 +26,10 @@ declare module 'rclnodejs' {
    *
    * See {@link DEFAULT_OPTIONS}
    */
-  type Options = {
+  interface Options<T = QoS | QoS.ProfileRef> {
     enableTypedArray?: boolean;
-    qos?: QoS | QoS.ProfileRef;
-  };
+    qos?: T;
+  }
 
   /**
    * A service response to a client request.

--- a/types/qos.d.ts
+++ b/types/qos.d.ts
@@ -79,6 +79,11 @@ declare module 'rclnodejs' {
     export const profileParameterEvents = 'qos_profile_parameter_events';
 
     /**
+     * The action status profileref.
+     */
+    export const profileActionStatusDefault = 'rcl_action_qos_profile_status_default';
+
+    /**
      * A named policy reference.
      */
     export type ProfileRef = string;


### PR DESCRIPTION
This PR contains the following changes.

- Adds typings for ActionClient and ActionServer.
- Generates action interface types.
- Replaces use of 'type' with 'interface' where applicable, which is generally preferred.
- Rename "Wrapper" to "Constructor" to follow TS naming conventions.

There are many more enhancements that can be made, but they are not necessary at this time.

This PR targets the 'actions' branch.