### PR TITLE
Use specified deleter for RclHandle

### DIFF
--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -180,11 +180,11 @@ RclResult Executor::WaitForReadyCallbacks(rcl_wait_set_t* wait_set,
       return RclResult(get_entity_ret, error_message);
     }
 
-    rcl_ret_t resize_ret = rcl_wait_set_resize(
-        wait_set, num_subscriptions, num_guard_conditions, num_timers,
-        num_clients, num_services,
-        // TODO(minggang): support events.
-        0u);
+    rcl_ret_t resize_ret =
+        rcl_wait_set_resize(wait_set, num_subscriptions, num_guard_conditions,
+                            num_timers, num_clients, num_services,
+                            // TODO(minggang): support events.
+                            0u);
     if (resize_ret != RCL_RET_OK) {
       std::string error_message = std::string("Failed to resize: ") +
                                   std::string(rcl_get_error_string().str);

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -22,7 +22,6 @@
     if (lhs op rhs) {                                               \
       Nan::ThrowError(message);                                     \
       rcl_reset_error();                                            \
-      info.GetReturnValue().Set(Nan::Undefined());                  \
       return;                                                       \
     }                                                               \
   }

--- a/src/rcl_action_bindings.cpp
+++ b/src/rcl_action_bindings.cpp
@@ -80,9 +80,13 @@ NAN_METHOD(ActionCreateClient) {
         rcl_action_client_init(action_client, node, ts, action_name.c_str(),
                                &action_client_ops),
         RCL_RET_OK, rcl_get_error_string().str);
