### PR TITLE
fix tests in foxy/ubuntu-20.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
         - ./node_modules
     # Test
     - run: npm install istanbul coveralls
-    - run: source ~/ros2_install/ros2-osx/local_setup.bash && export OPENSSL_ROOT_DIR="/usr/local/opt/openssl" && node scripts/compile_tests.js && node --expose-gc ./node_modules/.bin/istanbul cover ./scripts/run_test.js --report lcovonly && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
+    - run: source ~/ros2_install/ros2-osx/local_setup.bash && export OPENSSL_ROOT_DIR="/usr/local/opt/openssl" && node scripts/compile_tests.js && . install/setup.bash && node --expose-gc ./node_modules/.bin/istanbul cover ./scripts/run_test.js --report lcovonly && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
     # Teardown
     - run: find $HOME/Library/Developer/Xcode/DerivedData -name '*.xcactivitylog' -exec cp {} $CIRCLE_ARTIFACTS/xcactivitylog \; || true
     # Save test results

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,8 @@ before_build:
   - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2019-10-24/tinyxml2.6.0.0.nupkg
   - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2019-10-24/log4cxx.0.10.0.nupkg
   - choco install -y -s c:\download\ asio bullet cunit eigen tinyxml-usestl tinyxml2 log4cxx
-  - appveyor DownloadFile https://github.com/ros2/ros2/releases/download/release-foxy-20201009/ros2-foxy-20201009-windows-release-amd64.zip
-  - 7z x -y "c:\download\ros2-foxy-20201009-windows-release-amd64.zip" -o"c:\" > nul
+  - appveyor DownloadFile https://ci.ros2.org/view/packaging/job/packaging_windows/lastSuccessfulBuild/artifact/ws/ros2-package-windows-AMD64.zip
+  - 7z x -y "c:\download\ros2-package-windows-AMD64.zip" -o"c:\" > nul
   - setx -m OPENSSL_CONF C:\OpenSSL-Win64\bin\openssl.cfg
   - set PATH=C:\OpenSSL-Win64\bin;%PATH%
   - setx AMENT_PYTHON_EXECUTABLE "c:\Python37"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ before_build:
   - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2019-10-24/log4cxx.0.10.0.nupkg
   - choco install -y -s c:\download\ asio bullet cunit eigen tinyxml-usestl tinyxml2 log4cxx
   - appveyor DownloadFile https://github.com/ros2/ros2/releases/download/release-foxy-20201009/ros2-foxy-20201009-windows-release-amd64.zip
-  - 7z x -y "c:\download\ros2-package-windows-AMD64.zip" -o"c:\" > nul
+  - 7z x -y "c:\download\ros2-foxy-20201009-windows-release-amd64.zip" -o"c:\" > nul
   - setx -m OPENSSL_CONF C:\OpenSSL-Win64\bin\openssl.cfg
   - set PATH=C:\OpenSSL-Win64\bin;%PATH%
   - setx AMENT_PYTHON_EXECUTABLE "c:\Python37"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ before_build:
   - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2019-10-24/tinyxml2.6.0.0.nupkg
   - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2019-10-24/log4cxx.0.10.0.nupkg
   - choco install -y -s c:\download\ asio bullet cunit eigen tinyxml-usestl tinyxml2 log4cxx
-  - appveyor DownloadFile https://ci.ros2.org/view/packaging/job/packaging_windows/lastSuccessfulBuild/artifact/ws/ros2-package-windows-AMD64.zip
+  - appveyor DownloadFile https://github.com/ros2/ros2/releases/download/release-foxy-20201009/ros2-foxy-20201009-windows-release-amd64.zip
   - 7z x -y "c:\download\ros2-package-windows-AMD64.zip" -o"c:\" > nul
   - setx -m OPENSSL_CONF C:\OpenSSL-Win64\bin\openssl.cfg
   - set PATH=C:\OpenSSL-Win64\bin;%PATH%

