### PR TITLE
Added typescript typings to support serialized pub-sub messages.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -371,7 +371,11 @@ class Node {
     }
 
     if (options === undefined) {
-      options = { enableTypedArray: true, qos: QoS.profileDefault };
+      options = {
+        enableTypedArray: true,
+        isRaw: false,
+        qos: QoS.profileDefault,
+      };
       return options;
     }
 
@@ -382,6 +386,11 @@ class Node {
     if (options.qos === undefined) {
       options = Object.assign(options, { qos: QoS.profileDefault });
     }
+
+    if (options.isRaw === undefined) {
+      options = Object.assign(options, { isRaw: false });
+    }
+
     return options;
   }
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "install": "node-gyp rebuild",
     "docs": "cd docs && make",
-    "test": "node ./scripts/compile_tests.js && node --expose-gc ./scripts/run_test.js && node ./scripts/generate_tsd.js && dtslint test/types",
+    "test": "node ./scripts/compile_tests.js && node --expose-gc ./scripts/run_test.js && npm run dtslint",
+    "dtslint": "node ./scripts/generate_tsd.js && dtslint test/types",
     "lint": "eslint --max-warnings=0 index.js types/*.d.ts scripts lib example rosidl_gen rosidl_parser test benchmark/rclnodejs && node ./scripts/cpplint.js",
     "postinstall": "node scripts/generate_messages.js",
     "format": "clang-format -i -style=file ./src/*.cpp ./src/*.hpp && prettier --trailing-comma es5 --single-quote --write \"{.,{lib,rosidl_gen,rostsd_gen,rosidl_parser,types,example,test}/**}/*.{js,md,ts}\""
@@ -37,7 +38,7 @@
     "clang-format": "^1.4.0",
     "commander": "^6.0.0",
     "deep-equal": "^1.1.1",
-    "dtslint": "^3.6.13",
+    "dtslint": "^4.0.4",
     "eslint": "^7.5.0",
     "eslint-config-prettier": "^6.11.0",
     "husky": "^4.2.5",

--- a/test/types/index.d.ts
+++ b/test/types/index.d.ts
@@ -1,1 +1,2 @@
-// TypeScript Version: 3.7
+// Minimum TypeScript Version: 3.9
+

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -4,6 +4,8 @@ import * as rclnodejs from 'rclnodejs';
 const NODE_NAME = 'test_node';
 const TYPE_CLASS = 'std_msgs/msg/String';
 const TOPIC = 'topic';
+const MSG = rclnodejs.createMessageObject(TYPE_CLASS);
+MSG.data = '';
 
 // ---- rclnodejs -----
 // $ExpectType Promise<void>
@@ -85,7 +87,7 @@ node.countPublishers(TOPIC);
 node.countSubscribers(TOPIC);
 
 // ---- Publisher ----
-// $ExpectType Publisher
+// $ExpectType Publisher<"std_msgs/msg/String">
 const publisher = node.createPublisher(TYPE_CLASS, TOPIC);
 
 // $ExpectType object
@@ -104,7 +106,14 @@ publisher.typeClass;
 publisher.typedArrayEnabled;
 
 // $ExpectType void
-publisher.publish('');
+publisher.publish(MSG);
+
+// $ExpectType void
+publisher.publish(Buffer.from('Hello ROS World'));
+
+// $ExpectType void
+node.destroyPublisher(publisher);
+
 
 // ---- Subscription ----
 // $ExpectType Subscription
