### PR TITLE
Changed TimeSource subscription to use topic `/clock`

### DIFF
--- a/lib/time_source.js
+++ b/lib/time_source.js
@@ -22,7 +22,7 @@ const { Parameter, ParameterType } = require('./parameter.js');
 const Time = require('./time.js');
 
 const USE_SIM_TIME_PARAM = 'use_sim_time';
-const CLOCK_TOPIC = 'clock';
+const CLOCK_TOPIC = '/clock';
 
 /**
  * @class - Class representing a TimeSource in ROS

--- a/test/test-time-source.js
+++ b/test/test-time-source.js
@@ -51,7 +51,7 @@ describe('rclnodejs TimeSource testing', function() {
   });
 
   function publishClockMessage(node) {
-    let pub = node.createPublisher('builtin_interfaces/msg/Time', 'clock');
+    let pub = node.createPublisher('builtin_interfaces/msg/Time', '/clock');
     let count = 0;
     timer = setInterval(() => {
       pub.publish({ sec: count, nanosec: 0 });


### PR DESCRIPTION
Changed TimeSource subscription and test-time-source.js to use topic `/clock` in place of `clock`. 

I initiated a discussion on issue #696 describing the need for this small change when using sim-time. I am proactively submitting this PR prior to agreement for the need to use topic `/clock`.

Fix #696