### PR TITLE
Clean up some tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,8 +212,8 @@ let rcl = {
    * @param {Context} [context=Context.defaultContext()] - The context to initialize.
    * @param {string[]} argv - Process command line arguments.
    * @return {Promise<undefined>} A Promise.
-   * @throws {Error} If the given context has already been initialized.
-   * @throws {Error} If the command line arguments argv could not be parsed.
+   * @throws {Error} If the given context has already been initialized or the command
+   *                 line arguments argv could not be parsed.
    */
   init(context = Context.defaultContext(), argv = process.argv) {
     return new Promise((resolve, reject) => {

--- a/index.js
+++ b/index.js
@@ -213,6 +213,7 @@ let rcl = {
    * @param {string[]} argv - Process command line arguments.
    * @return {Promise<undefined>} A Promise.
    * @throws {Error} If the given context has already been initialized.
+   * @throws {Error} If the command line arguments argv could not be parsed.
    */
   init(context = Context.defaultContext(), argv = process.argv) {
     return new Promise((resolve, reject) => {

--- a/test/test-init-shutdown.js
+++ b/test/test-init-shutdown.js
@@ -17,7 +17,7 @@
 const assert = require('assert');
 const rclnodejs = require('../index.js');
 
-describe.only('rclnodejs init and shutdown test suite', function () {
+describe('rclnodejs init and shutdown test suite', function () {
   this.timeout(60 * 1000);
 
   it('basic rclnodejs.init() & rclnodejs.shutdown()', async function () {

--- a/test/test-init-shutdown.js
+++ b/test/test-init-shutdown.js
@@ -40,26 +40,26 @@ describe('rclnodejs init and shutdown test suite', function() {
     // and the second round: do it again!
     assert.doesNotThrow(async () => {
       await rclnodejs.init();
-    }, "re-initializing after a shutdown should work");
+    }, 're-initializing after a shutdown should work');
     rclnodejs.shutdown();
   });
 
   it('rclnodejs.init(argv)', async function() {
-    await rclnodejs.init(rclnodejs.Context.defaultContext(), ['a', 'b'])
+    await rclnodejs.init(rclnodejs.Context.defaultContext(), ['a', 'b']);
     rclnodejs.shutdown();
   });
 
   it('rclnodejs.init(argv) - invalid argv', async function() {
     assert.throws(async () => {
-      await rclnodejs.init(rclnodejs.Context.defaultContext(), 'foobar')
-    }, Error, "an invalid argument should be rejected")
+      await rclnodejs.init(rclnodejs.Context.defaultContext(), 'foobar');
+    }, Error, 'an invalid argument should be rejected');
     rclnodejs.shutdown();
   });
 
   it('rclnodejs.init(argv) with null argv elements', async function() {
     assert.throws(async () => {
-      await rclnodejs.init(rclnodejs.Context.defaultContext(), ['a', null, 'b'])
-    }, Error, "an invalid argument should be rejected")
+      await rclnodejs.init(rclnodejs.Context.defaultContext(), ['a', null, 'b']);
+    }, Error, 'an invalid argument should be rejected');
     rclnodejs.shutdown();
   });
 
@@ -67,7 +67,7 @@ describe('rclnodejs init and shutdown test suite', function() {
     await rclnodejs.init();
     assert.throws(async () => {
       await rclnodejs.init();
-    }, Error, "initializing it twice shall cause an error to be thrown")
+    }, Error, 'initializing it twice shall cause an error to be thrown');
   });
 
   it('rclnodejs double shutdown should work', async function() {
@@ -76,13 +76,13 @@ describe('rclnodejs init and shutdown test suite', function() {
 
     assert.doesNotThrow(() => {
       rclnodejs.shutdown();
-    }, "shutting rclnodejs down twice should not cause an error to be thrown")
+    }, 'shutting rclnodejs down twice should not cause an error to be thrown');
   });
 
   it('rclnodejs create node without init should fail', async function() {
     assert.throws(() => {
       rclnodejs.createNode('my_node');
-    }, Error, "creating a node on an uninitialized context should cause an error to be thrown");
+    }, Error, 'creating a node on an uninitialized context should cause an error to be thrown');
   });
 
   it('rclnodejs multiple contexts init shutdown sequence', async function() {

--- a/test/test-init-shutdown.js
+++ b/test/test-init-shutdown.js
@@ -17,7 +17,9 @@
 const assert = require('assert');
 const rclnodejs = require('../index.js');
 
-describe('rclnodejs init and shutdown test suite', function () {
+describe.only('rclnodejs init and shutdown test suite', function () {
+  this.timeout(60 * 1000);
+
   it('basic rclnodejs.init() & rclnodejs.shutdown()', async function () {
     await rclnodejs.init();
     rclnodejs.shutdown();
@@ -83,6 +85,9 @@ describe('rclnodejs init and shutdown test suite', function () {
       Error,
       'initializing it twice shall cause an error to be thrown'
     );
+
+    // and now clean up
+    rclnodejs.shutdown();
   });
 
   it('rclnodejs double shutdown should work', async function () {

--- a/test/test-init-shutdown.js
+++ b/test/test-init-shutdown.js
@@ -16,180 +16,109 @@
 
 const assert = require('assert');
 const rclnodejs = require('../index.js');
-const assertUtils = require('./utils.js');
-const assertThrowsError = assertUtils.assertThrowsError;
 
-describe('Node destroy testing', function() {
-  this.timeout(60 * 1000);
+describe('rclnodejs init and shutdown test suite', function() {
 
-  it('rclnodejs.init()', function(done) {
-    rclnodejs
-      .init()
-      .then(function() {
-        assert.ok(true);
-        rclnodejs.shutdown();
-        done();
-      })
-      .catch(function(err) {
-        assert.ok(false);
-        done(err);
-      });
+  it('basic rclnodejs.init() & rclnodejs.shutdown()', async function () {
+    await rclnodejs.init();
+    rclnodejs.shutdown();
   });
 
-  it('rclnodejs.init() & rclnodejs.shutdown()', function(done) {
+  it('rclnodejs.isShutdown() values', async function() {
     assert.deepStrictEqual(rclnodejs.isShutdown(), true);
-    rclnodejs
-      .init()
-      .then(function() {
-        assert.deepStrictEqual(rclnodejs.isShutdown(), false);
-        rclnodejs.shutdown();
-        assert.deepStrictEqual(rclnodejs.isShutdown(), true);
-        done();
-      })
-      .catch(function(err) {
-        assert.ok(false);
-        done(err);
-      });
+    await rclnodejs.init();
+    assert.deepStrictEqual(rclnodejs.isShutdown(), false);
+    rclnodejs.shutdown();
+    assert.deepStrictEqual(rclnodejs.isShutdown(), true);
   });
 
-  it('rclnodejs init shutdown sequence', function(done) {
-    rclnodejs
-      .init()
-      .then(function() {
-        rclnodejs.shutdown();
-        assert.ok(true);
-      })
-      .then(function() {
-        assert.ok(true);
-        return rclnodejs.init();
-      })
-      .then(function() {
-        assert.doesNotThrow(function() {
-          rclnodejs.shutdown();
-        });
-        assert.ok(true);
-        done();
-      })
-      .catch(function(err) {
-        assert.ok(false);
-        done(err);
-      });
+  it('rclnodejs init shutdown sequence', async function() {
+    // the first round
+    await rclnodejs.init();
+    rclnodejs.shutdown();
+
+    // and the second round: do it again!
+    assert.doesNotThrow(async () => {
+      await rclnodejs.init();
+    }, "re-initializing after a shutdown should work");
+    rclnodejs.shutdown();
   });
 
-  it('rclnodejs.init(argv)', function(done) {
-    rclnodejs
-      .init(rclnodejs.Context.defaultContext(), ['a', 'b'])
-      .then(function() {
-        assert.ok(true);
-        rclnodejs.shutdown();
-        done();
-      })
-      .catch(function(err) {
-        assert.ok(false);
-        done(err);
-      });
+  it('rclnodejs.init(argv)', async function() {
+    await rclnodejs.init(rclnodejs.Context.defaultContext(), ['a', 'b'])
+    rclnodejs.shutdown();
   });
 
-  it('rclnodejs.init(argv) - invalid argv', function(done) {
-    rclnodejs
-      .init(rclnodejs.Context.defaultContext(), 'foobar')
-      .then(function() {
-        assert.ok(false);
-        rclnodejs.shutdown();
-        done();
-      })
-      // eslint-disable-next-line handle-callback-err
-      .catch(function(_err) {
-        assert.ok(true);
-        done();
-      });
+  it('rclnodejs.init(argv) - invalid argv', async function() {
+    assert.throws(async () => {
+      await rclnodejs.init(rclnodejs.Context.defaultContext(), 'foobar')
+    }, Error, "an invalid argument should be rejected")
+    rclnodejs.shutdown();
   });
 
-  it('rclnodejs.init(argv) with null argv elements', function(done) {
-    rclnodejs
-      .init(rclnodejs.Context.defaultContext(), ['a', null, 'b'])
-      .then(function() {
-        assert.ok(false);
-        done();
-      })
-      // eslint-disable-next-line handle-callback-err
-      .catch(function(err) {
-        assert.ok(true);
-        done();
-      });
+  it('rclnodejs.init(argv) with null argv elements', async function() {
+    assert.throws(async () => {
+      await rclnodejs.init(rclnodejs.Context.defaultContext(), ['a', null, 'b'])
+    }, Error, "an invalid argument should be rejected")
+    rclnodejs.shutdown();
   });
 
-  it('rclnodejs double init', function(done) {
-    rclnodejs
-      .init()
-      .then(function() {
-        assert.ok(true);
-      })
-      .then(function() {
-        return rclnodejs.init();
-      })
-      .catch(function(err) {
-        assert.notDeepStrictEqual(err, null);
-        rclnodejs.shutdown();
-        done();
-      });
+  it('rclnodejs double init should throw', async function() {
+    await rclnodejs.init();
+    assert.throws(async () => {
+      await rclnodejs.init();
+    }, Error, "initializing it twice shall cause an error to be thrown")
   });
 
-  it('rclnodejs double shutdown', function(done) {
-    rclnodejs
-      .init()
-      .then(function() {
-        rclnodejs.shutdown();
-        assert.ok(true);
-      })
-      .then(function() {
-        assert.doesNotThrow(function() {
-          rclnodejs.shutdown();
-        });
-        assert.ok(true);
-        done();
-      })
-      .catch(function(err) {
-        assert.ok(true);
-        done(err);
-      });
+  it('rclnodejs double shutdown should work', async function() {
+    await rclnodejs.init();
+    rclnodejs.shutdown();
+
+    assert.doesNotThrow(() => {
+      rclnodejs.shutdown();
+    }, "shutting rclnodejs down twice should not cause an error to be thrown")
   });
 
-  it('rclnodejs create node without init', function() {
-    assert.throws(function() {
+  it('rclnodejs create node without init should fail', async function() {
+    assert.throws(() => {
       rclnodejs.createNode('my_node');
-    });
+    }, Error, "creating a node on an uninitialized context should cause an error to be thrown");
   });
 
   it('rclnodejs multiple contexts init shutdown sequence', async function() {
     async function initShutdownSequence() {
+      // init the default context
+      assert.ok(rclnodejs.isShutdown());
       await rclnodejs.init();
       assert.ok(!rclnodejs.isShutdown());
-      const defaultContext = rclnodejs.Context.defaultContext();
-      assert.ok(defaultContext !== null);
-      assert.ok(defaultContext.isOk);
-      assert.ok(defaultContext.isDefaultContext);
+      const defaultCtx = rclnodejs.Context.defaultContext();
+      assert.ok(defaultCtx !== null);
+      assert.ok(defaultCtx.isOk);
+      assert.ok(defaultCtx.isDefaultContext);
 
+      // init another one
       const ctx = new rclnodejs.Context();
       await rclnodejs.init(ctx);
       assert.ok(!rclnodejs.isShutdown(ctx));
       assert.ok(!rclnodejs.isShutdown());
       assert.ok(ctx.isOk);
       assert.ok(!ctx.isDefaultContext);
-      assert.ok(defaultContext.isOk);
-      assert.ok(defaultContext.isDefaultContext);
+      assert.ok(defaultCtx.isOk);
+      assert.ok(defaultCtx.isDefaultContext);
 
-      assert.doesNotThrow(() => rclnodejs.shutdown());
+      // shut down the default context
+      rclnodejs.shutdown();
       assert.ok(rclnodejs.isShutdown());
       assert.ok(!rclnodejs.isShutdown(ctx));
       assert.ok(ctx.isOk);
-      assert.ok(!defaultContext.isOk);
+      assert.ok(!defaultCtx.isOk);
 
-      assert.doesNotThrow(() => rclnodejs.shutdown(ctx));
+      // shut down the other context
+      rclnodejs.shutdown(ctx);
       assert.ok(rclnodejs.isShutdown());
       assert.ok(rclnodejs.isShutdown(ctx));
       assert.ok(!ctx.isOk);
-      assert.ok(!defaultContext.isOk);
+      assert.ok(!defaultCtx.isOk);
     }
 
     // execute it twice

--- a/test/test-init-shutdown.js
+++ b/test/test-init-shutdown.js
@@ -17,14 +17,13 @@
 const assert = require('assert');
 const rclnodejs = require('../index.js');
 
-describe('rclnodejs init and shutdown test suite', function() {
-
+describe('rclnodejs init and shutdown test suite', function () {
   it('basic rclnodejs.init() & rclnodejs.shutdown()', async function () {
     await rclnodejs.init();
     rclnodejs.shutdown();
   });
 
-  it('rclnodejs.isShutdown() values', async function() {
+  it('rclnodejs.isShutdown() values', async function () {
     assert.deepStrictEqual(rclnodejs.isShutdown(), true);
     await rclnodejs.init();
     assert.deepStrictEqual(rclnodejs.isShutdown(), false);
@@ -32,60 +31,80 @@ describe('rclnodejs init and shutdown test suite', function() {
     assert.deepStrictEqual(rclnodejs.isShutdown(), true);
   });
 
-  it('rclnodejs init shutdown sequence', async function() {
+  it('rclnodejs init shutdown sequence', async function () {
     // the first round
     await rclnodejs.init();
     rclnodejs.shutdown();
 
     // and the second round: do it again!
-    assert.doesNotThrow(async () => {
+    assert.doesNotReject(async () => {
       await rclnodejs.init();
     }, 're-initializing after a shutdown should work');
     rclnodejs.shutdown();
   });
 
-  it('rclnodejs.init(argv)', async function() {
+  it('rclnodejs.init(argv)', async function () {
     await rclnodejs.init(rclnodejs.Context.defaultContext(), ['a', 'b']);
     rclnodejs.shutdown();
   });
 
-  it('rclnodejs.init(argv) - invalid argv', async function() {
-    assert.throws(async () => {
-      await rclnodejs.init(rclnodejs.Context.defaultContext(), 'foobar');
-    }, Error, 'an invalid argument should be rejected');
+  it('rclnodejs.init(argv) - invalid argv', async function () {
+    assert.rejects(
+      async () => {
+        await rclnodejs.init(rclnodejs.Context.defaultContext(), 'foobar');
+      },
+      Error,
+      'an invalid argument should be rejected'
+    );
     rclnodejs.shutdown();
   });
 
-  it('rclnodejs.init(argv) with null argv elements', async function() {
-    assert.throws(async () => {
-      await rclnodejs.init(rclnodejs.Context.defaultContext(), ['a', null, 'b']);
-    }, Error, 'an invalid argument should be rejected');
+  it('rclnodejs.init(argv) with null argv elements', async function () {
+    assert.rejects(
+      async () => {
+        await rclnodejs.init(rclnodejs.Context.defaultContext(), [
+          'a',
+          null,
+          'b',
+        ]);
+      },
+      Error,
+      'an invalid argument should be rejected'
+    );
     rclnodejs.shutdown();
   });
 
-  it('rclnodejs double init should throw', async function() {
+  it('rclnodejs double init should throw', async function () {
     await rclnodejs.init();
-    assert.throws(async () => {
-      await rclnodejs.init();
-    }, Error, 'initializing it twice shall cause an error to be thrown');
+    assert.rejects(
+      async () => {
+        await rclnodejs.init();
+      },
+      Error,
+      'initializing it twice shall cause an error to be thrown'
+    );
   });
 
-  it('rclnodejs double shutdown should work', async function() {
+  it('rclnodejs double shutdown should work', async function () {
     await rclnodejs.init();
     rclnodejs.shutdown();
 
-    assert.doesNotThrow(() => {
+    assert.doesNotReject(() => {
       rclnodejs.shutdown();
     }, 'shutting rclnodejs down twice should not cause an error to be thrown');
   });
 
-  it('rclnodejs create node without init should fail', async function() {
-    assert.throws(() => {
-      rclnodejs.createNode('my_node');
-    }, Error, 'creating a node on an uninitialized context should cause an error to be thrown');
+  it('rclnodejs create node without init should fail', async function () {
+    assert.rejects(
+      () => {
+        rclnodejs.createNode('my_node');
+      },
+      Error,
+      'creating a node on an uninitialized context should cause an error to be thrown'
+    );
   });
 
-  it('rclnodejs multiple contexts init shutdown sequence', async function() {
+  it('rclnodejs multiple contexts init shutdown sequence', async function () {
     async function initShutdownSequence() {
       // init the default context
       assert.ok(rclnodejs.isShutdown());
@@ -125,5 +144,4 @@ describe('rclnodejs init and shutdown test suite', function() {
     await initShutdownSequence();
     await initShutdownSequence();
   });
-
 });

--- a/test/test-init-shutdown.js
+++ b/test/test-init-shutdown.js
@@ -89,13 +89,13 @@ describe('rclnodejs init and shutdown test suite', function () {
     await rclnodejs.init();
     rclnodejs.shutdown();
 
-    assert.doesNotReject(() => {
+    assert.doesNotThrow(() => {
       rclnodejs.shutdown();
     }, 'shutting rclnodejs down twice should not cause an error to be thrown');
   });
 
   it('rclnodejs create node without init should fail', async function () {
-    assert.rejects(
+    assert.throws(
       () => {
         rclnodejs.createNode('my_node');
       },

--- a/test/test-logging.js
+++ b/test/test-logging.js
@@ -16,107 +16,63 @@
 
 const assert = require('assert');
 const rclnodejs = require('../index.js');
-const Context = require('../lib/context.js');
 
 describe('Rclnodejs - Test logging util', function() {
+
   it('Test setting severity level', function() {
-    let logger = rclnodejs.logging.getLogger('severity_logger');
+    const logger = rclnodejs.logging.getLogger('severity_logger');
     logger.setLoggerLevel(logger.LoggingSeverity.DEBUG);
-    assert.equal(logger.loggerEffectiveLevel, logger.LoggingSeverity.DEBUG);
+    assert.deepStrictEqual(logger.loggerEffectiveLevel, logger.LoggingSeverity.DEBUG);
   });
 
   it('Test logger name', function() {
-    let logger = rclnodejs.logging.getLogger('logger');
-    assert.equal(logger.name, 'logger');
+    const logger = rclnodejs.logging.getLogger('logger');
+    assert.strictEqual(logger.name, 'logger');
   });
 
   it('Test severity level threshold', function() {
-    let logger = rclnodejs.logging.getLogger('threshold_logger');
+    const logger = rclnodejs.logging.getLogger('threshold_logger');
     logger.setLoggerLevel(logger.LoggingSeverity.INFO);
 
     // Logging below threshold not expected to be logged
-    assert.equal(logger.debug('message debug'), false);
+    assert.strictEqual(logger.debug('message debug'), false);
 
     // Logging at or above threshold expected to be logged
-    assert.equal(logger.info('message info'), true);
-    assert.equal(logger.warn('message warn'), true);
-    assert.equal(logger.fatal('message fatal'), true);
+    assert.strictEqual(logger.info('message info'), true);
+    assert.strictEqual(logger.warn('message warn'), true);
+    assert.strictEqual(logger.fatal('message fatal'), true);
   });
 
   it('Test logger name', function() {
-    let logger = rclnodejs.logging.getLogger('logger');
-    assert.equal(logger.name, 'logger');
+    const logger = rclnodejs.logging.getLogger('logger');
+    assert.strictEqual(logger.name, 'logger');
   });
 
-  it('Test commandline parameter configuration', async function() {
-    let argv, logger;
-
-    argv = ['--ros-args', '--log-level', 'debug'];
-    await rclnodejs.init(rclnodejs.Context.defaultContext(), argv);
-    logger = rclnodejs.logging.getLogger('test_logger1');
-    assert.deepStrictEqual(
-      logger.loggerEffectiveLevel,
-      logger.LoggingSeverity.DEBUG
-    );
+  async function testLoglevel(level) {
+    await rclnodejs.init(['--ros-args', '--log-level', level]);
+    const logger = rclnodejs.logging.getLogger(`test_logger_${level}`);
+    const expected = logger.LoggingSeverity[level.toUpperCase()];
+    assert.deepStrictEqual(logger.loggerEffectiveLevel, expected);
     rclnodejs.shutdown();
+  }
 
-    argv = ['--ros-args', '--log-level', 'info'];
-    await rclnodejs.init(rclnodejs.Context.defaultContext(), argv);
-    logger = rclnodejs.logging.getLogger('test_logger2');
-    assert.deepStrictEqual(
-      logger.loggerEffectiveLevel,
-      logger.LoggingSeverity.INFO
-    );
-    rclnodejs.shutdown();
+  for (const level of ['debug', 'info', 'warn', 'error', 'fatal']) {
+    it(`Test commandline parameter configuration of log level '${level}'`, async function() {
+      // test the specific log level
+      await testLoglevel(level)
+    });
+  }
 
-    argv = ['--ros-args', '--log-level', 'warn'];
-    await rclnodejs.init(rclnodejs.Context.defaultContext(), argv);
-    logger = rclnodejs.logging.getLogger('test_logger3');
-    assert.deepStrictEqual(
-      logger.loggerEffectiveLevel,
-      logger.LoggingSeverity.WARN
-    );
-    rclnodejs.shutdown();
+  it ('Test commandline parameter configuration resets correctly', async  function () {
+    // reset the default log level to 'info'
+    await testLoglevel('info')
 
-    argv = ['--ros-args', '--log-level', 'error'];
-    await rclnodejs.init(rclnodejs.Context.defaultContext(), argv);
-    logger = rclnodejs.logging.getLogger('test_logger4');
-    assert.deepStrictEqual(
-      logger.loggerEffectiveLevel,
-      logger.LoggingSeverity.ERROR
-    );
-    rclnodejs.shutdown();
-
-    argv = ['--ros-args', '--log-level', 'fatal'];
-    await rclnodejs.init(rclnodejs.Context.defaultContext(), argv);
-    logger = rclnodejs.logging.getLogger('test_logger5');
-    assert.deepStrictEqual(
-      logger.loggerEffectiveLevel,
-      logger.LoggingSeverity.FATAL
-    );
-    rclnodejs.shutdown();
-
-    argv = ['--ros-args', '--log-level', 'fatal'];
-    await rclnodejs.init(rclnodejs.Context.defaultContext(), argv);
-    logger = rclnodejs.logging.getLogger('test_logger6');
-    logger.setLoggerLevel(logger.LoggingSeverity.DEBUG);
-    assert.deepStrictEqual(
-      logger.loggerEffectiveLevel,
-      logger.LoggingSeverity.DEBUG
-    );
-    rclnodejs.shutdown();
-
-    // reset rcl's default log level to 'info'
-    argv = ['--ros-args', '--log-level', 'info'];
-    await rclnodejs.init(rclnodejs.Context.defaultContext(), argv);
-    rclnodejs.shutdown();
-
+    // check that it was reset to 'info' when creating a node
     await rclnodejs.init();
-    let node = rclnodejs.createNode('test_node');
-    assert.deepStrictEqual(
-      node.getLogger().loggerEffectiveLevel,
-      logger.LoggingSeverity.INFO
-    );
+    const node = rclnodejs.createNode('test_node');
+    const logger = node.getLogger();
+    assert.deepStrictEqual(logger.loggerEffectiveLevel,logger.LoggingSeverity.INFO);
     rclnodejs.shutdown();
   });
+
 });

--- a/test/test-logging.js
+++ b/test/test-logging.js
@@ -59,19 +59,19 @@ describe('Rclnodejs - Test logging util', function() {
   for (const level of ['debug', 'info', 'warn', 'error', 'fatal']) {
     it(`Test commandline parameter configuration of log level '${level}'`, async function() {
       // test the specific log level
-      await testLoglevel(level)
+      await testLoglevel(level);
     });
   }
 
   it ('Test commandline parameter configuration resets correctly', async  function () {
     // reset the default log level to 'info'
-    await testLoglevel('info')
+    await testLoglevel('info');
 
     // check that it was reset to 'info' when creating a node
     await rclnodejs.init();
     const node = rclnodejs.createNode('test_node');
     const logger = node.getLogger();
-    assert.deepStrictEqual(logger.loggerEffectiveLevel,logger.LoggingSeverity.INFO);
+    assert.deepStrictEqual(logger.loggerEffectiveLevel, logger.LoggingSeverity.INFO);
     rclnodejs.shutdown();
   });
 

--- a/test/test-logging.js
+++ b/test/test-logging.js
@@ -17,20 +17,22 @@
 const assert = require('assert');
 const rclnodejs = require('../index.js');
 
-describe('Rclnodejs - Test logging util', function() {
-
-  it('Test setting severity level', function() {
+describe('Test logging util', function () {
+  it('Test setting severity level', function () {
     const logger = rclnodejs.logging.getLogger('severity_logger');
     logger.setLoggerLevel(logger.LoggingSeverity.DEBUG);
-    assert.deepStrictEqual(logger.loggerEffectiveLevel, logger.LoggingSeverity.DEBUG);
+    assert.deepStrictEqual(
+      logger.loggerEffectiveLevel,
+      logger.LoggingSeverity.DEBUG
+    );
   });
 
-  it('Test logger name', function() {
+  it('Test logger name', function () {
     const logger = rclnodejs.logging.getLogger('logger');
     assert.strictEqual(logger.name, 'logger');
   });
 
-  it('Test severity level threshold', function() {
+  it('Test severity level threshold', function () {
     const logger = rclnodejs.logging.getLogger('threshold_logger');
     logger.setLoggerLevel(logger.LoggingSeverity.INFO);
 
@@ -43,13 +45,17 @@ describe('Rclnodejs - Test logging util', function() {
     assert.strictEqual(logger.fatal('message fatal'), true);
   });
 
-  it('Test logger name', function() {
+  it('Test logger name', function () {
     const logger = rclnodejs.logging.getLogger('logger');
     assert.strictEqual(logger.name, 'logger');
   });
 
   async function testLoglevel(level) {
-    await rclnodejs.init(['--ros-args', '--log-level', level]);
+    await rclnodejs.init(rclnodejs.Context.defaultContext(), [
+      '--ros-args',
+      '--log-level',
+      level,
+    ]);
     const logger = rclnodejs.logging.getLogger(`test_logger_${level}`);
     const expected = logger.LoggingSeverity[level.toUpperCase()];
     assert.deepStrictEqual(logger.loggerEffectiveLevel, expected);
@@ -57,13 +63,13 @@ describe('Rclnodejs - Test logging util', function() {
   }
 
   for (const level of ['debug', 'info', 'warn', 'error', 'fatal']) {
-    it(`Test commandline parameter configuration of log level '${level}'`, async function() {
+    it(`Test commandline parameter configuration of log level '${level}'`, async function () {
       // test the specific log level
       await testLoglevel(level);
     });
   }
 
-  it ('Test commandline parameter configuration resets correctly', async  function () {
+  it('Test commandline parameter configuration resets correctly', async function () {
     // reset the default log level to 'info'
     await testLoglevel('info');
 
@@ -71,8 +77,10 @@ describe('Rclnodejs - Test logging util', function() {
     await rclnodejs.init();
     const node = rclnodejs.createNode('test_node');
     const logger = node.getLogger();
-    assert.deepStrictEqual(logger.loggerEffectiveLevel, logger.LoggingSeverity.INFO);
+    assert.deepStrictEqual(
+      logger.loggerEffectiveLevel,
+      logger.LoggingSeverity.INFO
+    );
     rclnodejs.shutdown();
   });
-
 });


### PR DESCRIPTION
This:
- roughly cuts the changed code length in half,
- is *much* more readable thanks to `async` code,
- uses strict comparisons,
- has better error messages/test titles,
- is less duplicated, and
- does not really change *what* is tested.

Closes #731 