### PR TITLE
Gen 'number[] | typed-array' union in tsd files #658

### DIFF
--- a/rostsd_gen/index.js
+++ b/rostsd_gen/index.js
@@ -406,7 +406,7 @@ function primitiveType2JSName(type) {
     case 'char':
     case 'byte':
     case 'octet':
-    
+
     // signed explicit integer types
     case 'short':
     case 'long':
@@ -461,6 +461,7 @@ function fieldTypeArray2JSTypedArrayName(type) {
     case 'uint8':
       jsName = 'Uint8Array';
       break;
+    case 'char':
     case 'int8':
       jsName = 'Int8Array';
       break;

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -306,6 +306,48 @@ logger.error('test msg');
 // $ExpectType boolean
 logger.fatal('test msg');
 
+// FOXY-ONLY, example_interfaces introduced with foxy release
+// ---- Int8Array ----
+const i8arr = rclnodejs.require('example_interfaces.msg.Int8MultiArray') as rclnodejs.example_interfaces.msg.Int8MultiArray;
+// $ExpectType number[] | Int8Array
+i8arr.data;
+
+// ---- Uint8Array ----
+const u8arr = rclnodejs.require('example_interfaces.msg.UInt8MultiArray') as rclnodejs.example_interfaces.msg.UInt8MultiArray;
+// $ExpectType number[] | Uint8Array
+u8arr.data;
+
+// ---- Int16Array ----
+const i16arr = rclnodejs.require('example_interfaces.msg.Int16MultiArray') as rclnodejs.example_interfaces.msg.Int16MultiArray;
+// $ExpectType number[] | Int16Array
+i16arr.data;
+
+// ---- Uint16Array ----
+const u16arr = rclnodejs.require('example_interfaces.msg.UInt16MultiArray') as rclnodejs.example_interfaces.msg.UInt16MultiArray;
+// $ExpectType number[] | Uint16Array
+u16arr.data;
+
+// ---- Int32Array ----
+const i32arr = rclnodejs.require('example_interfaces.msg.Int32MultiArray') as rclnodejs.example_interfaces.msg.Int32MultiArray;
+// $ExpectType number[] | Int32Array
+i32arr.data;
+
+// ---- Uint16Array ----
+const u32arr = rclnodejs.require('example_interfaces.msg.UInt32MultiArray') as rclnodejs.example_interfaces.msg.UInt32MultiArray;
+// $ExpectType number[] | Uint32Array
+u32arr.data;
+
+// ---- Float32Array ----
+const f32arr = rclnodejs.require('example_interfaces.msg.Float32MultiArray') as rclnodejs.example_interfaces.msg.Float32MultiArray;
+// $ExpectType number[] | Float32Array
+f32arr.data;
+
+// ---- Float64Array ----
+const f64arr = rclnodejs.require('example_interfaces.msg.Float64MultiArray') as rclnodejs.example_interfaces.msg.Float64MultiArray;
+// $ExpectType number[] | Float64Array
+f64arr.data;
+
+
 // $ExpectType FibonacciConstructor
 const Fibonacci = rclnodejs.require('rclnodejs_test_msgs/action/Fibonacci');
 
@@ -402,3 +444,5 @@ function executeCallback(
 
   return new Fibonacci.Result();
 }
+
+


### PR DESCRIPTION
rostsd_gen/index.js
* Previously numeric idl array types were generated as a simple `number[]`. Now some of them are generate as a type union of `number[] | <typed-array>`

Implemented mapping of [IDL numeric type arrays](https://design.ros2.org/articles/idl_interface_definition.html) to JavaScript typed-array. Additional support was found by inspecting the the [idl parser code](https://github.com/ros2/rosidl/blob/master/rosidl_parser/rosidl_parser/definition.py).

| IDL type | JS type generated |
|---------|--------------------|
| byte[]       | number[] \| Uint8Array |
| octet[]     |number[] \| Uint8Array |
| uint8[]  | number[] \| Uint8Array |
| int8[]     | number[] \| Int8Array|
| int16[]     | number[] \| Int16Array|
| short[]     | number[] \| Int16Array|
| uint16[]     | number[] \| Uint16Array|
| unsigned short| number[] \| Uint16Array|
| int32[]     | number[] \| Int32Array|
| long[]     | number[] \| Int32Array|
| uint32[]     | number[] \| Uint32Array|
| unsigned long[]     | number[] \| Uint32Array|
| float[] | number[] \| Float32Array |
| float32[] | number[] \| Float32Array |
| double[] | number[] \| Float64Array |
| float64[] | number[] \| Float64Array |
| int64[] | number[] |
| uint64[] | number[] |
| long long | number[] |
|unsigned long long| number[] |

test/types/main.ts
* added tests to support new number array union types, e.g., number[] |
typed-array