### PR TITLE
Added galactic to the list of supported ros2 distros

### DIFF
--- a/scripts/ros_distro.js
+++ b/scripts/ros_distro.js
@@ -5,6 +5,7 @@ switch (process.env.ROS_DISTRO) {
     console.log('1911');
     process.exit(0);
   case 'foxy':
+  case 'galactic':
   case 'rolling':
     console.log('2006');
     process.exit(0);


### PR DESCRIPTION
Simple change that adds 'galactic' to the recognized ros2 distros.

Fix #790