### PR TITLE
multiple context support #668

### DIFF
--- a/example/rate-example.js
+++ b/example/rate-example.js
@@ -35,7 +35,7 @@ async function main() {
     undefined,
     msg => console.log(`Received(${Date.now()}): ${msg.data}`)
   );
-  const rate = node.createRate(0.5);
+  const rate = await node.createRate(0.5);
 
   setInterval(() => publisher.publish(`hello ${Date.now()}`), 10);
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -330,8 +330,8 @@ class Node {
     });
   }
 
-  startSpinning(context, timeout) {
-    this.start(context, timeout);
+  startSpinning(timeout) {
+    this.start(this.context.handle(), timeout);
     this.spinning = true;
   }
 
@@ -382,16 +382,20 @@ class Node {
    * Create a Timer.
    * @param {number} period - The number representing period in millisecond.
    * @param {function} callback - The callback to be called when timeout.
-   * @param {Context} context - The context, default is Context.defaultContext().
-   * @param {Clock} clock - The clock which the timer gets time from.
+   * @param {Clock} [clock] - The clock which the timer gets time from.
    * @return {Timer} - An instance of Timer.
    */
   createTimer(
     period,
     callback,
-    context = Context.defaultContext(),
     clock = null
   ) {
+    if (arguments.length === 3 && !(arguments[2] instanceof Clock)) {
+      clock = null;
+    } else if (arguments.length === 4) {
+      clock = arguments[3];
+    }
+
     if (typeof period !== 'number' || typeof callback !== 'function') {
       throw new TypeError('Invalid argument');
     }
@@ -413,7 +417,7 @@ class Node {
 
     let timerHandle = rclnodejs.createTimer(
       timerClock.handle,
-      context.handle(),
+      this.context.handle(),
       period
     );
     let timer = new Timer(timerHandle, period, callback);
@@ -428,9 +432,9 @@ class Node {
    * Create a Rate.
    *
    * @param {number} hz - The frequency of the rate timer; default is 1 hz.
-   * @returns {Rate} - New instance
+   * @returns {Promise<Rate>} - Promise resolving to new instance of Rate.
    */
-  createRate(hz = 1) {
+  async createRate(hz = 1) {
     if (typeof hz !== 'number') {
       throw new TypeError('Invalid argument');
     }
@@ -445,6 +449,7 @@ class Node {
     // lazy initialize rateTimerServer
     if (!this._rateTimerServer) {
       this._rateTimerServer = new Rates.RateTimerServer(this);
+      await this._rateTimerServer.init();
     }
 
     const period = Math.round(1000 / hz);

--- a/lib/rate.js
+++ b/lib/rate.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const rclnodejs = require('bindings')('rclnodejs');
+const rclnodejs = require('../index.js');
 const Context = require('./context.js');
 const NodeOptions = require('./node_options.js');
 
@@ -40,7 +40,7 @@ const NOP_FN = () => {};
  * async function run() {
  *   await rclnodejs.init();
  *   const node = rclnodejs.createNode('mynode');
- *   const rate = node.createRate(1); // 1 hz
+ *   const rate = await node.createRate(1); // 1 hz
  *   while (true) {
  *     doSomeStuff();
  *     await rate.sleep();
@@ -131,30 +131,32 @@ class RateTimerServer {
    *  supplies timers to.
    */
   constructor(parentNode) {
+    this._parentNode = parentNode;
     this._context = new Context();
+  }
 
-    // init rcl environment
-    rclnodejs.init(this._context.handle());
+  /**
+   * Setup the server's rcl context and node in preparation for creating
+   * rate timer instances.
+   * 
+   * @returns {undefined}
+   */
+  async init() {
+    await rclnodejs.init(this._context);
 
     // create hidden node
-    const nodeName = `_${parentNode.name()}_rate_timer_server`;
-    const nodeNamespace = parentNode.namespace();
-    this._node = new rclnodejs.ShadowNode();
-    this._node.handle = rclnodejs.createNode(
-      nodeName,
-      nodeNamespace,
-      this._context.handle()
-    );
-
+    const nodeName = `_${this._parentNode.name()}_rate_timer_server`;
+    const nodeNamespace = this._parentNode.namespace();
     const options = new NodeOptions();
     options.startParameterServices = false;
-    options.parameterOverrides = parentNode.getParameters();
+    options.parameterOverrides = this._parentNode.getParameters();
     options.automaticallyDeclareParametersFromOverrides = true;
 
-    this._node.init(nodeName, nodeNamespace, this._context, options);
+    this._node = 
+      rclnodejs.createNode(nodeName, nodeNamespace, this._context, options);
 
     // spin node
-    this._node.startSpinning(this._context.handle(), 10);
+    rclnodejs.spin(this._node, 10);
   }
 
   /**
@@ -164,7 +166,7 @@ class RateTimerServer {
    * @returns {Timer} - The new timer instance.
    */
   createTimer(period) {
-    const timer = this._node.createTimer(period, () => {}, this._context);
+    const timer = this._node.createTimer(period, () => {});
     return timer;
   }
 
@@ -178,8 +180,7 @@ class RateTimerServer {
    * @returns {undefined}
    */
   shutdown() {
-    this._node.destroy();
-    this._context.shutdown();
+    rclnodejs.shutdown(this._context);
   }
 }
 // module.exports = {Rate, RateTimerServer};

--- a/test/test-init-shutdown.js
+++ b/test/test-init-shutdown.js
@@ -160,4 +160,39 @@ describe('Node destroy testing', function() {
       rclnodejs.createNode('my_node');
     });
   });
+
+  it('rclnodejs multiple contexts init shutdown sequence', async function() {
+    await rclnodejs.init();
+    assert.ok(!rclnodejs.isShutdown());
+
+    let ctx = new rclnodejs.Context();
+    await rclnodejs.init(ctx);
+    assert.ok(!rclnodejs.isShutdown(ctx));
+    assert.ok(!rclnodejs.isShutdown());
+
+    assert.doesNotThrow(() => rclnodejs.shutdown());
+    assert.ok(rclnodejs.isShutdown());
+    assert.ok(!rclnodejs.isShutdown(ctx));
+
+    assert.doesNotThrow(() => rclnodejs.shutdown(ctx));
+    assert.ok(rclnodejs.isShutdown());
+    assert.ok(rclnodejs.isShutdown(ctx));
+
+    // repeat
+    await rclnodejs.init();
+    assert.ok(!rclnodejs.isShutdown());
+
+    ctx = new rclnodejs.Context();
+    await rclnodejs.init(ctx);
+    assert.ok(!rclnodejs.isShutdown(ctx));
+    assert.ok(!rclnodejs.isShutdown());
+
+    assert.doesNotThrow(() => rclnodejs.shutdown());
+    assert.ok(rclnodejs.isShutdown());
+    assert.ok(!rclnodejs.isShutdown(ctx));
+
+    assert.doesNotThrow(() => rclnodejs.shutdown(ctx));
+    assert.ok(rclnodejs.isShutdown());
+    assert.ok(rclnodejs.isShutdown(ctx));
+  });
 });

--- a/test/test-rate.js
+++ b/test/test-rate.js
@@ -41,33 +41,39 @@ describe('rclnodejs rate test suite', function() {
     rclnodejs.shutdown();
   });
 
-  it('rate constructor tests', function() {
-    const rate1 = node.createRate();
+  it('rate constructor tests', async function() {
+    const rate1 = await node.createRate();
     assert.equal(rate1.frequency, 1);
 
-    const rate2 = node.createRate(1000);
+    const rate2 = await node.createRate(1000);
     assert.equal(rate2.frequency, 1000);
 
-    const rate3 = node.createRate(0.001);
+    const rate3 = await node.createRate(0.001);
     assert.equal(rate3.frequency, 0.001);
 
-    assertThrowsError(() => {
-      node.createRate(1001);
-    }, RangeError);
+    try {
+      await node.createRate(1001);
+      assert.fail(false);
+    } catch (err) {
+      assert.ok(err instanceof RangeError);
+    }
 
-    assertThrowsError(() => {
-      node.createRate(0);
-    }, RangeError);
+    try {
+      await node.createRate(0);
+      assert.fail(false);
+    } catch (err) {
+      assert.ok(err instanceof RangeError);
+    }
   });
 
-  it('rate api tests', function() {
-    const rate = node.createRate();
+  it('rate api tests', async function() {
+    const rate = await node.createRate();
     assert.equal(rate.frequency, 1);
     assert.equal(rate.isCanceled(), false);
   });
 
   it('rate sleep cancel tests', async function() {
-    const rate = node.createRate();
+    const rate = await node.createRate();
     assert.equal(rate.isCanceled(), false);
 
     rate.cancel();
@@ -77,7 +83,7 @@ describe('rclnodejs rate test suite', function() {
   });
 
   it('rate server node naming test', async function() {
-    const rate = node.createRate();
+    const rate = await node.createRate();
     await assertUtils.createDelay(1000);
     const rateTimerServerName = `_${node.name()}_rate_timer_server`;
     assert.ok(node.getNodeNames().includes(rateTimerServerName));
@@ -88,7 +94,7 @@ describe('rclnodejs rate test suite', function() {
     //   collect and average the sleep intervals
     //   compare average sleep interval with the period of the timer
     const hz = 1000;
-    const rate = node.createRate(hz);
+    const rate = await node.createRate(hz);
 
     const dataSize = hz * 3;
     const arr = new Array(dataSize).fill(0);

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -171,21 +171,23 @@ timer.isCanceled();
 // $ExpectType void
 timer.cancel();
 
-// ---- Rate ----
-// $ExpectType Rate
-const rate = node.createRate(1);
+(async () => {
+  // ---- Rate ----
+  // $ExpectType Rate
+  const rate = await node.createRate(1);
 
-// $ExpectType number
-rate.frequency;
+  // $ExpectType number
+  rate.frequency;
 
-// $ExpectType boolean
-rate.isCanceled();
+  // $ExpectType boolean
+  rate.isCanceled();
 
-// $ExpectType Promise<void>
-rate.sleep();
+  // $ExpectType Promise<void>
+  rate.sleep();
 
-// $ExpectType void
-rate.cancel();
+  // $ExpectType void
+  rate.cancel();
+})();
 
 // ---- Duration ----
 // $ExpectType Duration

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -221,22 +221,22 @@ declare module 'rclnodejs' {
      *
      * @param period - Elapsed time between interrupt events (milliseconds).
      * @param callback - Called on timeout interrupt.
-     * @param context - Context, default is Context.defaultContext().
+     * @param clock - Optional clock to use for the timer.
      * @returns New instance of Timer.
      */
     createTimer(
       period: number,
       callback: TimerRequestCallback,
-      context?: Context
+      clock?: Clock
     ): Timer;
 
     /**
      * Create a Rate.
      *
      * @param hz - The frequency of the rate timer; default is 1 hz.
-     * @returns New instance of Rate.
+     * @returns Promise resolving to new instance of Rate.
      */
-    createRate(hz: number): Rate;
+    createRate(hz: number): Promise<Rate>;
 
     /**
      * Create a Publisher.


### PR DESCRIPTION
Adds the ability to support multiple simultaneous rcl contexts, #668.

index.js
* Replaced _nodes array with a Map<context,Array<Node>. A list of nodes
is maintained for each context provided to rcl.init(context,argv).
* Moved to end of file the import of node.js and time_source.js, the
TimeSource property and ShadowNode inheritance function call. This
change was made to workaround a circular dependency in rate.js.
* Added context parameter to
`isShutdown(context=Context.defaultContext())`

node.js
* Changed createRate() to return Promise<Rate>
* Removed the context parameter from createTimer()

rate.js
* Reimplemented RateTimerServer to use public rclnodejs methods.
* Added `init(): Promise<void>` method which creates internal private
context and node

test-init-shutdown.js
* Updated to include a multiple-contexts testcase

test-rate.js
* Updated to use node.createRate(): Promise<Rate> correctly.

node.d.ts
* Removed context parameter from createTimer() method declaration.

main.ts
* Updated Rate tests for async node.createRate()