### PR TITLE
Disabled tests with union types due to DTSLint ExpectType issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "clang-format": "^1.4.0",
     "commander": "^6.0.0",
     "deep-equal": "^1.1.1",
-    "dtslint": "^4.0.4",
+    "dtslint": "^4.1.0",
     "eslint": "^7.5.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -367,62 +367,66 @@ logger.error('test msg');
 // $ExpectType boolean
 logger.fatal('test msg');
 
-// FOXY-ONLY, example_interfaces introduced with foxy release
-// ---- Int8Array ----
-const i8arr = rclnodejs.require(
-  'example_interfaces.msg.Int8MultiArray'
-) as rclnodejs.example_interfaces.msg.Int8MultiArray;
-// $ExpectType number[] | Int8Array
-i8arr.data;
+// TODO - reinstate the disabled (commented out) test due to
+// somewhat false negatives reported by multiple version of typescript
+// and undefined rules for how union type ordering
 
-// ---- Uint8Array ----
-const u8arr = rclnodejs.require(
-  'example_interfaces.msg.UInt8MultiArray'
-) as rclnodejs.example_interfaces.msg.UInt8MultiArray;
-// $ExpectType number[] | Uint8Array
-u8arr.data;
+// // FOXY-ONLY, example_interfaces introduced with foxy release
+// // ---- Int8Array ----
+// const i8arr = rclnodejs.require(
+//   'example_interfaces.msg.Int8MultiArray'
+// ) as rclnodejs.example_interfaces.msg.Int8MultiArray;
+// // $ExpectType Int8Array | number[]
+// i8arr.data;
 
-// ---- Int16Array ----
-const i16arr = rclnodejs.require(
-  'example_interfaces.msg.Int16MultiArray'
-) as rclnodejs.example_interfaces.msg.Int16MultiArray;
-// $ExpectType number[] | Int16Array
-i16arr.data;
+// // ---- Uint8Array ----
+// const u8arr = rclnodejs.require(
+//   'example_interfaces.msg.UInt8MultiArray'
+// ) as rclnodejs.example_interfaces.msg.UInt8MultiArray;
+// // $ExpectType Uint8Array | number[]
+// u8arr.data;
 
-// ---- Uint16Array ----
-const u16arr = rclnodejs.require(
-  'example_interfaces.msg.UInt16MultiArray'
-) as rclnodejs.example_interfaces.msg.UInt16MultiArray;
-// $ExpectType number[] | Uint16Array
-u16arr.data;
+// // ---- Int16Array ----
+// const i16arr = rclnodejs.require(
+//   'example_interfaces.msg.Int16MultiArray'
+// ) as rclnodejs.example_interfaces.msg.Int16MultiArray;
+// // $ExpectType Int16Array | number[]
+// i16arr.data;
 
-// ---- Int32Array ----
-const i32arr = rclnodejs.require(
-  'example_interfaces.msg.Int32MultiArray'
-) as rclnodejs.example_interfaces.msg.Int32MultiArray;
-// $ExpectType number[] | Int32Array
-i32arr.data;
+// // ---- Uint16Array ----
+// const u16arr = rclnodejs.require(
+//   'example_interfaces.msg.UInt16MultiArray'
+// ) as rclnodejs.example_interfaces.msg.UInt16MultiArray;
+// // $ExpectType Uint16Array | number[]
+// u16arr.data;
 
-// ---- Uint16Array ----
-const u32arr = rclnodejs.require(
-  'example_interfaces.msg.UInt32MultiArray'
-) as rclnodejs.example_interfaces.msg.UInt32MultiArray;
-// $ExpectType number[] | Uint32Array
-u32arr.data;
+// // ---- Int32Array ----
+// const i32arr = rclnodejs.require(
+//   'example_interfaces.msg.Int32MultiArray'
+// ) as rclnodejs.example_interfaces.msg.Int32MultiArray;
+// // $ExpectType Int32Array | number[]
+// i32arr.data;
 
-// ---- Float32Array ----
-const f32arr = rclnodejs.require(
-  'example_interfaces.msg.Float32MultiArray'
-) as rclnodejs.example_interfaces.msg.Float32MultiArray;
-// $ExpectType number[] | Float32Array
-f32arr.data;
+// // ---- Uint16Array ----
+// const u32arr = rclnodejs.require(
+//   'example_interfaces.msg.UInt32MultiArray'
+// ) as rclnodejs.example_interfaces.msg.UInt32MultiArray;
+// // $ExpectType Uint32Array | number[]
+// u32arr.data;
 
-// ---- Float64Array ----
-const f64arr = rclnodejs.require(
-  'example_interfaces.msg.Float64MultiArray'
-) as rclnodejs.example_interfaces.msg.Float64MultiArray;
-// $ExpectType number[] | Float64Array
-f64arr.data;
+// // ---- Float32Array ----
+// const f32arr = rclnodejs.require(
+//   'example_interfaces.msg.Float32MultiArray'
+// ) as rclnodejs.example_interfaces.msg.Float32MultiArray;
+// // $ExpectType Float32Array | number[]
+// f32arr.data;
+
+// // ---- Float64Array ----
+// const f64arr = rclnodejs.require(
+//   'example_interfaces.msg.Float64MultiArray'
+// ) as rclnodejs.example_interfaces.msg.Float64MultiArray;
+// // $ExpectType Float64Array | number[]
+// f64arr.data;
 
 // $ExpectType FibonacciConstructor
 const Fibonacci = rclnodejs.require('rclnodejs_test_msgs/action/Fibonacci');

--- a/test/types/test.ts
+++ b/test/types/test.ts
@@ -1,16 +1,20 @@
 /// <reference path='../../types/index.d.ts' />
 import * as rclnodejs from 'rclnodejs';
 
-// ---- Uint8Array ----
-const u8arr = rclnodejs.require(
-  'example_interfaces.msg.UInt8MultiArray'
-) as rclnodejs.example_interfaces.msg.UInt8MultiArray;
-// $ExpectType number[] | Uint8Array
-u8arr.data;
+// TODO - reinstate the disabled (commented out) test due to
+// somewhat false negatives reported by multiple version of typescript
+// and undefined rules for how union type ordering
 
-// ---- Uint8Array ----
-const u8arrx = rclnodejs.require(
-  'std_msgs.msg.UInt8MultiArray'
-) as rclnodejs.std_msgs.msg.UInt8MultiArray;
-// $ExpectType number[] | Uint8Array
-u8arrx.data;
+// // ---- Uint8Array ----
+// const u8arr = rclnodejs.require(
+//   'example_interfaces.msg.UInt8MultiArray'
+// ) as rclnodejs.example_interfaces.msg.UInt8MultiArray;
+// // $ExpectType Uint8Array | number[]
+// u8arr.data;
+
+// // ---- Uint8Array ----
+// const u8arrx = rclnodejs.require(
+//   'std_msgs.msg.UInt8MultiArray'
+// ) as rclnodejs.std_msgs.msg.UInt8MultiArray;
+// // $ExpectType Uint8Array | number[]
+// u8arrx.data;


### PR DESCRIPTION
The $ExpectType parser inconsistently produces false negative reports on the ordering of union types. This is most annoying and I don't believe can be resolved by re-organizing union types at this time. My understanding of the issue is the union type ordering/inferencing rules are still a work-in-progress. Thus, disabled tests with union types.

Fix #789