### PR TITLE
Remove spdlog as dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "spdlog"]
-	path = src/third_party/spdlog
-	url = https://github.com/gabime/spdlog.git

--- a/README.md
+++ b/README.md
@@ -54,12 +54,6 @@ Open a terminal, and input:
 git clone https://github.com/RobotWebTools/rclnodejs.git
 ```
 
-then enter the folder `rclnodejs`, and get the submodule:
-
-```bash
-git submodule update --init --recursive
-```
-
 ### Build Module
 
 Before you build the module, you should make sure the ROS2 environments were loaded. You can check if the `AMENT_PREFIX_PATH` environment variable was set:

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,7 @@
     'default_configuration': 'Release',
     'configurations': {
       'Debug': {
-        'defines': ['SPDLOG_DEBUG_ON'],
+        'defines': ['DEBUG_ON'],
       },
     }
   },
@@ -22,7 +22,6 @@
       ],
       'include_dirs': [
         '.',
-        'src/third_party/spdlog/include/',
         "<!(node -e \"require('nan')\")",
       ],
       'cflags!': [

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -14,15 +14,13 @@
 
 #include <nan.h>
 
+#include "macros.hpp"
 #include "rcl_action_bindings.hpp"
 #include "rcl_bindings.hpp"
 #include "rcl_handle.hpp"
+#include "rcutils/logging.h"
+#include "rcutils/macros.h"
 #include "shadow_node.hpp"
-#include "spdlog/spdlog.h"
-
-#ifdef SPDLOG_DEBUG_ON
-#include "spdlog/sinks/stdout_color_sinks.h"
-#endif
 
 void InitModule(v8::Local<v8::Object> exports) {
   v8::Local<v8::Context> context = exports->GetIsolate()->GetCurrentContext();
@@ -51,9 +49,10 @@ void InitModule(v8::Local<v8::Object> exports) {
   rclnodejs::ShadowNode::Init(exports);
   rclnodejs::RclHandle::Init(exports);
 
-#ifdef SPDLOG_DEBUG_ON
-  auto console = spdlog::stdout_color_mt("rclnodejs");
-  console->set_level(spdlog::level::debug);
+#ifdef DEBUG_ON
+  int result = rcutils_logging_set_logger_level(PACKAGE_NAME,
+                                                RCUTILS_LOG_SEVERITY_DEBUG);
+  RCUTILS_UNUSED(result);
 #endif
 }
 

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -20,8 +20,8 @@
 #include <string>
 
 #include "handle_manager.hpp"
+#include "macros.hpp"
 #include "rcl_bindings.hpp"
-#include "spdlog/spdlog.h"
 
 #ifdef WIN32
 #define UNUSED
@@ -106,7 +106,7 @@ void Executor::Stop() {
                });
       while (!handle_closed) uv_run(uv_default_loop(), UV_RUN_ONCE);
 
-      SPDLOG_DEBUG(spdlog::get("rclnodejs"), "Background thread stopped.");
+      RCLNODEJS_DEBUG("Background thread stopped.");
     }
   }
 }
@@ -117,7 +117,7 @@ void Executor::DoWork(uv_async_t* handle) {
 }
 
 void Executor::Run(void* arg) {
-  SPDLOG_DEBUG(spdlog::get("rclnodejs"), "Background thread started.");
+  RCLNODEJS_DEBUG("Background thread started.");
   Executor* executor = reinterpret_cast<Executor*>(arg);
   HandleManager* handle_manager = executor->handle_manager_;
 

--- a/src/handle_manager.cpp
+++ b/src/handle_manager.cpp
@@ -18,7 +18,7 @@
 
 #include <vector>
 
-#include "spdlog/spdlog.h"
+#include "macros.hpp"
 
 namespace rclnodejs {
 
@@ -81,11 +81,11 @@ void HandleManager::CollectHandles(const v8::Local<v8::Object> node) {
   is_synchronizing_.store(false);
   uv_sem_post(&sem_);
 
-  SPDLOG_DEBUG(spdlog::get("rclnodejs"),
-               "Add {0:d} timers, {1:d} subscriptions, {2:d} clients, " +
-                   "{3:d} services, {4:d} guards.",
-               timers_.size(), subscriptions_.size(), clients_.size(),
-               services_.size(), guard_conditions_.size());
+  RCLNODEJS_DEBUG(
+      "Add %lu timers, %lu subscriptions, %lu clients, %lu services, %lu "
+      "guards.",
+      timers_.size(), subscriptions_.size(), clients_.size(), services_.size(),
+      guard_conditions_.size());
 }
 
 bool HandleManager::AddHandlesToWaitSet(rcl_wait_set_t* wait_set) {

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -15,6 +15,8 @@
 #ifndef RCLNODEJS_MARCOS_HPP_
 #define RCLNODEJS_MARCOS_HPP_
 
+#include "rcutils/logging_macros.h"
+
 #define CHECK_OP_AND_THROW_ERROR_IF_NOT_TRUE(op, lhs, rhs, message) \
   {                                                                 \
     if (lhs op rhs) {                                               \
@@ -30,5 +32,16 @@
 
 #define THROW_ERROR_IF_EQUAL(lhs, rhs, message) \
   CHECK_OP_AND_THROW_ERROR_IF_NOT_TRUE(==, lhs, rhs, message)
+
+#define PACKAGE_NAME "rclnodejs"
+
+#ifdef DEBUG_ON
+#define RCLNODEJS_DEBUG(...)                                   \
+  RCUTILS_LOG_COND_NAMED(                                      \
+      RCUTILS_LOG_SEVERITY_DEBUG, RCUTILS_LOG_CONDITION_EMPTY, \
+      RCUTILS_LOG_CONDITION_EMPTY, PACKAGE_NAME, __VA_ARGS__)
+#else
+#define RCLNODEJS_DEBUG(...)
+#endif
 
 #endif


### PR DESCRIPTION
Currently, we depend on spdlog to log for C++ codes when debug build.
The reason is that there was no logging util in the early stage.

This patch uses the logging util from rcutils to replace spdlog.
Thus, we can remove the spdlog as a dependency and reduce
the size of npm package also.

Fix #634