### PR TITLE
Improve tsd generation resilency.

### DIFF
--- a/rostsd_gen/index.js
+++ b/rostsd_gen/index.js
@@ -65,7 +65,7 @@ function getPkgInfos(generatedRoot) {
     for (let filename of files) {
       const typeClass = fileName2Typeclass(filename);
 
-      if (typeClass.type === 'srv') {
+      if (typeClass.type && typeClass.type.startsWith('srv')) {
         // skip __srv__<action>
         if (
           !typeClass.name.endsWith('_Request') &&
@@ -90,7 +90,7 @@ function getPkgInfos(generatedRoot) {
         def: def,
       };
 
-      if (typeClass.type === 'action') {
+      if (typeClass.type && typeClass.type.startsWith('action')) {
         pkgInfo.actions.push(msgInfo);
       } else {
         pkgInfo.messages.push(msgInfo);


### PR DESCRIPTION
rostsd_gen/index.js
- support service idl defined in any folder starting with 'srv', e.g.,
'srvs'
-  support action idl defined in any folder starting with 'action',
e.g., 'actions'

Fix #688