### PR TITLE
Support to subscribe serialized messages

### DIFF
--- a/example/subscription-raw-message.js
+++ b/example/subscription-raw-message.js
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/* eslint-disable camelcase */
+
+const rclnodejs = require('../index.js');
+
+rclnodejs.init().then(() => {
+  const node = rclnodejs.createNode('subscription_message_example_node');
+
+  node.createSubscription(
+    'test_msgs/msg/BasicTypes',
+    'chatter',
+    { isRaw: true },
+    (msg) => {
+      console.log(`Received message: ${msg.toString('utf8')}`);
+    }
+  );
+
+  rclnodejs.spin(node);
+});

--- a/lib/node.js
+++ b/lib/node.js
@@ -111,35 +111,42 @@ class Node {
 
   execute(handles) {
     let timersReady = this._timers.filter(
-      timer => handles.indexOf(timer.handle) !== -1
+      (timer) => handles.indexOf(timer.handle) !== -1
     );
     let guardsReady = this._guards.filter(
-      guard => handles.indexOf(guard.handle) !== -1
+      (guard) => handles.indexOf(guard.handle) !== -1
     );
     let subscriptionsReady = this._subscriptions.filter(
-      subscription => handles.indexOf(subscription.handle) !== -1
+      (subscription) => handles.indexOf(subscription.handle) !== -1
     );
     let clientsReady = this._clients.filter(
-      client => handles.indexOf(client.handle) !== -1
+      (client) => handles.indexOf(client.handle) !== -1
     );
     let servicesReady = this._services.filter(
-      service => handles.indexOf(service.handle) !== -1
+      (service) => handles.indexOf(service.handle) !== -1
     );
     let actionClientsReady = this._actionClients.filter(
-      actionClient => handles.indexOf(actionClient.handle) !== -1
+      (actionClient) => handles.indexOf(actionClient.handle) !== -1
     );
     let actionServersReady = this._actionServers.filter(
-      actionServer => handles.indexOf(actionServer.handle) !== -1
+      (actionServer) => handles.indexOf(actionServer.handle) !== -1
     );
 
-    timersReady.forEach(timer => {
+    timersReady.forEach((timer) => {
       if (timer.isReady()) {
         rclnodejs.callTimer(timer.handle);
         timer.callback();
       }
     });
 
-    subscriptionsReady.forEach(subscription => {
+    subscriptionsReady.forEach((subscription) => {
+      if (subscription.isRaw) {
+        let rawMessage = rclnodejs.rclTakeRaw(subscription.handle);
+        if (rawMessage) {
+          subscription.processResponse(rawMessage);
+        }
+        return;
+      }
       this._runWithMessageType(
         subscription.typeClass,
         (message, deserialize) => {
@@ -151,11 +158,11 @@ class Node {
       );
     });
 
-    guardsReady.forEach(guard => {
+    guardsReady.forEach((guard) => {
       guard.callback();
     });
 
-    clientsReady.forEach(client => {
+    clientsReady.forEach((client) => {
       this._runWithMessageType(
         client.typeClass.Response,
         (message, deserialize) => {
@@ -171,7 +178,7 @@ class Node {
       );
     });
 
-    servicesReady.forEach(service => {
+    servicesReady.forEach((service) => {
       this._runWithMessageType(
         service.typeClass.Request,
         (message, deserialize) => {
@@ -187,7 +194,7 @@ class Node {
       );
     });
 
-    actionClientsReady.forEach(actionClient => {
+    actionClientsReady.forEach((actionClient) => {
       const properties = actionClient.handle.properties;
 
       if (properties.isGoalResponseReady) {
@@ -266,7 +273,7 @@ class Node {
       }
     });
 
-    actionServersReady.forEach(actionServer => {
+    actionServersReady.forEach((actionServer) => {
       const properties = actionServer.handle.properties;
 
       if (properties.isGoalRequestReady) {
@@ -385,11 +392,7 @@ class Node {
    * @param {Clock} [clock] - The clock which the timer gets time from.
    * @return {Timer} - An instance of Timer.
    */
-  createTimer(
-    period,
-    callback,
-    clock = null
-  ) {
+  createTimer(period, callback, clock = null) {
     if (arguments.length === 3 && !(arguments[2] instanceof Clock)) {
       clock = null;
     } else if (arguments.length === 4) {
@@ -510,6 +513,7 @@ class Node {
    * @param {object} options - The options argument used to parameterize the subscription.
    * @param {boolean} options.enableTypedArray - The topic will use TypedArray if necessary, default: true.
    * @param {QoS} options.qos - ROS Middleware "quality of service" settings for the subscription, default: QoS.profileDefault.
+   * @param {boolean} options.isRaw - The topic is serialized when true, default: false.
    * @param {SubscriptionCallback} callback - The callback to be call when receiving the topic subscribed.
    * @return {Subscription} - An instance of Subscription.
    * @see {@link SubscriptionCallback}
@@ -671,8 +675,8 @@ class Node {
     }
 
     // Action servers/clients require manual destruction due to circular reference with goal handles.
-    this._actionClients.forEach(actionClient => actionClient.destroy());
-    this._actionServers.forEach(actionServer => actionServer.destroy());
+    this._actionClients.forEach((actionClient) => actionClient.destroy());
+    this._actionServers.forEach((actionServer) => actionServer.destroy());
 
     this.handle.release();
     this._clock = null;
@@ -869,7 +873,7 @@ class Node {
    * @return {array} - An array of the names.
    */
   getNodeNames() {
-    return this.getNodeNamesAndNamespaces().map(item => item.name);
+    return this.getNodeNamesAndNamespaces().map((item) => item.name);
   }
 
   /**
@@ -1047,7 +1051,7 @@ class Node {
       throw new Error(result.reason);
     }
 
-    return this.getParameters(declaredParameters.map(param => param.name));
+    return this.getParameters(declaredParameters.map((param) => param.name));
   }
 
   /**
@@ -1134,7 +1138,7 @@ class Node {
    *    no parameters have been declared.
    */
   getParameterNames() {
-    return this.getParameters().map(param => param.name);
+    return this.getParameters().map((param) => param.name);
   }
 
   /**
@@ -1230,7 +1234,7 @@ class Node {
    * @return {rclnodejs.rcl_interfaces.msg.SetParameterResult[]} - A list of SetParameterResult, one for each parameter that was set.
    */
   setParameters(parameters = []) {
-    return parameters.map(parameter =>
+    return parameters.map((parameter) =>
       this.setParametersAtomically([parameter])
     );
   }
@@ -1326,19 +1330,19 @@ class Node {
         : this.namespace() + '/' + this.name();
 
     if (newParameters.length > 0) {
-      parameterEvent['new_parameters'] = newParameters.map(parameter =>
+      parameterEvent['new_parameters'] = newParameters.map((parameter) =>
         parameter.toParameterMessage()
       );
     }
     if (changedParameters.length > 0) {
-      parameterEvent['changed_parameters'] = changedParameters.map(parameter =>
-        parameter.toParameterMessage()
-      );
+      parameterEvent[
+        'changed_parameters'
+      ] = changedParameters.map((parameter) => parameter.toParameterMessage());
     }
     if (deletedParameters.length > 0) {
-      parameterEvent['deleted_parameters'] = deletedParameters.map(parameter =>
-        parameter.toParameterMessage()
-      );
+      parameterEvent[
+        'deleted_parameters'
+      ] = deletedParameters.map((parameter) => parameter.toParameterMessage());
     }
 
     // publish ParameterEvent

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -28,11 +28,16 @@ class Subscription extends Entity {
     super(handle, typeClass, options);
     this._topic = topic;
     this._callback = callback;
+    this._isRaw = options.isRaw || false;
   }
 
   processResponse(msg) {
     debug(`Message of topic ${this._topic} received.`);
-    this._callback(msg.toPlainObject(this.typedArrayEnabled));
+    if (this._isRaw) {
+      this._callback(msg);
+    } else {
+      this._callback(msg.toPlainObject(this.typedArrayEnabled));
+    }
   }
 
   static createSubscription(nodeHandle, typeClass, topic, options, callback) {
@@ -53,6 +58,13 @@ class Subscription extends Entity {
    */
   get topic() {
     return this._topic;
+  }
+
+  /**
+   * @type {boolean}
+   */
+  get isRaw() {
+    return this._isRaw;
   }
 }
 

--- a/test/test-raw-pub-sub.js
+++ b/test/test-raw-pub-sub.js
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const rclnodejs = require('../index.js');
+
+describe('rclnodejs publisher test suite', function () {
+  this.timeout(60 * 1000);
+
+  beforeEach(function () {
+    return rclnodejs.init();
+  });
+
+  afterEach(function () {
+    rclnodejs.shutdown();
+  });
+
+  it('Publish serialized messages', function (done) {
+    const node = rclnodejs.createNode('serialized_messages_node');
+    const topic = Buffer.from('Hello ROS World');
+    const publisher = node.createPublisher(
+      'test_msgs/msg/BasicTypes',
+      'chatter'
+    );
+    let timer = setInterval(function () {
+      publisher.publish(topic);
+    }, 10);
+
+    node.createSubscription(
+      'test_msgs/msg/BasicTypes',
+      'chatter',
+      { isRaw: true },
+      (msg) => {
+        clearInterval(timer);
+        assert.deepStrictEqual(Buffer.compare(msg, topic), 0);
+        done();
+      }
+    );
+
+    rclnodejs.spin(node);
+  });
+});


### PR DESCRIPTION
This patch implements the feature that a subscription can subscribe a raw
message. Meanwhile, an example showing the usage is added and a unit
test for the serialized publisher & subscription.

Fix #646