### PR TITLE
Support to publish serialized messages

### DIFF
--- a/example/publisher-raw-message.js
+++ b/example/publisher-raw-message.js
@@ -1,0 +1,43 @@
+// Copyright (c) 2020 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/* eslint-disable camelcase */
+
+const rclnodejs = require('../index.js');
+
+rclnodejs
+  .init()
+  .then(() => {
+    const node = rclnodejs.createNode('publisher_message_example_node');
+
+    // We have to make sure the message type of publisher and subscription is
+    // the same, although it seems meaningless when sending raw messages.
+    const publisher = node.createPublisher(
+      'test_msgs/msg/BasicTypes',
+      'chatter'
+    );
+    let count = 0;
+
+    setInterval(function () {
+      publisher.publish(Buffer.from('Hello ROS World'));
+      console.log(`Publish ${++count} messages.`);
+    }, 1000);
+
+    rclnodejs.spin(node);
+  })
+  .catch((e) => {
+    console.log(e);
+  });

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -38,21 +38,27 @@ class Publisher extends Entity {
 
   /**
    * Publish a message
-   * @param {object} message - The message to be sent.
+   * @param {object|Buffer} message - The message to be sent, could be kind of JavaScript message generated from .msg
+   *                                                          or be a Buffer for a raw message.
    * @return {undefined}
    */
   publish(message) {
-    // Enables call by plain object/number/string argument
-    //  e.g. publisher.publish(3.14);
-    //       publisher.publish('The quick brown fox...');
-    //       publisher.publish({linear: {x: 0, y: 1, z: 2}, ...});
-    let messageToSend =
-      message instanceof this._typeClass
-        ? message
-        : new this._typeClass(message);
+    if (message instanceof Buffer) {
+      rclnodejs.publishRawMessage(this._handle, message);
+    } else {
+      // Enables call by plain object/number/string argument
+      //  e.g. publisher.publish(3.14);
+      //       publisher.publish('The quick brown fox...');
+      //       publisher.publish({linear: {x: 0, y: 1, z: 2}, ...});
+      let messageToSend =
+        message instanceof this._typeClass
+          ? message
+          : new this._typeClass(message);
 
-    let rawMessage = messageToSend.serialize();
-    rclnodejs.publish(this._handle, rawMessage);
+      let rawMessage = messageToSend.serialize();
+      rclnodejs.publish(this._handle, rawMessage);
+    }
+
     debug(`Message of topic ${this.topic} has been published.`);
   }
 


### PR DESCRIPTION
This patch implements the feature that a publisher can publish a raw
message, and an example is added.

Fix #646