### PR TITLE
Don't login docker hub anonymous

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ branches:
   only:
   - develop
 
-before_install:
+script:
+  - 'if [ "$DOCKER_USERNAME" != "" ]; then sudo docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD; fi'
   - sudo docker pull ubuntu:focal
   - sudo docker build -t rcldocker .
-
-script:
   - sudo docker run -v $(pwd):/root/rclnodejs --rm rcldocker bash -i -c 'cd /root/rclnodejs && cppcheck --suppress=syntaxError --enable=all src/*.cpp src/*.hpp && ./scripts/build.sh && npm test'


### PR DESCRIPTION
Becasue rate limits anonymous and free authenticated use of Docker Hub
went into effect (https://www.docker.com/increase-rate-limits),
we need to login docker with an account.

This patch sets two environment variables
(DOCKER_PASSWORD & DOCKER_USERNAME) for the travis-ci that will be
used to login to the docker hub, thus, we could break the limiting.
Please be aware, the PR submitted from a fork repo will not use
this account due to
https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions

Fix #766