### PR TITLE
Fix 100% CPU usage if there are no handles

### DIFF
--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -113,8 +113,10 @@ void Executor::Run(void* arg) {
 
       {
         ScopedMutex mutex(handle_manager->mutex());
-        if (handle_manager->is_empty())
+        if (handle_manager->is_empty()) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(1));
           continue;
+        }
 
         if (rcl_wait_set_resize(&wait_set, handle_manager->subscription_count(),
                                 // TODO(minggang): support guard conditions


### PR DESCRIPTION
_Originally posted by @renehoelbling in https://github.com/Intermodalics/rclnodejs/pull/1:_

> Add sleep to avoid busy waiting

Without the patch we observed situations where the [ros2-web-bridge](https://github.com/RobotWebTools/ros2-web-bridge) process consumed 100% of CPU while looping in `Executor::Run()`, if there is actually nothing to do (no clients connected). But I am not familiar with `rclnodejs` internals to check whether it is still an issue with the latest version, and in which cases `handle_manager->is_empty()` can return `true`.

This patch was based on version [0.10.3](https://github.com/RobotWebTools/rclnodejs/tree/0.10.3) (for ROS dashing). In the meantime the `is_empty()` check has been moved to
https://github.com/RobotWebTools/rclnodejs/blob/45d7bd0a5cbc7b9d5bd6b397b33abc770845771b/src/executor.cpp#L166-L167
in https://github.com/RobotWebTools/rclnodejs/pull/563, but nothing fundamentally changed and the loop in `Executor::Run()` could still busy-wait.

What do you think? Is this a real issue, and if yes, would you solve it in a different way?