--- a/benchmark/rclcpp/service/client-stress-test.cpp
+++ b/benchmark/rclcpp/service/client-stress-test.cpp
@@ -22,11 +22,10 @@
 #include "utilities.hpp"
 
 void ShowUsage(const std::string name) {
-    std::cerr << "Usage: " << name << " [options]\n"
-              << "\nOptions:\n"
-              << "\n--run <n>     \tHow many times to run\n"
-              << "--help          \toutput usage information"
-              << std::endl;
+  std::cerr << "Usage: " << name << " [options]\n"
+            << "\nOptions:\n"
+            << "\n--run <n>     \tHow many times to run\n"
+            << "--help          \toutput usage information" << std::endl;
 }
 
 int main(int argc, char* argv[]) {
@@ -36,15 +35,16 @@ int main(int argc, char* argv[]) {
   for (int i = 1; i < argc; i++) {
     std::string arg = argv[i];
     if ((arg == "-h") || (arg == "--help")) {
-        ShowUsage(argv[0]);
-        return 0;
+      ShowUsage(argv[0]);
+      return 0;
     } else if (arg.find("--run=") != std::string::npos) {
-        total_times = std::stoi(arg.substr(arg.find("=") + 1));
+      total_times = std::stoi(arg.substr(arg.find("=") + 1));
     }
   }
   printf(
       "The client will send a GetMap request continuously until receiving "
-      "response %d times.\n", total_times);
+      "response %d times.\n",
+      total_times);
 
   auto start = std::chrono::high_resolution_clock::now();
   auto node = rclcpp::Node::make_shared("stress_client_rclcpp");
@@ -60,7 +60,7 @@ int main(int argc, char* argv[]) {
     } else {
       auto result_future = client->async_send_request(request);
       if (rclcpp::spin_until_future_complete(node, result_future) !=
-          rclcpp::executor::FutureReturnCode::SUCCESS) {
+          rclcpp::FutureReturnCode::SUCCESS) {
         RCLCPP_ERROR(node->get_logger(), "service call failed.");
         return 1;
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "install": "node-gyp rebuild",
     "docs": "cd docs && make",
-    "test": "node ./scripts/compile_tests.js && node --expose-gc ./scripts/run_test.js && npm run dtslint",
+    "test": "node ./scripts/compile_tests.js && node ./scripts/test.js && npm run dtslint",
     "dtslint": "node ./scripts/generate_tsd.js && dtslint test/types",
     "lint": "eslint --max-warnings=0 --ext js,ts index.js types scripts lib example rosidl_gen rosidl_parser test benchmark/rclnodejs && node ./scripts/cpplint.js",
     "postinstall": "node scripts/generate_messages.js",

--- a/scripts/compile_tests.js
+++ b/scripts/compile_tests.js
@@ -14,111 +14,20 @@
 
 'use strict';
 
-/* eslint-disable */
-const fs = require('fs-extra');
-const os = require('os');
 const path = require('path');
 const child = require('child_process');
 
 var rootDir = path.dirname(__dirname);
 var testCppDir = path.join(rootDir, 'test', 'cpp');
 
-function getExecutable(input) {
-  if (os.platform() === 'win32') return input + '.exe';
-
-  return input;
-}
-
-var publisher = getExecutable('publisher_msg');
-var subscription = getExecutable('subscription_msg');
-var listener = getExecutable('listener');
-var client = getExecutable('add_two_ints_client');
-
-function getExecutablePath(input) {
-  var releaseDir = '';
-  if (os.platform() === 'win32') releaseDir = 'Release';
-
-  return path.join(rootDir, 'build', 'cpp_nodes', releaseDir, input);
-}
-
-var publisherPath = getExecutablePath(publisher);
-var subscriptionPath = getExecutablePath(subscription);
-var listenerPath = getExecutablePath(listener);
-var clientPath = getExecutablePath(client);
-
-function copyFile(platform, srcFile, destFile) {
-  if (!fs.existsSync(destFile)) {
-    if (os.platform() === 'win32') {
-      child.spawn('cmd.exe', ['/c', `copy ${srcFile} ${destFile}`]);
-    } else {
-      child.spawn('sh', ['-c', `cp ${srcFile} ${destFile}`]);
-    }
-  }
-}
-
-function copyAll(fileList, dest) {
-  fileList.forEach((file) => {
-    copyFile(os.platform(), file, path.join(dest, path.basename(file)));
-    console.log(`cpp executables ${file} is copied to test/cpp.`);
-  });
-}
-
-function copyPkgToRos2(pkgName) {
-  let srcDir = path.join(rootDir, 'install', pkgName);
-  let destDir = process.env.COLCON_PREFIX_PATH;
-  if (os.platform() === 'win32') {
-    child.spawn('cmd.exe', ['/c', `xcopy ${srcDir} ${destDir} /O /X /E /K`]);
-  } else {
-    child.spawn('sh', ['-c ', '"' + `cp -fr ${srcDir}/. ${destDir}` + '"'], {
-      shell: true,
-    });
-  }
-}
-
-var subProcess = child.spawn('colcon', [
-  'build',
-  '--event-handlers',
-  'console_cohesion+',
-  '--base-paths',
+const basePaths = [
   path.join(rootDir, 'test', 'rclnodejs_test_msgs'),
-]);
-subProcess.on('close', (code) => {
-  copyPkgToRos2('rclnodejs_test_msgs');
-});
-subProcess.stdout.on('data', (data) => {
-  console.log(`${data}`);
-});
-subProcess.stderr.on('data', (data) => {
-  console.log(`${data}`);
-});
+  testCppDir,
+];
 
-if (
-  !fs.existsSync(publisherPath) &&
-  !fs.existsSync(subscriptionPath) &&
-  !fs.existsSync(listenerPath) &&
-  !fs.existsSync(clientPath)
-) {
-  var compileProcess = child.spawn('colcon', [
-    'build',
-    '--base-paths',
-    testCppDir,
-  ]);
-  compileProcess.on('close', (code) => {
-    copyAll(
-      [publisherPath, subscriptionPath, listenerPath, clientPath],
-      testCppDir
-    );
-  });
-  compileProcess.stdout.on('data', (data) => {
-    console.log(`${data}`);
-  });
-  compileProcess.stderr.on('data', (data) => {
-    console.log(`${data}`);
-  });
-} else {
-  copyAll(
-    [publisherPath, subscriptionPath, , listenerPath, clientPath],
-    testCppDir
-  );
-}
-/* eslint-enable */
+// foxy has a bug where fastRTPS can't be found, a workaround is to add
+// AMENT_PREFIX_PATH to CMAKE_PREFIX_PATH
+process.env.CMAKE_PREFIX_PATH = `${process.env.CMAKE_PREFIX_PATH}:${process.env.AMENT_PREFIX_PATH}`;
+child.spawnSync('colcon', ['build', '--base-paths', ...basePaths], {
+  stdio: 'inherit',
+});

--- a/scripts/run_test.js
+++ b/scripts/run_test.js
@@ -19,14 +19,6 @@ const Mocha = require('mocha');
 const os = require('os');
 const path = require('path');
 
-let rootDir = path.dirname(__dirname);
-let actionPath = path.join(rootDir, 'test', 'ros1_actions');
-process.env.AMENT_PREFIX_PATH =
-  process.env.AMENT_PREFIX_PATH + path.delimiter + actionPath;
-let msgPath = path.join(rootDir, 'test', 'rclnodejs_test_msgs');
-process.env.AMENT_PREFIX_PATH =
-  process.env.AMENT_PREFIX_PATH + path.delimiter + msgPath;
-
 fs.remove(path.join(path.dirname(__dirname), 'generated'), (err) => {
   if (!err) {
     let mocha = new Mocha();

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -23,7 +23,7 @@ const path = require('path');
 
 const rootDir = path.dirname(__dirname);
 
-if (os.platform === 'win32') {
+if (os.platform() === 'win32') {
   childprocess.execSync(
     `. ${rootDir}\\install\\setup.ps1 && node --expose-gc ${rootDir}\\scripts\\run_test.js`,
     { stdio: 'inherit', shell: 'powershell' }

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -25,8 +25,8 @@ const rootDir = path.dirname(__dirname);
 
 if (os.platform() === 'win32') {
   childprocess.execSync(
-    `. ${rootDir}\\install\\setup.ps1 && node --expose-gc ${rootDir}\\scripts\\run_test.js`,
-    { stdio: 'inherit', shell: 'powershell' }
+    `dir ${rootDir}\\install && call ${rootDir}\\install\\setup.bat && node --expose-gc ${rootDir}\\scripts\\run_test.js`,
+    { stdio: 'inherit' }
   );
 } else {
   childprocess.execSync(

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+'use strict';
+
+const os = require('os');
+const childprocess = require('child_process');
+const path = require('path');
+
+const rootDir = path.dirname(__dirname);
+
+if (os.platform === 'win32') {
+  childprocess.execSync(
+    `. ${rootDir}\\install\\setup.ps1 && node --expose-gc ${rootDir}\\scripts\\run_test.js`,
+    { stdio: 'inherit', shell: 'powershell' }
+  );
+} else {
+  childprocess.execSync(
+    `. ${rootDir}/install/setup.bash && node --expose-gc ${rootDir}/scripts/run_test.js`,
+    { stdio: 'inherit', shell: 'bash' }
+  );
+}

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -25,7 +25,7 @@ const rootDir = path.dirname(__dirname);
 
 if (os.platform() === 'win32') {
   childprocess.execSync(
-    `dir ${rootDir}\\install && call ${rootDir}\\install\\setup.bat && node --expose-gc ${rootDir}\\scripts\\run_test.js`,
+    `call ${rootDir}\\install\\setup.bat && node --expose-gc ${rootDir}\\scripts\\run_test.js`,
     { stdio: 'inherit' }
   );
 } else {


### PR DESCRIPTION
I'm not sure if I'm the only one having this problem, the tests are failing for me in foxy/ubuntu-20.04. I actually saw in problem before in other projects and it is due to fastRTPS not correctly exported some cmake files. The simple workaround is to add AMENT_PREFIX_PATH to CMAKE_PREFIX_PATH.

I also try to simplify the compiling step by using colcon and sourcing the output instead of copying files around.

Edit: Actually all the previous build have been failing but it seems tests still passes
```
> rclnodejs@0.17.0 test /root/rclnodejs
> node ./scripts/compile_tests.js && node --expose-gc ./scripts/run_test.js && npm run dtslint

Starting >>> cpp_nodes

Starting >>> rclnodejs_test_msgs

--- stderr: cpp_nodes
/root/rclnodejs/test/cpp/add_two_ints_client.cpp: In function â€˜example_interfaces::srv::AddTwoInts_Response_<std::allocator<void> >::SharedPtr send_request(rclcpp::Node::SharedPtr, rclcpp::Client<example_interfaces::srv::AddTwoInts>::SharedPtr, example_interfaces::srv::AddTwoInts_Request_<std::allocator<void> >::SharedPtr)â€™:
/root/rclnodejs/test/cpp/add_two_ints_client.cpp:48:23: error: â€˜rclcpp::executor::FutureReturnCodeâ€™ has not been declared
   48 |     rclcpp::executor::FutureReturnCode::SUCCESS)
      |                       ^~~~~~~~~~~~~~~~
/root/rclnodejs/test/cpp/add_two_ints_client.cpp: In function â€˜int main(int, char**)â€™:
/root/rclnodejs/test/cpp/add_two_ints_client.cpp:94:23: error: â€˜rclcpp::executor::FutureReturnCodeâ€™ has not been declared
   94 |     rclcpp::executor::FutureReturnCode::SUCCESS)
      |                       ^~~~~~~~~~~~~~~~
/root/rclnodejs/test/cpp/add_two_ints_client.cpp: In function â€˜example_interfaces::srv::AddTwoInts_Response_<std::allocator<void> >::SharedPtr send_request(rclcpp::Node::SharedPtr, rclcpp::Client<example_interfaces::srv::AddTwoInts>::SharedPtr, example_interfaces::srv::AddTwoInts_Request_<std::allocator<void> >::SharedPtr)â€™:
/root/rclnodejs/test/cpp/add_two_ints_client.cpp:54:1: warning: control reaches end of non-void function [-Wreturn-type]
   54 | }
      | ^
make[2]: *** [CMakeFiles/add_two_ints_client.dir/build.make:63: CMakeFiles/add_two_ints_client.dir/add_two_ints_client.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:84: CMakeFiles/add_two_ints_client.dir/all] Error 2
make: *** [Makefile:95: all] Error 2
---
Failed   <<< cpp_nodes [7.06s, exited with code 2]
```