### PR TITLE
Improve the docs & shutdown behavior when the node process is terminated

### DIFF
--- a/index.js
+++ b/index.js
@@ -311,7 +311,7 @@ let rcl = {
 
   /**
    * Shuts down the given context by shutting down and destroying all nodes contained within.
-   * Does nothing is the context si already shut down.
+   * Does nothing if the context is already shut down.
    * @param {Context} [context=Context.defaultContext()] - The context to be shutdown.
    * @return {undefined}
    */

--- a/index.js
+++ b/index.js
@@ -404,7 +404,7 @@ let rcl = {
    * Create a plain JavaScript from the specified type identifier.
    * @param {string|Object} type -- the type identifier, acceptable formats could be 'std_msgs/std/String'
    *                                or {package: 'std_msgs', type: 'msg', name: 'String'}
-   * @return {Object|undefined} A plain JavaScript of that type or undefined if the object could not be created
+   * @return {Object|undefined} A plain JavaScript of that type, or undefined if the object could not be created
    */
   createMessageObject(type) {
     return this.createMessage(type).toPlainObject();

--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ let rcl = {
   getActionNamesAndTypes: getActionNamesAndTypes,
 
   /**
-   * Create a node.
+   * Create and initialize a node.
    * @param {string} nodeName - The name used to register in ROS.
    * @param {string} [namespace=''] - The namespace used in ROS.
    * @param {Context} [context=Context.defaultContext()] - The context to create the node in.
@@ -208,7 +208,7 @@ let rcl = {
   },
 
   /**
-   * Init the module.
+   * Initialize the module.
    * @param {Context} [context=Context.defaultContext()] - The context to initialize.
    * @param {string[]} argv - Process command line arguments.
    * @return {Promise<undefined>} A Promise.
@@ -299,7 +299,7 @@ let rcl = {
    * Shuts down the given context by shutting down and destroying all nodes contained within.
    *
    * If no context is explicitly given, only the default context will be shut down, and not all of them.
-   * This follows the semantics of [`rclpy.shutdown()`](http://docs.ros2.org/latest/api/rclpy/api/init_shutdown.html#rclpy.shutdown).
+   * This follows the semantics of [rclpy.shutdown()]{@link http://docs.ros2.org/latest/api/rclpy/api/init_shutdown.html#rclpy.shutdown}.
    *
    * @param {Context} [context=Context.defaultContext()] - The context to be shutdown.
    * @return {undefined}
@@ -412,8 +412,8 @@ let rcl = {
 };
 
 process.on('SIGINT', () => {
-  debug('Catch ctrl+c event and will cleanup and terminate.');
-  rcl.tryShutdown();
+  debug('Caught SIGINT/ctrl+c event and will cleanup and terminate.');
+  rcl.shutdown();
   process.exit(0);
 });
 

--- a/index.js
+++ b/index.js
@@ -175,9 +175,9 @@ let rcl = {
   /**
    * Create a node.
    * @param {string} nodeName - The name used to register in ROS.
-   * @param {string} namespace - The namespace used in ROS, default is an empty string.
-   * @param {Context} context - The context, default is Context.defaultContext().
-   * @param {NodeOptions} options - The options to configure the new node behavior.
+   * @param {string} [namespace=''] - The namespace used in ROS.
+   * @param {Context} [context=Context.defaultContext()] - The context to create the node in.
+   * @param {NodeOptions} [options=NodeOptions.defaultOptions] - The options to configure the new node behavior.
    * @return {Node} A new instance of the specified node.
    * @throws {Error} If the given context is not registered.
    */
@@ -209,8 +209,8 @@ let rcl = {
 
   /**
    * Init the module.
-   * @param {Context} context - The context, default is Context.defaultContext().
-   * @param {string[]} argv - Process commandline arguments.
+   * @param {Context} [context=Context.defaultContext()] - The context to initialize.
+   * @param {string[]} argv - Process command line arguments.
    * @return {Promise<undefined>} A Promise.
    * @throws {Error} If the given context has already been initialized.
    */
@@ -264,7 +264,7 @@ let rcl = {
   /**
    * Start to spin the node, which triggers the event loop to start to check the incoming events.
    * @param {Node} node - The node to be spun.
-   * @param {number} [timeout=10] - ms to wait, block forever if negative, don't wait if 0, default is 10.
+   * @param {number} [timeout=10] - Timeout to wait in milliseconds. Block forever if negative. Don't wait if 0.
    * @throws {Error} If the node is already spinning.
    * @return {undefined}
    */
@@ -280,8 +280,8 @@ let rcl = {
 
   /**
    * Execute one item of work or wait until a timeout expires.
-   * @param {Node} node - The node to be spun.
-   * @param {number} [timeout=10] - ms to wait, block forever if negative, don't wait if 0, default is 10.
+   * @param {Node} node - The node to be spun once.
+   * @param {number} [timeout=10] - Timeout to wait in milliseconds. Block forever if negative. Don't wait if 0.
    * @throws {Error} If the node is already spinning.
    * @return {undefined}
    */
@@ -325,7 +325,7 @@ let rcl = {
    * Shuts down the given context by shutting down and destroying all nodes contained within.
    * Does not perform any checks.
    *
-   * @param {Context} context - The context to be shutdown.
+   * @param {Context} context - The context to be shut down.
    * @return {undefined}
    * @private
    */
@@ -347,7 +347,7 @@ let rcl = {
 
   /**
    * A predicate for testing if a context has been shutdown.
-   * @param {Context} [context=Context.defaultContext()] - The context to inspect
+   * @param {Context} [context=Context.defaultContext()] - The context to inspect.
    * @return {boolean} Return true if the module is shut down, otherwise return false.
    */
   isShutdown(context = Context.defaultContext()) {

--- a/index.js
+++ b/index.js
@@ -310,7 +310,7 @@ let rcl = {
       debug(`The module rclnodejs (with context handle ${context.handle}) has been shutdown.`);
     } else {
       // shutdown and remove all nodes assigned to context
-      this._contextToNodeArrayMap[context].forEach((node) => {
+      this._contextToNodeArrayMap.get(context).forEach((node) => {
         node.stopSpinning();
         node.destroy();
       });

--- a/index.js
+++ b/index.js
@@ -305,7 +305,7 @@ let rcl = {
     if (this.isShutdown(context)) {
       throw new Error('The module rclnodejs has been shutdown.');
     } else {
-      this._shutdown(context)
+      this._shutdown(context);
     }
   },
 
@@ -317,7 +317,7 @@ let rcl = {
    */
   tryShutdown(context = Context.defaultContext()) {
     if (!this.isShutdown(context)) {
-      this._shutdown(context)
+      this._shutdown(context);
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ let rcl = {
       throw new Error('Invalid context. Must call rclnodejs(context) before using the context');
     }
 
-    let handle = rclnodejs.createNode(nodeName, namespace, context.handle());
+    let handle = rclnodejs.createNode(nodeName, namespace, context.handle);
     let node = new rclnodejs.ShadowNode();
     node.handle = handle;
     Object.defineProperty(node, 'handle', { configurable: false, writable: false }); // make read-only
@@ -230,7 +230,7 @@ let rcl = {
       }
 
       // initialize context
-      rclnodejs.init(context.handle(), argv);
+      rclnodejs.init(context.handle, argv);
       this._contextToNodeArrayMap.set(context, []);
 
       if (this._rosVersionChecked) {
@@ -292,7 +292,7 @@ let rcl = {
     if (node.spinning) {
       throw new Error('The node is already spinning.');
     }
-    node.spinOnce(node.context.handle(), timeout);
+    node.spinOnce(node.context.handle, timeout);
   },
 
   /**

--- a/lib/context.js
+++ b/lib/context.js
@@ -52,7 +52,7 @@ class Context {
   }
 
   /**
-   * Get the handle referencing the internal context object. Do not modify it yousrself: only pass it to *rclnodejs* functions!
+   * Get the handle referencing the internal context object. Do not modify it yourself: only pass it to *rclnodejs* functions!
    * @return {undefined} a reference to the internal context object
    */
   get handle() {

--- a/lib/context.js
+++ b/lib/context.js
@@ -30,10 +30,11 @@ class Context {
   /**
    * Shut down the context.
    * @return {undefined}
+   * @throws {Error} If there is a problem shutting down the context.
    */
   shutdown() {
     rclnodejs.shutdown(this.handle);
-    if (this === defaultContext) {
+    if (this.isDefaultContext) {
       defaultContext = null;
     }
   }
@@ -41,6 +42,7 @@ class Context {
   /**
    * Try to shut down the context.
    * @return {undefined}
+   * @throws {Error} If there is a problem shutting down the context.
    */
   tryShutdown() {
     // check chat the context is valid
@@ -55,6 +57,14 @@ class Context {
    */
   get handle() {
     return this._handle;
+  }
+
+  /**
+   * Check if this context is the default one.
+   * @return {boolean}
+   */
+  get isDefaultContext() {
+    return this === defaultContext
   }
 
   /**

--- a/lib/context.js
+++ b/lib/context.js
@@ -19,7 +19,7 @@ const rclnodejs = require('bindings')('rclnodejs');
 let defaultContext = null;
 
 /**
- * @class - Class representing a Context in ROS
+ * Class representing a Context in ROS
  * @hideconstructor
  */
 class Context {
@@ -60,23 +60,23 @@ class Context {
 
   /**
    * Check if this context is the default one.
-   * @return {boolean}
+   * @return {boolean} whether this is the default context
    */
   get isDefaultContext() {
-    return this === defaultContext
+    return this === defaultContext;
   }
 
   /**
    * Check that the context is valid.
-   * @return {boolean}
+   * @return {boolean} whether this context is (still) valid
    */
   get isOk() {
-    return rclnodejs.ok(this.handle)
+    return rclnodejs.ok(this.handle);
   }
 
   /**
    * Get the global default Context object.
-   * @return {Context} - default Context
+   * @return {Context} The default Context
    */
   static defaultContext() {
     if (defaultContext === null) {

--- a/lib/context.js
+++ b/lib/context.js
@@ -45,8 +45,7 @@ class Context {
    * @throws {Error} If there is a problem shutting down the context.
    */
   tryShutdown() {
-    // check chat the context is valid
-    if (rclnodejs.ok(this.handle)) {
+    if (this.isOk) {
       this.shutdown();
     }
   }
@@ -65,6 +64,14 @@ class Context {
    */
   get isDefaultContext() {
     return this === defaultContext
+  }
+
+  /**
+   * Check that the context is valid.
+   * @return {boolean}
+   */
+  get isOk() {
+    return rclnodejs.ok(this.handle)
   }
 
   /**

--- a/lib/context.js
+++ b/lib/context.js
@@ -32,7 +32,7 @@ class Context {
    * @return {undefined}
    */
   shutdown() {
-    rclnodejs.shutdown(this.handle());
+    rclnodejs.shutdown(this.handle);
     if (this === defaultContext) {
       defaultContext = null;
     }
@@ -44,12 +44,16 @@ class Context {
    */
   tryShutdown() {
     // check chat the context is valid
-    if (rclnodejs.ok(this.handle())) {
+    if (rclnodejs.ok(this.handle)) {
       this.shutdown();
     }
   }
 
-  handle() {
+  /**
+   * Get the handle referencing the internal context object. Do not modify it yousrself: only pass it to *rclnodejs* functions!
+   * @return {undefined} a reference to the internal context object
+   */
+  get handle() {
     return this._handle;
   }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -16,33 +16,36 @@
 
 const rclnodejs = require('bindings')('rclnodejs');
 
-let defaultContext = undefined;
+let defaultContext = null;
 
 /**
  * @class - Class representing a Context in ROS
  * @hideconstructor
  */
-
 class Context {
   constructor() {
     this._handle = rclnodejs.createContext();
   }
 
   /**
-   * Shutdown the context.
+   * Shut down the context.
    * @return {undefined}
    */
   shutdown() {
-    rclnodejs.shutdown(this._handle);
+    rclnodejs.shutdown(this.handle());
+    if (this === defaultContext) {
+      defaultContext = null;
+    }
   }
 
   /**
-   * Try to shutdown the context.
+   * Try to shut down the context.
    * @return {undefined}
    */
   tryShutdown() {
-    if (rclnodejs.ok(this._handle)) {
-      rclnodejs.shutdown(this._handle);
+    // check chat the context is valid
+    if (rclnodejs.ok(this.handle())) {
+      this.shutdown();
     }
   }
 
@@ -55,19 +58,10 @@ class Context {
    * @return {Context} - default Context
    */
   static defaultContext() {
-    if (!defaultContext) {
+    if (defaultContext === null) {
       defaultContext = new Context();
     }
     return defaultContext;
-  }
-
-  /**
-   * Shutdown the default context.
-   * @return {undefined}
-   */
-  static shutdownDefaultContext() {
-    defaultContext.shutdown();
-    defaultContext = undefined;
   }
 }
 

--- a/lib/guard_condition.js
+++ b/lib/guard_condition.js
@@ -33,7 +33,7 @@ class GuardCondition extends Entity {
   }
 
   static createGuardCondition(callback, context = Context.defaultContext()) {
-    let handle = rclnodejs.createGuardCondition(context.handle());
+    let handle = rclnodejs.createGuardCondition(context.handle);
     return new GuardCondition(handle, callback);
   }
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -338,7 +338,7 @@ class Node {
   }
 
   startSpinning(timeout) {
-    this.start(this.context.handle(), timeout);
+    this.start(this.context.handle, timeout);
     this.spinning = true;
   }
 
@@ -429,7 +429,7 @@ class Node {
 
     let timerHandle = rclnodejs.createTimer(
       timerClock.handle,
-      this.context.handle(),
+      this.context.handle,
       period
     );
     let timer = new Timer(timerHandle, period, callback);
@@ -1467,7 +1467,7 @@ class Node {
     //     value: object
     // }
     const cliParamOverrideData = rclnodejs.getParameterOverrides(
-      context.handle()
+      context.handle
     );
 
     // convert native CLI parameterOverrides to Map<nodeName,Array<ParameterOverride>>

--- a/test/test-init-shutdown.js
+++ b/test/test-init-shutdown.js
@@ -143,7 +143,7 @@ describe('Node destroy testing', function() {
         assert.ok(true);
       })
       .then(function() {
-        assert.throws(function() {
+        assert.doesNotThrow(function() {
           rclnodejs.shutdown();
         });
         assert.ok(true);

--- a/test/test-init-shutdown.js
+++ b/test/test-init-shutdown.js
@@ -166,6 +166,7 @@ describe('Node destroy testing', function() {
       await rclnodejs.init();
       assert.ok(!rclnodejs.isShutdown());
       const defaultContext = rclnodejs.Context.defaultContext();
+      assert.ok(defaultContext !== null);
       assert.ok(defaultContext.isOk);
       assert.ok(defaultContext.isDefaultContext);
 
@@ -181,14 +182,12 @@ describe('Node destroy testing', function() {
       assert.doesNotThrow(() => rclnodejs.shutdown());
       assert.ok(rclnodejs.isShutdown());
       assert.ok(!rclnodejs.isShutdown(ctx));
-      assert.ok(rclnodejs.Context.defaultContext() === null);
       assert.ok(ctx.isOk);
       assert.ok(!defaultContext.isOk);
 
       assert.doesNotThrow(() => rclnodejs.shutdown(ctx));
       assert.ok(rclnodejs.isShutdown());
       assert.ok(rclnodejs.isShutdown(ctx));
-      assert.ok(rclnodejs.Context.defaultContext() === null);
       assert.ok(!ctx.isOk);
       assert.ok(!defaultContext.isOk);
     }

--- a/test/test-init-shutdown.js
+++ b/test/test-init-shutdown.js
@@ -162,37 +162,40 @@ describe('Node destroy testing', function() {
   });
 
   it('rclnodejs multiple contexts init shutdown sequence', async function() {
-    await rclnodejs.init();
-    assert.ok(!rclnodejs.isShutdown());
+    async function initShutdownSequence() {
+      await rclnodejs.init();
+      assert.ok(!rclnodejs.isShutdown());
+      const defaultContext = rclnodejs.Context.defaultContext()
+      assert.ok(defaultContext.isOk)
+      assert.ok(defaultContext.isDefaultContext)
 
-    let ctx = new rclnodejs.Context();
-    await rclnodejs.init(ctx);
-    assert.ok(!rclnodejs.isShutdown(ctx));
-    assert.ok(!rclnodejs.isShutdown());
+      const ctx = new rclnodejs.Context();
+      await rclnodejs.init(ctx);
+      assert.ok(!rclnodejs.isShutdown(ctx));
+      assert.ok(!rclnodejs.isShutdown());
+      assert.ok(ctx.isOk)
+      assert.ok(!ctx.isDefaultContext)
+      assert.ok(defaultContext.isOk)
+      assert.ok(defaultContext.isDefaultContext)
 
-    assert.doesNotThrow(() => rclnodejs.shutdown());
-    assert.ok(rclnodejs.isShutdown());
-    assert.ok(!rclnodejs.isShutdown(ctx));
+      assert.doesNotThrow(() => rclnodejs.shutdown());
+      assert.ok(rclnodejs.isShutdown());
+      assert.ok(!rclnodejs.isShutdown(ctx));
+      assert.ok(rclnodejs.Context.defaultContext() === null);
+      assert.ok(ctx.isOk)
+      assert.ok(!defaultContext.isOk)
 
-    assert.doesNotThrow(() => rclnodejs.shutdown(ctx));
-    assert.ok(rclnodejs.isShutdown());
-    assert.ok(rclnodejs.isShutdown(ctx));
+      assert.doesNotThrow(() => rclnodejs.shutdown(ctx));
+      assert.ok(rclnodejs.isShutdown());
+      assert.ok(rclnodejs.isShutdown(ctx));
+      assert.ok(rclnodejs.Context.defaultContext() === null);
+      assert.ok(!ctx.isOk)
+      assert.ok(!defaultContext.isOk)
+    }
 
-    // repeat
-    await rclnodejs.init();
-    assert.ok(!rclnodejs.isShutdown());
-
-    ctx = new rclnodejs.Context();
-    await rclnodejs.init(ctx);
-    assert.ok(!rclnodejs.isShutdown(ctx));
-    assert.ok(!rclnodejs.isShutdown());
-
-    assert.doesNotThrow(() => rclnodejs.shutdown());
-    assert.ok(rclnodejs.isShutdown());
-    assert.ok(!rclnodejs.isShutdown(ctx));
-
-    assert.doesNotThrow(() => rclnodejs.shutdown(ctx));
-    assert.ok(rclnodejs.isShutdown());
-    assert.ok(rclnodejs.isShutdown(ctx));
+    // execute it twice
+    await initShutdownSequence()
+    await initShutdownSequence()
   });
+
 });

--- a/test/test-init-shutdown.js
+++ b/test/test-init-shutdown.js
@@ -165,37 +165,37 @@ describe('Node destroy testing', function() {
     async function initShutdownSequence() {
       await rclnodejs.init();
       assert.ok(!rclnodejs.isShutdown());
-      const defaultContext = rclnodejs.Context.defaultContext()
-      assert.ok(defaultContext.isOk)
-      assert.ok(defaultContext.isDefaultContext)
+      const defaultContext = rclnodejs.Context.defaultContext();
+      assert.ok(defaultContext.isOk);
+      assert.ok(defaultContext.isDefaultContext);
 
       const ctx = new rclnodejs.Context();
       await rclnodejs.init(ctx);
       assert.ok(!rclnodejs.isShutdown(ctx));
       assert.ok(!rclnodejs.isShutdown());
-      assert.ok(ctx.isOk)
-      assert.ok(!ctx.isDefaultContext)
-      assert.ok(defaultContext.isOk)
-      assert.ok(defaultContext.isDefaultContext)
+      assert.ok(ctx.isOk);
+      assert.ok(!ctx.isDefaultContext);
+      assert.ok(defaultContext.isOk);
+      assert.ok(defaultContext.isDefaultContext);
 
       assert.doesNotThrow(() => rclnodejs.shutdown());
       assert.ok(rclnodejs.isShutdown());
       assert.ok(!rclnodejs.isShutdown(ctx));
       assert.ok(rclnodejs.Context.defaultContext() === null);
-      assert.ok(ctx.isOk)
-      assert.ok(!defaultContext.isOk)
+      assert.ok(ctx.isOk);
+      assert.ok(!defaultContext.isOk);
 
       assert.doesNotThrow(() => rclnodejs.shutdown(ctx));
       assert.ok(rclnodejs.isShutdown());
       assert.ok(rclnodejs.isShutdown(ctx));
       assert.ok(rclnodejs.Context.defaultContext() === null);
-      assert.ok(!ctx.isOk)
-      assert.ok(!defaultContext.isOk)
+      assert.ok(!ctx.isOk);
+      assert.ok(!defaultContext.isOk);
     }
 
     // execute it twice
-    await initShutdownSequence()
-    await initShutdownSequence()
+    await initShutdownSequence();
+    await initShutdownSequence();
   });
 
 });


### PR DESCRIPTION
This PR:
- First of all fixes #719.
- Improves the documentation in `rclnodejs/index.js`.

Some other stuff that I noticed and wanted to discuss. In [`rclnodejs/lib/context.js`](https://github.com/RobotWebTools/rclnodejs/blob/develop/lib/context.js):

- [x] 1. Should we remove `Context.shutdownDefaultContext()`? I'd argue that we want to have a `Context.tryShutdownDefaultContext()` too, but that would start to weirdly duplicate stuff. Instead, I'd suggest the following:
    - Delete `Context.shutdownDefaultContext()`, which would now become the barely longer `Context.defaultContext().shutdown()`.
    - By that, we get the "try" version for free, e.g. with `Context.defaultContext().tryShutdown()`.
    - Finally, we should add a check like `if (this === defaultContext) { defaultContext = undefined; }` to `Context.shutdown()`/`Context.tryShutdown()` anyways, as we would miss the cleanup if a user already explicitly chose to shut down the default context. This would, however, make `Context.shutdownDefaultContext()` even more redundant.
    - If we were to implement it like that, would we have a deprecation cycle/notice?
    - It would slightly simplify `_shutdown()` in `rclnodejs/index.js`.
   - ==> Yes, done.
- [x] 2. Shouldn't `defaultContext` be set to `null` instead of `undefined` to explicitly signal that it is absent and not just a typo somewhere? ==> Yes, done.
- [x] 3. I would expect the code `rclnodejs.shutdown()` to shut down *all* existing contexts instead of only the default one. Is that intentional? Is there a will to change that? ==> Okay, I'm convinced to not change things here. We follow rclpy's semantics.
- [x] 4. Shouldn't we call `NodeOptions.defaultOptions` in [`index.js`](https://github.com/RobotWebTools/rclnodejs/blob/develop/index.js#L187) instead of reference that method? I.e. append `()`. ==> Nevermind, didn't know the getter syntax.

EDIT:

- [x] I slightly changed the signature of the `Context` class to better align with that of rclpy. Is that OK? ==> Apparently
- [x] How should the actual `exit()` be done? ==> Will be improved in #720 
- [X] Once all else is done, how should we notify the users of the changes? ==> place it in the release notes