-    auto js_obj = RclHandle::NewInstance(
-        action_client, node_handle, [action_client, node] {
-          return rcl_action_client_fini(action_client, node);
+    auto js_obj =
+        RclHandle::NewInstance(action_client, node_handle, [node](void* ptr) {
+          rcl_action_client_t* action_client =
+              reinterpret_cast<rcl_action_client_t*>(ptr);
+          rcl_ret_t ret = rcl_action_client_fini(action_client, node);
+          free(ptr);
+          THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
         });
 
     info.GetReturnValue().Set(js_obj);
@@ -147,9 +151,13 @@ NAN_METHOD(ActionCreateServer) {
         rcl_action_server_init(action_server, node, clock, ts,
                                action_name.c_str(), &action_server_ops),
         RCL_RET_OK, rcl_get_error_string().str);
-    auto js_obj = RclHandle::NewInstance(
-        action_server, node_handle, [action_server, node] {
-          return rcl_action_server_fini(action_server, node);
+    auto js_obj =
+        RclHandle::NewInstance(action_server, node_handle, [node](void* ptr) {
+          rcl_action_server_t* action_server =
+              reinterpret_cast<rcl_action_server_t*>(ptr);
+          rcl_ret_t ret = rcl_action_server_fini(action_server, node);
+          free(ptr);
+          THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
         });
 
     info.GetReturnValue().Set(js_obj);
@@ -208,7 +216,8 @@ NAN_METHOD(ActionTakeGoalRequest) {
   rcl_ret_t ret =
       rcl_action_take_goal_request(action_server, header, taken_request);
   if (ret != RCL_RET_ACTION_SERVER_TAKE_FAILED) {
-    auto js_obj = RclHandle::NewInstance(header);
+    auto js_obj =
+        RclHandle::NewInstance(header, nullptr, [](void* ptr) { free(ptr); });
     info.GetReturnValue().Set(js_obj);
     return;
   }
@@ -296,7 +305,8 @@ NAN_METHOD(ActionTakeCancelRequest) {
   rcl_ret_t ret =
       rcl_action_take_cancel_request(action_server, header, taken_request);
   if (ret != RCL_RET_ACTION_SERVER_TAKE_FAILED) {
-    auto js_obj = RclHandle::NewInstance(header);
+    auto js_obj =
+        RclHandle::NewInstance(header, nullptr, [](void* ptr) { free(ptr); });
     info.GetReturnValue().Set(js_obj);
     return;
   }
@@ -386,7 +396,8 @@ NAN_METHOD(ActionTakeResultRequest) {
   rcl_ret_t ret =
       rcl_action_take_result_request(action_server, header, taken_request);
   if (ret != RCL_RET_ACTION_SERVER_TAKE_FAILED) {
-    auto js_obj = RclHandle::NewInstance(header);
+    auto js_obj =
+        RclHandle::NewInstance(header, nullptr, [](void* ptr) { free(ptr); });
     info.GetReturnValue().Set(js_obj);
     return;
   }
@@ -464,8 +475,12 @@ NAN_METHOD(ActionAcceptNewGoal) {
     return;
   }
 
-  auto js_obj = RclHandle::NewInstance(goal_handle, nullptr, [goal_handle] {
-    return rcl_action_goal_handle_fini(goal_handle);
+  auto js_obj = RclHandle::NewInstance(goal_handle, nullptr, [](void* ptr) {
+    rcl_action_goal_handle_t* goal_handle =
+        reinterpret_cast<rcl_action_goal_handle_t*>(ptr);
+    rcl_ret_t ret = rcl_action_goal_handle_fini(goal_handle);
+    free(ptr);
+    THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
   });
 
   info.GetReturnValue().Set(js_obj);
@@ -646,9 +661,13 @@ NAN_METHOD(ActionProcessCancelRequest) {
   }
 
   *response = cancel_response_ptr->msg;
-  auto js_obj = RclHandle::NewInstance(
-      cancel_response_ptr, nullptr, [cancel_response_ptr] {
-        return rcl_action_cancel_response_fini(cancel_response_ptr);
+  auto js_obj =
+      RclHandle::NewInstance(cancel_response_ptr, nullptr, [](void* ptr) {
+        rcl_action_cancel_response_t* cancel_response_ptr =
+            reinterpret_cast<rcl_action_cancel_response_t*>(ptr);
+        rcl_ret_t ret = rcl_action_cancel_response_fini(cancel_response_ptr);
+        free(ptr);
+        THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
       });
   info.GetReturnValue().Set(js_obj);
 }

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -258,8 +258,12 @@ NAN_METHOD(CreateNode) {
                                          name_space.c_str(), context, &options),
                            rcl_get_error_string().str);
 
-  auto handle = RclHandle::NewInstance(node, nullptr,
-                                       [node] { return rcl_node_fini(node); });
+  auto handle = RclHandle::NewInstance(node, nullptr, [](void* ptr) {
+    rcl_node_t* node = reinterpret_cast<rcl_node_t*>(ptr);
+    rcl_ret_t ret = rcl_node_fini(node);
+    free(ptr);
+    THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
+  });
   info.GetReturnValue().Set(handle);
 }
 
@@ -280,8 +284,12 @@ NAN_METHOD(CreateGuardCondition) {
                            rcl_guard_condition_init(gc, context, gc_options),
                            rcl_get_error_string().str);
 
-  auto handle = RclHandle::NewInstance(
-      gc, nullptr, [gc] { return rcl_guard_condition_fini(gc); });
+  auto handle = RclHandle::NewInstance(gc, nullptr, [](void* ptr) {
+    rcl_guard_condition_t* gc = reinterpret_cast<rcl_guard_condition_t*>(ptr);
+    rcl_ret_t ret = rcl_guard_condition_fini(gc);
+    free(ptr);
+    THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
+  });
   info.GetReturnValue().Set(handle);
 }
 
@@ -315,8 +323,12 @@ NAN_METHOD(CreateTimer) {
                      rcl_get_default_allocator()),
       rcl_get_error_string().str);
 
-  auto js_obj = RclHandle::NewInstance(
-      timer, clock_handle, [timer] { return rcl_timer_fini(timer); });
+  auto js_obj = RclHandle::NewInstance(timer, clock_handle, [](void* ptr) {
+    rcl_timer_t* timer = reinterpret_cast<rcl_timer_t*>(ptr);
+    rcl_ret_t ret = rcl_timer_fini(timer);
+    free(ptr);
+    THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
+  });
   info.GetReturnValue().Set(js_obj);
 }
 
@@ -411,7 +423,8 @@ NAN_METHOD(CreateTimePoint) {
   time_point->nanoseconds = std::stoll(str);
   time_point->clock_type = static_cast<rcl_clock_type_t>(clock_type);
 
-  auto js_obj = RclHandle::NewInstance(time_point, nullptr, nullptr);
+  auto js_obj =
+      RclHandle::NewInstance(time_point, nullptr, [](void* ptr) { free(ptr); });
   info.GetReturnValue().Set(js_obj);
 }
 
@@ -431,7 +444,8 @@ NAN_METHOD(CreateDuration) {
       reinterpret_cast<rcl_duration_t*>(malloc(sizeof(rcl_duration_t)));
   duration->nanoseconds = std::stoll(str);
 
-  auto js_obj = RclHandle::NewInstance(duration, nullptr, nullptr);
+  auto js_obj =
+      RclHandle::NewInstance(duration, nullptr, [](void* ptr) { free(ptr); });
   info.GetReturnValue().Set(js_obj);
 }
 
@@ -500,8 +514,13 @@ NAN_METHOD(CreateClock) {
                            rcl_clock_init(clock_type, clock, &allocator),
                            rcl_get_error_string().str);
 
-  info.GetReturnValue().Set(RclHandle::NewInstance(
-      clock, nullptr, [clock]() { return rcl_clock_fini(clock); }));
+  info.GetReturnValue().Set(
+      RclHandle::NewInstance(clock, nullptr, [](void* ptr) {
+        rcl_clock_t* clock = reinterpret_cast<rcl_clock_t*>(ptr);
+        rcl_ret_t ret = rcl_clock_fini(clock);
+        free(ptr);
+        THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
+      }));
 }
 
 static void ReturnJSTimeObj(
@@ -654,8 +673,12 @@ NAN_METHOD(CreateSubscription) {
         rcl_get_error_string().str);
 
     auto js_obj =
-        RclHandle::NewInstance(subscription, node_handle, [subscription, node] {
-          return rcl_subscription_fini(subscription, node);
+        RclHandle::NewInstance(subscription, node_handle, [node](void* ptr) {
+          rcl_subscription_t* subscription =
+              reinterpret_cast<rcl_subscription_t*>(ptr);
+          rcl_ret_t ret = rcl_subscription_fini(subscription, node);
+          free(ptr);
+          THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
         });
     info.GetReturnValue().Set(js_obj);
   } else {
@@ -702,9 +725,13 @@ NAN_METHOD(CreatePublisher) {
         RCL_RET_OK, rcl_get_error_string().str);
 
     // Wrap the handle into JS object
-    auto js_obj = RclHandle::NewInstance(
-        publisher, node_handle,
-        [publisher, node]() { return rcl_publisher_fini(publisher, node); });
+    auto js_obj =
+        RclHandle::NewInstance(publisher, node_handle, [node](void* ptr) {
+          rcl_publisher_t* publisher = reinterpret_cast<rcl_publisher_t*>(ptr);
+          rcl_ret_t ret = rcl_publisher_fini(publisher, node);
+          free(ptr);
+          THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
+        });
 
     // Everything is done
     info.GetReturnValue().Set(js_obj);
@@ -767,9 +794,13 @@ NAN_METHOD(CreateClient) {
         rcl_client_init(client, node, ts, service_name.c_str(), &client_ops),
         RCL_RET_OK, rcl_get_error_string().str);
 
-    auto js_obj = RclHandle::NewInstance(client, node_handle, [client, node] {
-      return rcl_client_fini(client, node);
-    });
+    auto js_obj =
+        RclHandle::NewInstance(client, node_handle, [node](void* ptr) {
+          rcl_client_t* client = reinterpret_cast<rcl_client_t*>(ptr);
+          rcl_ret_t ret = rcl_client_fini(client, node);
+          free(ptr);
+          THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
+        });
 
     info.GetReturnValue().Set(js_obj);
   } else {
@@ -846,9 +877,13 @@ NAN_METHOD(CreateService) {
     THROW_ERROR_IF_NOT_EQUAL(
         rcl_service_init(service, node, ts, service_name.c_str(), &service_ops),
         RCL_RET_OK, rcl_get_error_string().str);
-    auto js_obj = RclHandle::NewInstance(service, node_handle, [service, node] {
-      return rcl_service_fini(service, node);
-    });
+    auto js_obj =
+        RclHandle::NewInstance(service, node_handle, [node](void* ptr) {
+          rcl_service_t* service = reinterpret_cast<rcl_service_t*>(ptr);
+          rcl_ret_t ret = rcl_service_fini(service, node);
+          free(ptr);
+          THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
+        });
 
     info.GetReturnValue().Set(js_obj);
   } else {
@@ -868,7 +903,8 @@ NAN_METHOD(RclTakeRequest) {
       node::Buffer::Data(Nan::To<v8::Object>(info[2]).ToLocalChecked());
   rcl_ret_t ret = rcl_take_request(service, header, taken_request);
   if (ret != RCL_RET_SERVICE_TAKE_FAILED) {
-    auto js_obj = RclHandle::NewInstance(header);
+    auto js_obj =
+        RclHandle::NewInstance(header, nullptr, [](void* ptr) { free(ptr); });
     info.GetReturnValue().Set(js_obj);
     return;
   }
@@ -1294,7 +1330,7 @@ NAN_METHOD(CreateArrayBufferCleaner) {
 
   char* target = *reinterpret_cast<char**>(address + offset);
   info.GetReturnValue().Set(
-      RclHandle::NewInstance(target, nullptr, [] { return RCL_RET_OK; }));
+      RclHandle::NewInstance(target, nullptr, [](void* ptr) { free(ptr); }));
 }
 
 NAN_METHOD(setLoggerLevel) {
@@ -1378,8 +1414,12 @@ NAN_METHOD(CreateContext) {
   rcl_context_t* context =
       reinterpret_cast<rcl_context_t*>(malloc(sizeof(rcl_context_t)));
   *context = rcl_get_zero_initialized_context();
-  auto js_obj = RclHandle::NewInstance(context, nullptr,
-                                       std::bind(DestroyContext, context));
+  auto js_obj = RclHandle::NewInstance(context, nullptr, [](void* ptr) {
+    rcl_context_t* context = reinterpret_cast<rcl_context_t*>(ptr);
+    rcl_ret_t ret = DestroyContext(context);
+    free(ptr);
+    THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
+  });
 
   info.GetReturnValue().Set(js_obj);
 }

--- a/src/rcl_handle.cpp
+++ b/src/rcl_handle.cpp
@@ -85,8 +85,8 @@ NAN_METHOD(RclHandle::Dismiss) {
   info.GetReturnValue().Set(Nan::Undefined());
 }
 
-v8::Local<v8::Object> RclHandle::NewInstance(void* handle, RclHandle* parent,
-                                             std::function<int()> deleter) {
+v8::Local<v8::Object> RclHandle::NewInstance(
+    void* handle, RclHandle* parent, std::function<void(void*)> deleter) {
   Nan::EscapableHandleScope scope;
 
   v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
@@ -123,12 +123,7 @@ void RclHandle::Reset() {
     child->Reset();
   }
 
-  if (deleter_ && deleter_() != RCL_RET_OK) {
-    Nan::ThrowError(rcl_get_error_string().str);
-    rcl_reset_error();
-  }
-
-  free(pointer_);
+  if (deleter_) deleter_(pointer_);
 
   pointer_ = nullptr;
   children_.clear();

--- a/src/rcl_handle.hpp
+++ b/src/rcl_handle.hpp
@@ -27,11 +27,10 @@ namespace rclnodejs {
 class RclHandle : public Nan::ObjectWrap {
  public:
   static void Init(v8::Local<v8::Object> exports);
-  static v8::Local<v8::Object> NewInstance(
-      void* handle, RclHandle* parent = nullptr,
-      std::function<int()> deleter = [] { return 0; } );
+  static v8::Local<v8::Object> NewInstance(void* handle, RclHandle* parent,
+                                           std::function<void(void*)> deleter);
 
-  void set_deleter(std::function<int()> deleter) { deleter_ = deleter; }
+  void set_deleter(std::function<void(void*)> deleter) { deleter_ = deleter; }
 
   RclHandle* parent() { return parent_; }
   void set_parent(RclHandle* parent) { parent_ = parent; }
@@ -63,7 +62,7 @@ class RclHandle : public Nan::ObjectWrap {
   std::map<std::string, bool> properties_;
   v8::Local<v8::Object> properties_obj_;
 
-  std::function<int()> deleter_;
+  std::function<void(void*)> deleter_;
   std::set<RclHandle*> children_;
 };
 


### PR DESCRIPTION
This patch will enable RclHandle to use a specified deleter to free
the resources, which means the pointer passed when contructing the
RclHandle object will not be freed by default.

After this patch, caller should be responsible to manage the memory.

Fix #728