### PR TITLE
Add missing type declarations for action server/client destroy methods

### DIFF
--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -367,6 +367,9 @@ client.isServiceServerAvailable();
 // $ExpectType Promise<boolean>
 actionClient.waitForServer();
 
+// $ExpectType void
+actionClient.destroy();
+
 // $ExpectType Promise<ClientGoalHandle<"rclnodejs_test_msgs/action/Fibonacci">>
 const goalHandlePromise = actionClient.sendGoal(new Fibonacci.Goal());
 
@@ -410,6 +413,9 @@ actionServer.registerCancelCallback();
 
 // $ExpectType void
 actionServer.registerExecuteCallback(() => new Fibonacci.Result());
+
+// $ExpectType void
+actionServer.destroy();
 
 function executeCallback(
   goalHandle: rclnodejs.ServerGoalHandle<'rclnodejs_test_msgs/action/Fibonacci'>

--- a/types/action_client.d.ts
+++ b/types/action_client.d.ts
@@ -132,5 +132,10 @@ declare module 'rclnodejs' {
      * @returns True if the service is available.
      */
     waitForServer(timeout?: number): Promise<boolean>;
+
+    /**
+     * Destroy the underlying action client handle.
+     */
+    destroy(): void;
   }
 }

--- a/types/action_server.d.ts
+++ b/types/action_server.d.ts
@@ -173,5 +173,10 @@ declare module 'rclnodejs' {
      * @param executeCallback - Callback function.
      */
     registerExecuteCallback(executeCallback: ExecuteCallback<T>): void;
+
+    /**
+     * Destroy the action server and all goals.
+     */
+    destroy(): void;
   }
 }


### PR DESCRIPTION
Action servers and clients are not created through a node and therefore don't have corresponding destroy methods on the Node class. Instead, to destroy an action server/client outside of destroying the Node itself it is expected to call `destroy` on the server/client directly. This adds the type declarations for the `destroy` function which were missing.

Fix #687