### PR TITLE
Fix all build warnings when building with Node.js v12

### DIFF
--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -28,7 +28,7 @@ void InitModule(v8::Local<v8::Object> exports) {
 
   for (uint32_t i = 0;
        i < rclnodejs::GetBindingMethodsCount(rclnodejs::binding_methods); i++) {
-    exports->Set(
+    Nan::Set(exports,
         Nan::New(rclnodejs::binding_methods[i].name).ToLocalChecked(),
         Nan::New<v8::FunctionTemplate>(rclnodejs::binding_methods[i].function)
             ->GetFunction(context).ToLocalChecked());

--- a/src/handle_manager.cpp
+++ b/src/handle_manager.cpp
@@ -159,8 +159,8 @@ void HandleManager::CollectHandlesByType(
             .ToLocalChecked()).FromJust();
 
     for (uint32_t index = 0; index < length; index++) {
-      v8::Local<v8::Object> obj =
-          Nan::To<v8::Object>(typeObject->Get(index)).ToLocalChecked();
+      v8::Local<v8::Object> obj = Nan::To<v8::Object>(
+          Nan::Get(typeObject, index).ToLocalChecked()).ToLocalChecked();
       Nan::MaybeLocal<v8::Value> handle =
           Nan::Get(obj, Nan::New("_handle").ToLocalChecked());
       rclnodejs::RclHandle* rcl_handle =

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -206,8 +206,9 @@ static v8::Local<v8::Object> wrapParameters(rcl_params_t *parsed_args) {
       }
       else if (value.string_value != NULL) {  // NOLINT()
         param_type = PARAMETER_STRING;
-        parameter->Set(Nan::New("value").ToLocalChecked(),
-                       Nan::New(value.string_value).ToLocalChecked());
+        Nan::Set(parameter,
+                 Nan::New("value").ToLocalChecked(),
+                 Nan::New(value.string_value).ToLocalChecked());
       }
       else if (value.bool_array_value != NULL) {  // NOLINT()
         param_type = PARAMETER_BOOL_ARRAY;
@@ -549,10 +550,10 @@ static void ReturnJSTimeObj(
       static_cast<std::int32_t>(nanoseconds % (1000 * 1000 * 1000));
   const int32_t type = clock_type;
 
-  obj->Set(Nan::New("sec").ToLocalChecked(), Nan::New(sec));
-  obj->Set(Nan::New("nanosec").ToLocalChecked(), Nan::New(nanosec));
+  Nan::Set(obj, Nan::New("sec").ToLocalChecked(), Nan::New(sec));
+  Nan::Set(obj, Nan::New("nanosec").ToLocalChecked(), Nan::New(nanosec));
   if (clock_type != RCL_CLOCK_UNINITIALIZED) {
-    obj->Set(Nan::New("type").ToLocalChecked(), Nan::New(type));
+    Nan::Set(obj, Nan::New("type").ToLocalChecked(), Nan::New(type));
   }
 
   info.GetReturnValue().Set(obj);
@@ -1190,21 +1191,28 @@ std::unique_ptr<rmw_qos_profile_t> GetQosProfileFromObject(
   std::unique_ptr<rmw_qos_profile_t> qos_profile =
       std::make_unique<rmw_qos_profile_t>();
 
+  auto history = Nan::Get(object,
+      Nan::New("history").ToLocalChecked()).ToLocalChecked();
+  auto depth = Nan::Get(object,
+      Nan::New("depth").ToLocalChecked()).ToLocalChecked();
+  auto reliability = Nan::Get(object,
+      Nan::New("reliability").ToLocalChecked()).ToLocalChecked();
+  auto durability = Nan::Get(object,
+      Nan::New("durability").ToLocalChecked()).ToLocalChecked();
+  auto avoid_ros_namespace_conventions = Nan::Get(object,
+      Nan::New("avoidRosNameSpaceConventions").ToLocalChecked())
+          .ToLocalChecked();
+
   qos_profile->history = static_cast<rmw_qos_history_policy_t>(
-      Nan::To<uint32_t>(
-          object->Get(Nan::New("history").ToLocalChecked())).FromJust());
+      Nan::To<uint32_t>(history).FromJust());
   qos_profile->depth =
-      Nan::To<uint32_t>(
-          object->Get(Nan::New("depth").ToLocalChecked())).FromJust();
+      Nan::To<uint32_t>(depth).FromJust();
   qos_profile->reliability = static_cast<rmw_qos_reliability_policy_t>(
-      Nan::To<uint32_t>(
-          object->Get(Nan::New("reliability").ToLocalChecked())).FromJust());
+      Nan::To<uint32_t>(reliability).FromJust());
   qos_profile->durability = static_cast<rmw_qos_durability_policy_t>(
-      Nan::To<uint32_t>(
-          object->Get(Nan::New("durability").ToLocalChecked())).FromJust());
-  qos_profile->avoid_ros_namespace_conventions =
-      object->Get(Nan::New("avoidRosNameSpaceConventions").ToLocalChecked())
-          ->BooleanValue(currentContent).FromJust();
+      Nan::To<uint32_t>(durability).FromJust());
+  qos_profile->avoid_ros_namespace_conventions = avoid_ros_namespace_conventions
+      ->BooleanValue(currentContent->GetIsolate());
 
   return qos_profile;
 }
@@ -1412,8 +1420,9 @@ void ExtractNamesAndTypes(rcl_names_and_types_t names_and_types,
   for (int i = 0; i < names_and_types.names.size; ++i) {
     auto item = v8::Object::New(v8::Isolate::GetCurrent());
     std::string topic_name = names_and_types.names.data[i];
-    item->Set(Nan::New("name").ToLocalChecked(),
-              Nan::New(names_and_types.names.data[i]).ToLocalChecked());
+    Nan::Set(item,
+             Nan::New("name").ToLocalChecked(),
+             Nan::New(names_and_types.names.data[i]).ToLocalChecked());
 
     v8::Local<v8::Array> type_list =
         Nan::New<v8::Array>(names_and_types.types[i].size);
@@ -1421,7 +1430,7 @@ void ExtractNamesAndTypes(rcl_names_and_types_t names_and_types,
       Nan::Set(type_list, j,
                Nan::New(names_and_types.types[i].data[j]).ToLocalChecked());
     }
-    item->Set(Nan::New("types").ToLocalChecked(), type_list);
+    Nan::Set(item, Nan::New("types").ToLocalChecked(), type_list);
     Nan::Set(*result_list, i, item);
   }
 }
@@ -1589,10 +1598,12 @@ NAN_METHOD(GetNodeNames) {
   for (int i = 0; i < node_names.size; ++i) {
     auto item = v8::Object::New(v8::Isolate::GetCurrent());
 
-    item->Set(Nan::New("name").ToLocalChecked(),
-              Nan::New(node_names.data[i]).ToLocalChecked());
-    item->Set(Nan::New("namespace").ToLocalChecked(),
-              Nan::New(node_namespaces.data[i]).ToLocalChecked());
+    Nan::Set(item,
+             Nan::New("name").ToLocalChecked(),
+             Nan::New(node_names.data[i]).ToLocalChecked());
+    Nan::Set(item,
+             Nan::New("namespace").ToLocalChecked(),
+             Nan::New(node_namespaces.data[i]).ToLocalChecked());
 
     Nan::Set(result_list, i, item);
   }

--- a/src/rcl_handle.cpp
+++ b/src/rcl_handle.cpp
@@ -39,8 +39,9 @@ void RclHandle::Init(v8::Local<v8::Object> exports) {
   v8::Local<v8::Context> context = exports->GetIsolate()->GetCurrentContext();
 
   constructor.Reset(tpl->GetFunction(context).ToLocalChecked());
-  exports->Set(Nan::New("RclHandle").ToLocalChecked(),
-               tpl->GetFunction(context).ToLocalChecked());
+  Nan::Set(exports,
+           Nan::New("RclHandle").ToLocalChecked(),
+           tpl->GetFunction(context).ToLocalChecked());
 }
 
 void RclHandle::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {

--- a/src/shadow_node.cpp
+++ b/src/shadow_node.cpp
@@ -59,8 +59,9 @@ void ShadowNode::Init(v8::Local<v8::Object> exports) {
   v8::Local<v8::Context> context = exports->GetIsolate()->GetCurrentContext();
 
   constructor.Reset(tpl->GetFunction(context).ToLocalChecked());
-  exports->Set(Nan::New("ShadowNode").ToLocalChecked(),
-               tpl->GetFunction(context).ToLocalChecked());
+  Nan::Set(exports,
+           Nan::New("ShadowNode").ToLocalChecked(),
+           tpl->GetFunction(context).ToLocalChecked());
 }
 
 NAN_GETTER(ShadowNode::HandleGetter) {


### PR DESCRIPTION
Removes deprecated use of Set and Get.

Fix #None