@@ -112,7 +121,7 @@ const subscription = node.createSubscription(
   TYPE_CLASS,
   TOPIC,
   {},
-  (msg: rclnodejs.Message) => {}
+  (msg) => {}
 );
 
 // $ExpectType string

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -113,7 +113,7 @@ declare module 'rclnodejs' {
    *                                or {package: 'std_msgs', type: 'msg', name: 'String'}
    * @returns A Message object or undefined if type is not recognized.
    */
-  function createMessageObject(type: TypeClass): Message;
+  function createMessageObject<T extends TypeClass<MessageTypeClassName>>(type: T): MessageType<T>;
 
   /**
    * Get a list of action names and types for action clients associated with a node.

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 
-import { Clock } from 'rclnodejs';
+import { Clock, TypeClassName, MessageTypeClassName } from 'rclnodejs';
 import { Logging } from 'rclnodejs';
 import { Parameter, ParameterDescriptor, ParameterType } from 'rclnodejs';
 import { QoS } from 'rclnodejs';
@@ -27,7 +27,23 @@ declare module 'rclnodejs' {
    * See {@link DEFAULT_OPTIONS}
    */
   interface Options<T = QoS | QoS.ProfileRef> {
-    enableTypedArray?: boolean;
+	
+	/**  
+	 * A messages will use TypedArray if necessary, default: true. 
+	 */
+	enableTypedArray?: boolean;
+
+	/**
+	 * Indicates messages are serialized, default: false. 
+	 *
+	 * @remarks
+	 * See {@link Node#createSubscription | Node.createSubscription}
+	 */
+	isRaw?: boolean;
+
+	/**
+	 * ROS Middleware "quality of service" setting, default: QoS.profileDefault.
+	 */
     qos?: T;
   }
 
@@ -37,7 +53,8 @@ declare module 'rclnodejs' {
    * ```ts
    * {
    *   enableTypedArray: true,
-   *   qos: QoS.profileDefault
+   *   qos: QoS.profileDefault,
+   *   isRaw: false
    * }
    * ```
    */
@@ -84,9 +101,9 @@ declare module 'rclnodejs' {
    * See {@link Publisher}
    * See {@link Subscription}
    */
-  type SubscriptionCallback =
+  type SubscriptionCallback<T extends TypeClass<MessageTypeClassName>> =
     // * @param message - The published message
-    (message: Message) => void;
+    (message: MessageType<T> | Buffer) => void;
 
   /**
    * Callback for receiving service requests from a client.
@@ -246,11 +263,11 @@ declare module 'rclnodejs' {
      * @param options - Configuration options, see DEFAULT_OPTIONS
      * @returns New instance of Publisher.
      */
-    createPublisher(
-      typeClass: TypeClass,
+    createPublisher<T extends TypeClass<MessageTypeClassName>>(
+      typeClass: T,
       topic: string,
       options?: Options
-    ): Publisher;
+    ): Publisher<T>;
 
     /**
      * Create a Subscription.
@@ -261,11 +278,11 @@ declare module 'rclnodejs' {
      * @param callback - Called when a new message is received.
      * @returns New instance of Subscription.
      */
-    createSubscription(
-      typeClass: TypeClass,
+    createSubscription<T extends TypeClass<MessageTypeClassName>>(
+      typeClass: T,
       topic: string,
       options: Options,
-      callback: SubscriptionCallback
+      callback: SubscriptionCallback<T>
     ): Subscription;
 
     /**
@@ -318,7 +335,7 @@ declare module 'rclnodejs' {
      *
      * @param publisher - Publisher to be destroyed.
      */
-    destroyPublisher(publisher: Publisher): void;
+    destroyPublisher<T extends MessageTypeClassName>(publisher: Publisher<T>): void;
 
     /**
      * Destroy a Subscription.

--- a/types/publisher.d.ts
+++ b/types/publisher.d.ts
@@ -1,8 +1,10 @@
+import { MessageTypeClassName } from 'rclnodejs';
+
 declare module 'rclnodejs' {
   /**
    * A ROS Publisher that publishes messages on a topic.
    */
-  class Publisher extends Entity {
+  class Publisher<T extends TypeClass<MessageTypeClassName>> extends Entity {
     /**
      * Topic on which messages are published.
      */
@@ -13,6 +15,6 @@ declare module 'rclnodejs' {
      *
      * @param message - The message to be sent.
      */
-    publish(message: Message): void;
+    publish(message: MessageType<T> | Buffer): void;
   }
 }


### PR DESCRIPTION
Added typescript typings to support publishing and subscribing to serialized messages.

* index.js - converted `createMessageObject()` to constrained generic
returning less ambiguous MessageType<T> instead of Message.
* node.js - added isRaw to `_validateOption()`
* node.d.ts - converted `createPublisher()` & `createSubscription()` &
`deletePublisher()` to  generic constrained to MessageTypeClassName.
Improves type inferencing. Similarly modified SubscriptionCallback.
* package.json - refactor dtslint test stage of the `test` script to
`test-ts` script
* publisher.d.ts - converted Publisher class to generic constrained to
MessageTypeClassName.
* test/type/main.ts - updated tests; added new tests

Fix #706