### PR TITLE
Removes compiler format-string-literal warning

### DIFF
--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -1387,7 +1387,8 @@ NAN_METHOD(Log) {
   if (enabled) {
     rcutils_log_location_t logging_location = {function_name.c_str(),
                                                file_name.c_str(), line_number};
-    rcutils_log(&logging_location, severity, name.c_str(), message.c_str());
+    rcutils_log(&logging_location, severity, name.c_str(), "%s",
+        message.c_str());
   }
 
   info.GetReturnValue().Set(Nan::New(enabled));


### PR DESCRIPTION
Adds a literal "%s" format string which satisfies the compiler and eliminates the following compiler warning: 
```
../src/rcl_bindings.cpp: In function ‘Nan::NAN_METHOD_RETURN_TYPE rclnodejs::Log(Nan::NAN_METHOD_ARGS_TYPE)’:
../src/rcl_bindings.cpp:1390:75: warning: format not a string literal and no format arguments [-Wformat-security]
     rcutils_log(&logging_location, severity, name.c_str(), message.c_str());
```