### PR TITLE
Remove extraneous surrounding namespace from DEFAULT_OPTIONS

### DIFF
--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -33,6 +33,18 @@ declare module 'rclnodejs' {
   }
 
   /**
+   * Default options when creating a Node, Publisher, Subscription, Client or Service
+   *
+   * ```ts
+   * {
+   *   enableTypedArray: true,
+   *   qos: QoS.profileDefault
+   * }
+   * ```
+   */
+  const DEFAULT_OPTIONS: Options;
+
+  /**
    * A service response to a client request.
    *
    * @remarks
@@ -659,18 +671,4 @@ declare module 'rclnodejs' {
     countSubscribers(topic: string): number;
   }
 
-  namespace rclnodejs {
-    /**
-     * Default options when creating a Node, Publisher, Subscription, Client or Service
-     *
-     * ```ts
-     * {
-     *   enableTypedArray: true,
-     *   qos: QoS.profileDefault
-     * }
-     *
-     * ```
-     */
-    export const DEFAULT_OPTIONS: Options;
-  }
 }


### PR DESCRIPTION
This PR removes an unnecessary inner rclnodejs namespace that wraps DEFAULT_OPTIONS.

The current node.d.ts typings includes an Options interface as well as a DEFAULT_OPTIONS constant. DEFAULT_OPTIONS maps to a JS constant in node.js. At issue is the current TS declaration incorrectly wraps DEFAULT_OPTIONS in an inner 'rclnodejs' namespace. Thus to access it one must use rclnodejs.rclnodejs.DEFAULT_OPTIONS. Propose removing the inner rclnodejs namespace.