### PR TITLE
Fix double-free when using typed array

### DIFF
--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -460,7 +460,7 @@ class {{=objectWrapper}} {
     if (refObject.{{=field.name}}.size != 0) {
       {{=getWrapperNameByType(field.type)}}.ArrayType.freeArray(refObject.{{=field.name}});
       if ({{=getWrapperNameByType(field.type)}}.ArrayType.useTypedArray) {
-        deallocator.delayFreeStructMember(refObject.{{=field.name}}, {{=getWrapperNameByType(field.type)}}.refObjectArrayType, 'data');
+        // Do nothing, the v8 will take the ownership of the ArrayBuffer used by the typed array.
       } else {
         deallocator.freeStructMember(refObject.{{=field.name}}, {{=getWrapperNameByType(field.type)}}.refObjectArrayType, 'data');
       }

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -1318,12 +1318,15 @@ NAN_METHOD(FreeMemeoryAtOffset) {
 }
 
 NAN_METHOD(CreateArrayBufferFromAddress) {
-  auto address = GetBufAddr(info[0]);
+  char* addr = GetBufAddr(info[0]);
   int32_t length = Nan::To<int32_t>(info[1]).FromJust();
 
-  auto array_buffer =
-      v8::ArrayBuffer::New(v8::Isolate::GetCurrent(), address, length,
-                           v8::ArrayBufferCreationMode::kExternalized);
+  // We will create an ArrayBuffer with mode of
+  // ArrayBufferCreationMode::kInternalized and copy data starting from |addr|,
+  // thus the memory block will be collected by the garbage collector.
+  v8::Local<v8::ArrayBuffer> array_buffer =
+      v8::ArrayBuffer::New(v8::Isolate::GetCurrent(), addr, length,
+                           v8::ArrayBufferCreationMode::kInternalized);
 
   info.GetReturnValue().Set(array_buffer);
 }


### PR DESCRIPTION
This patch enables to transfer the ownership of ArrayBuffer to v8
when deserializing the messages, which has type of TypedArray.
This will avoid double-free when the v8 executes gc.

Fix #673