### PR TITLE
Fix test failures with dtslint v3.4

### DIFF
--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -6,11 +6,6 @@
     "target": "es6",
     /* Strict Type-Checking Options */
     "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
     /* Additional Checks */
     /* next line commented out because we need unused vars for type tests */
     // "noUnusedLocals": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,11 +5,6 @@
     "target": "es6",
     /* Strict Type-Checking Options */
     "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
     /* Additional Checks */
     /* next line commented out because we need unused vars for type tests */
     // "noUnusedLocals": true,


### PR DESCRIPTION
All options removed are automatically implied by `strict: true`.

Fix #None