### PR TITLE
Use libuv utilities to retrive symbols

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "spdlog"]
 	path = src/third_party/spdlog
 	url = https://github.com/gabime/spdlog.git
-[submodule "src/third_party/dlfcn-win32"]
-	path = src/third_party/dlfcn-win32
-	url = https://github.com/dlfcn-win32/dlfcn-win32.git

--- a/binding.gyp
+++ b/binding.gyp
@@ -75,9 +75,6 @@
               './src/third_party/dlfcn-win32/',
               "<!@(node -e \"console.log(process.env.AMENT_PREFIX_PATH.replace(/;/g, '\\\include ').replace(/\\\/g, '/') + '/include')\")",
             ],
-            'sources': [
-              './src/third_party/dlfcn-win32/dlfcn.c',
-            ],
             'msvs_settings': {
               'VCCLCompilerTool': {
                 'ExceptionHandling': '2', # /EHsc

--- a/src/rcl_action_bindings.cpp
+++ b/src/rcl_action_bindings.cpp
@@ -86,7 +86,7 @@ NAN_METHOD(ActionCreateClient) {
 
     info.GetReturnValue().Set(js_obj);
   } else {
-    Nan::ThrowError(GetErrorMessageAndClear());
+    Nan::ThrowError(GetErrorMessageAndClear().c_str());
   }
 }
 
@@ -154,7 +154,7 @@ NAN_METHOD(ActionCreateServer) {
 
     info.GetReturnValue().Set(js_obj);
   } else {
-    Nan::ThrowError(GetErrorMessageAndClear());
+    Nan::ThrowError(GetErrorMessageAndClear().c_str());
   }
 }
 

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -148,7 +148,7 @@ static const int PARAMETER_INTEGER_ARRAY = 7;
 static const int PARAMETER_DOUBLE_ARRAY = 8;
 static const int PARAMETER_STRING_ARRAY = 9;
 
-/* 
+/*
 Convert parsed ros arguments to parameters.
 
 type Parameter = {
@@ -697,7 +697,7 @@ NAN_METHOD(CreateSubscription) {
         });
     info.GetReturnValue().Set(js_obj);
   } else {
-    Nan::ThrowError(GetErrorMessageAndClear());
+    Nan::ThrowError(GetErrorMessageAndClear().c_str());
   }
 }
 
@@ -747,7 +747,7 @@ NAN_METHOD(CreatePublisher) {
     // Everything is done
     info.GetReturnValue().Set(js_obj);
   } else {
-    Nan::ThrowError(GetErrorMessageAndClear());
+    Nan::ThrowError(GetErrorMessageAndClear().c_str());
   }
 }
 
@@ -809,7 +809,7 @@ NAN_METHOD(CreateClient) {
 
     info.GetReturnValue().Set(js_obj);
   } else {
-    Nan::ThrowError(GetErrorMessageAndClear());
+    Nan::ThrowError(GetErrorMessageAndClear().c_str());
   }
 }
 
@@ -886,7 +886,7 @@ NAN_METHOD(CreateService) {
 
     info.GetReturnValue().Set(js_obj);
   } else {
-    Nan::ThrowError(GetErrorMessageAndClear());
+    Nan::ThrowError(GetErrorMessageAndClear().c_str());
   }
 }
 

--- a/src/rcl_utilities.hpp
+++ b/src/rcl_utilities.hpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string>
-
 #ifndef RCLNODEJS_RCL_UTILITIES_HPP_
 #define RCLNODEJS_RCL_UTILITIES_HPP_
+
+#include <string>
 
 struct rosidl_message_type_support_t;
 struct rosidl_service_type_support_t;
@@ -36,7 +36,7 @@ const rosidl_action_type_support_t* GetActionTypeSupport(
     const std::string& package_name,
     const std::string& action_name);
 
-const char* GetErrorMessageAndClear();
+std::string GetErrorMessageAndClear();
 
 }  // namespace rclnodejs
 


### PR DESCRIPTION
Before the patch, we use dlfcn wrappered as POSIX APIs to load library
dynamically and find the wanted symbols on Windows.

This patch replaces these functions with the ones offered by libuv and
removes the dlfcn as a third-party dependency.

doc: http://docs.libuv.org/en/stable/dll.html

Fix #613