### PR TITLE
fix compatibility for eloquent

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,6 +7,9 @@
       },
     }
   },
+  'variables': {
+    'ros_version': '<!(node scripts/ros_distro.js)'
+  },
   'targets': [
     {
       'target_name': 'rclnodejs',
@@ -43,6 +46,9 @@
         '-lrcl_yaml_param_parser',
         '-lrmw',
         '-lrosidl_runtime_c',
+      ],
+      'defines': [
+        'ROS_VERSION=<(ros_version)'
       ],
       'conditions': [
         [
@@ -103,6 +109,17 @@
               'MACOS_DEPLOYMENT_TARGET': '10.12',
               'CLANG_CXX_LANGUAGE_STANDARD': 'c++14'
             }
+          }
+        ],
+        [
+          'ros_version<=1911',
+          {
+            'libraries': [
+              '-lrosidl_generator_c'
+            ],
+            'libraries!': [
+              '-lrosidl_runtime_c'
+            ]
           }
         ]
       ]

--- a/scripts/ros_distro.js
+++ b/scripts/ros_distro.js
@@ -1,0 +1,16 @@
+'use strict';
+
+switch (process.env.ROS_DISTRO) {
+  case 'eloquent':
+    console.log('1911');
+    process.exit(0);
+  case 'foxy':
+    console.log('2006');
+    process.exit(0);
+  case undefined:
+    console.error('Unable to detect ROS, please make sure a supported version of ROS is sourced');
+    process.exit(1);
+  default:
+    console.error(`Unknown or unsupported ROS version "${process.env.ROS_DISTRO}"`);
+    process.exit(1);
+}

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -30,7 +30,11 @@
 #include <rmw/validate_full_topic_name.h>
 #include <rmw/validate_namespace.h>
 #include <rmw/validate_node_name.h>
+#if ROS_VERSION >= 2006
 #include <rosidl_runtime_c/string_functions.h>
+#else
+#include <rosidl_generator_c/string_functions.h>
+#endif
 
 #include <memory>
 #include <string>
@@ -1277,10 +1281,17 @@ NAN_METHOD(Shutdown) {
 NAN_METHOD(InitString) {
   void* buffer =
       node::Buffer::Data(Nan::To<v8::Object>(info[0]).ToLocalChecked());
+#if ROS_VERSION >= 2006
   rosidl_runtime_c__String* ptr =
       reinterpret_cast<rosidl_runtime_c__String*>(buffer);
 
   rosidl_runtime_c__String__init(ptr);
+#else
+  rosidl_generator_c__String* ptr =
+      reinterpret_cast<rosidl_generator_c__String*>(buffer);
+
+  rosidl_generator_c__String__init(ptr);
+#endif
   info.GetReturnValue().Set(Nan::Undefined());
 }
 


### PR DESCRIPTION
fix: compatibility for eloquent

v0.14.1 introduces support for ROS2 foxy however it also drops support for eloquent. This breaks existing users on v0.14.0+eloquent that expects api to remain stable when upgrading to a patch release.