### PR TITLE
Use Read-write locks to protect the data shared between threads

### DIFF
--- a/src/executor.hpp
+++ b/src/executor.hpp
@@ -29,6 +29,7 @@ struct rcl_context_t;
 namespace rclnodejs {
 
 class HandleManager;
+struct RclResult;
 
 class Executor {
  public:
@@ -50,7 +51,10 @@ class Executor {
   static void Run(void* arg);
 
  private:
-  bool WaitForReadyCallbacks(rcl_wait_set_t* wait_set, int32_t time_out);
+  // Returns RclResult object which indicates the final result.
+  RclResult WaitForReadyCallbacks(rcl_wait_set_t* wait_set, int32_t time_out);
+
+  // Calls the callback of the ready handle.
   void ExecuteReadyHandles();
 
   uv_async_t* async_;

--- a/src/shadow_node.cpp
+++ b/src/shadow_node.cpp
@@ -84,12 +84,12 @@ void ShadowNode::StopRunning() {
 }
 
 void ShadowNode::StartRunning(rcl_context_t* context, int32_t timeout) {
-  handle_manager_->CollectHandles(this->handle());
+  handle_manager_->SynchronizeHandles(this->handle());
   executor_->Start(context, timeout);
 }
 
 void ShadowNode::RunOnce(rcl_context_t* context, int32_t timeout) {
-  handle_manager_->CollectHandles(this->handle());
+  handle_manager_->SynchronizeHandles(this->handle());
   executor_->SpinOnce(context, timeout);
 }
 
@@ -127,7 +127,7 @@ NAN_METHOD(ShadowNode::SpinOnce) {
 NAN_METHOD(ShadowNode::SyncHandles) {
   auto* me = Nan::ObjectWrap::Unwrap<ShadowNode>(info.Holder());
   if (me) {
-    me->handle_manager()->CollectHandles(me->handle());
+    me->handle_manager()->SynchronizeHandles(me->handle());
   }
 }
 


### PR DESCRIPTION
Currently, we are using uv_mutex_lock/uv_mutex_unlock to protect data
shared between threads, but we could use Read-write locks to make it
more efficient.

Fix #649