### PR TITLE
Run rclnodejs with Node.js (>= 10 and <=12) on appveyor 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ rclnodejs.init().then(() => {
 
 Before installing `rclnodejs` please ensure the following softare is installed and configured on your systemd:
 
-- [Nodejs](https://nodejs.org/en/) version between 8.12 - 12.x.
+- [Nodejs](https://nodejs.org/en/) version between 10.23.1 - 12.x.
 
 - [ROS 2 SDK](https://index.ros.org/doc/ros2/Installation/) for details.
   **DON'T FORGET TO [SOURCE THE ROS 2 SETUP FILE](https://index.ros.org/doc/ros2/Tutorials/Configuring-ROS2-Environment/#source-the-setup-files)**

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,11 @@ branches:
 image: Visual Studio 2019
 
 environment:
-  nodejs_version: "12"
   PYTHON3: "c:\\Python37-x64"
   PYTHON2: "c:\\Python27"
+  matrix:
+    - nodejs_version: "10"
+    - nodejs_version: "12"
 
 clone_folder: c:\proj\rclnodejs
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -44,8 +44,6 @@ let defaultContext = null;
  * to the usable 'initialized' (valid) state be using.
  */
 class Context {
-  static _instances = [];
-
   /**
    * Access the list of usable (initialized/valid) contexts.
    * @returns {Context[]} Array of valid contexts
@@ -222,5 +220,7 @@ class Context {
     return defaultContext;
   }
 }
+
+Context._instances = [];
 
 module.exports = Context;

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "compare-versions": "^3.6.0",
     "debug": "^4.1.1",
     "dot": "^1.1.3",
-    "fs-extra": "^9.0.1",
+    "fs-extra": "^9.1.0",
     "is-close": "^1.3.3",
     "mkdirp": "^1.0.4",
     "mz": "^2.7.0",
@@ -67,7 +67,8 @@
     "ref-struct-di": "^1.1.1",
     "walk": "^2.3.14",
     "uuid": "^8.2.0",
-    "int64-napi": "^1.0.1"
+    "int64-napi": "^1.0.1",
+    "array.prototype.flat": "^1.2.4"
   },
   "husky": {
     "hooks": {
@@ -83,6 +84,6 @@
     ]
   },
   "engines": {
-    "node": ">= 8.12.0 <13.0.0"
+    "node": ">= 10.23.1 <13.0.0"
   }
 }

--- a/rosidl_gen/packages.js
+++ b/rosidl_gen/packages.js
@@ -20,6 +20,7 @@ const readline = require('readline');
 const path = require('path');
 const walk = require('walk');
 const os = require('os');
+const flat = require('array.prototype.flat');
 
 const fsp = fs.promises;
 
@@ -135,9 +136,13 @@ async function getPackageDefinitionsFiles(packageName, amentRoot) {
  */
 async function findAmentPackagesInDirectory(dir) {
   const pkgs = await getAmentPackages(dir);
-  const rosFiles = (
-    await Promise.all(pkgs.map((pkg) => getPackageDefinitionsFiles(pkg, dir)))
-  ).flat();
+  const files = await Promise.all(
+    pkgs.map((pkg) => getPackageDefinitionsFiles(pkg, dir))
+  );
+
+  // Support flat() methond for nodejs < 11.
+  const rosFiles = Array.prototype.flat ? files.flat() : flat(files);
+
   const pkgMap = new Map();
   return new Promise((resolve, reject) => {
     rosFiles.forEach((filePath) => {

--- a/test/blocklist.json
+++ b/test/blocklist.json
@@ -1,5 +1,5 @@
 {
   "Linux": ["test-multi-nodes.js", "test-msg-type-py-node.js", "test-msg-type-cpp-node.js", "test-cross-lang.js"],
   "Darwin": ["test-multi-nodes.js", "test-msg-type-py-node.js", "test-msg-type-cpp-node.js", "test-cross-lang.js"],
-  "Windows_NT": ["test-multi-nodes.js", "test-msg-type-py-node.js", "test-msg-type-cpp-node.js", "test-cross-lang.js"]
+  "Windows_NT": ["test-multi-nodes.js", "test-msg-type-py-node.js", "test-msg-type-cpp-node.js", "test-cross-lang.js", "test-generate-messages-bin.js"]
 }


### PR DESCRIPTION
Recently, we observerd that rcnodejs is not supported by some version of
Node.js, because some new features the current JS code used are not
supported by these versions yet.

This patch replaces these cases with compatible patterns. As the nodejs
v8.x has been EOF already (https://nodejs.org/en/about/releases/), we
decided to drop it. (Another reason is that some depenency of rclnodejs
requires nodejs >= 10.x)

Meanwhile, we are going to use a matrix to run Node.js (LTS) version
for both 10 and 12.

Fix #768