### PR TITLE
Block the background thread when no handles are added 

### DIFF
--- a/lib/node_options.js
+++ b/lib/node_options.js
@@ -23,11 +23,18 @@ class NodeOptions {
   /**
    * Create a new instance with default property values.
    * @constructor
+   * @param {boolean} [startParameterServices=true]
+   * @param {array} [parameterOverrides=[]]
+   * @param {boolean} [automaticallyDeclareParametersFromOverrides=false]
    */
-  constructor() {
-    this._startParameterServices = true;
-    this._parameterOverrides = [];
-    this._automaticallyDeclareParametersFromOverrides = false;
+  constructor(
+    startParameterServices = true,
+    parameterOverrides = [],
+    automaticallyDeclareParametersFromOverrides = false
+  ) {
+    this._startParameterServices = startParameterServices;
+    this._parameterOverrides = parameterOverrides;
+    this._automaticallyDeclareParametersFromOverrides = automaticallyDeclareParametersFromOverrides;
   }
 
   /**

--- a/src/executor.hpp
+++ b/src/executor.hpp
@@ -46,6 +46,7 @@ class Executor {
   void Stop();
   void SpinOnce(rcl_context_t* context, int32_t time_out);
   int32_t time_out() { return time_out_; }
+  bool IsMainThread();
 
   static void DoWork(uv_async_t* handle);
   static void Run(void* arg);
@@ -58,7 +59,12 @@ class Executor {
   void ExecuteReadyHandles();
 
   uv_async_t* async_;
-  uv_thread_t thread_;
+
+  // The v8 main thread.
+  uv_thread_t main_thread_;
+
+  // Sub thread used to query the ready handles.
+  uv_thread_t background_thread_;
 
   HandleManager* handle_manager_;
   Delegate* delegate_;


### PR DESCRIPTION
Currently, if parameter service is not enabled and no handles are added
into the wait set, the background thread will loop without doing
anything, which causes a high CPU load.

This patch implements that when there is no handles are attached to the
current node, the background thread will be blocked by a semaphore and
the main thread will signal it later when new handle has been created.

Fix #752