### PR TITLE
support foxy & galactic simultaneously

### DIFF
--- a/scripts/ros_distro.js
+++ b/scripts/ros_distro.js
@@ -5,9 +5,11 @@ switch (process.env.ROS_DISTRO) {
     console.log('1911');
     process.exit(0);
   case 'foxy':
+    console.log('2006');
+    process.exit(0);
   case 'galactic':
   case 'rolling':
-    console.log('2006');
+    console.log('2105');
     process.exit(0);
   case undefined:
     console.error(

--- a/src/rcl_lifecycle_bindings.cpp
+++ b/src/rcl_lifecycle_bindings.cpp
@@ -73,7 +73,6 @@ NAN_METHOD(CreateLifecycleStateMachine) {
   const rosidl_service_type_support_t* gtg =
       GetServiceTypeSupport("lifecycle_msgs", "GetAvailableTransitions");
 
-	  
 #if ROS_VERSION >= 2105
   rcl_lifecycle_state_machine_options_t options =
       rcl_lifecycle_get_default_state_machine_options();

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -397,13 +397,15 @@ describe('rcl node methods testing', function () {
     assert.strictEqual(currentNode.namespace, '/my_ns');
   });
 
-  it('node.countPublishers', function () {
+  it('node.countPublishers', async () => {
     assert.strictEqual(node.countPublishers('chatter'), 0);
 
     node.createPublisher(RclString, 'chatter');
+    await assertUtils.createDelay(500);
     assert.strictEqual(node.countPublishers('chatter'), 1);
 
     node.createPublisher(RclString, 'chatter');
+    await assertUtils.createDelay(500);
     assert.strictEqual(node.countPublishers('chatter'), 2);
   });
 


### PR DESCRIPTION
ros_distro.js
- added ros galactic version id: 2105

rcl_lifecycle_binding.cpp
- uses ros galactic version id (2105) to select between foxy and
galactic lifecycle api

test-raw-pub-sub.js
- uses ros_distro.js to access ros version id
- for galactic version, test uses null-terminated string

test-node.js
- added small 100ms wait between publisher creation and test for
node.publisherCount() to avoid failing on slower systems.

fixes #729