### PR TITLE
adds Time#toMsg()

### DIFF
--- a/lib/time.js
+++ b/lib/time.js
@@ -250,6 +250,19 @@ class Time {
   }
 
   /**
+   * Create a builtin_interfaces.msg.Time message
+   *
+   * @return {builtin_interfaces.msg.Time} - The new Time message.
+   */
+  toMsg() {
+    const secondsAndNanoseconds = this.secondsAndNanoseconds;
+    return {
+      sec: secondsAndNanoseconds.seconds,
+      nanosec: secondsAndNanoseconds.nanoseconds,
+    };
+  }
+
+  /**
    * Create a Time object from a message of builtin_interfaces/msg/Time
    * @param {object} msg - The builtin_interfaces.msg.Time message to be
    *  created from.

--- a/test/test-time.js
+++ b/test/test-time.js
@@ -196,4 +196,12 @@ describe('rclnodejs Time/Clock testing', function() {
       left.lte(time);
     }, TypeError);
   });
+
+  it('Conversion to Time message', function() {
+    let time = new Time(100, 200);
+    let msg = time.toMsg();
+
+    assert.strictEqual(msg.sec, 100);
+    assert.strictEqual(msg.nanosec, 200);
+  });
 });

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -261,6 +261,9 @@ time1.gt(time2);
 // $ExpectType boolean
 time1.gte(time2);
 
+// $ExpectType Time
+time3.toMsg();
+
 // ---- Clock -----
 // $ExpectType Clock
 const clock = new rclnodejs.Clock(rclnodejs.ClockType.SYSTEM_TIME);

--- a/types/time.d.ts
+++ b/types/time.d.ts
@@ -102,6 +102,14 @@ declare module 'rclnodejs' {
     gte(other: Time): boolean;
 
     /**
+     * Create a builtin_interfaces/msg/Time message
+     *
+     * @returns The new Time message.
+     */
+    // eslint-disable-next-line camelcase
+    toMsg(): builtin_interfaces.msg.Time;
+
+    /**
      * Create a Time object from a message of builtin_interfaces/msg/Time
      *
      * @param msg - The Time message to be created from.


### PR DESCRIPTION
Adds Time#toMsg(): builtin_interfaces.msg/Time to satisfy #619.

- updated time.js with toMsg() function
- updated time.d.js with toMsg() declaration
- updated test-time.js with toMsg() conversion testcase
- updated main.ts with toMsg() typescript test