### PR TITLE
Implements LifecycleNode constructor enableCommunicationInterface

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,12 +187,13 @@ let rcl = {
   },
 
   /**
-   * Create a managed Node that implements a well-defined life-cycle state
+   * Create a LifecycleNode, a managed Node that implements a well-defined life-cycle state
    * model using the {@link https://github.com/ros2/rcl/tree/master/rcl_lifecycle|ros2 client library (rcl) lifecyle api}.
    * @param {string} nodeName - The name used to register in ROS.
    * @param {string} [namespace=''] - The namespace used in ROS.
    * @param {Context} [context=Context.defaultContext()] - The context to create the node in.
    * @param {NodeOptions} [options=NodeOptions.defaultOptions] - The options to configure the new node behavior.
+   * @param {boolean} [enableCommunicationsInterface=true] - enable lifecycle service interfaces, e.g., GetState.
    * @return {LifecycleNode} A new instance of the specified node.
    * @throws {Error} If the given context is not registered.
    * @deprecated since 0.18.0, Use new LifecycleNode constructor.
@@ -201,13 +202,15 @@ let rcl = {
     nodeName,
     namespace = '',
     context = Context.defaultContext(),
-    options = NodeOptions.defaultOptions
+    options = NodeOptions.defaultOptions,
+    enableCommunicationsInterface = true
   ) {
     return new this.lifecycle.LifecycleNode(
       nodeName,
       namespace,
       context,
-      options
+      options,
+      enableCommunicationsInterface
     );
   },
 

--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -17,8 +17,11 @@
 const rclnodejs = require('bindings')('rclnodejs');
 const LifecyclePublisher = require('./lifecycle_publisher.js');
 const loader = require('./interface_loader.js');
-const Service = require('./service.js');
+const Context = require('./context.js');
 const Node = require('./node.js');
+const NodeOptions = require('./node_options.js');
+const Service = require('./service.js');
+
 
 const SHUTDOWN_TRANSITION_LABEL =
   rclnodejs.getLifecycleShutdownTransitionLabel();
@@ -263,24 +266,42 @@ class CallbackReturnValue {
  */
 
 class LifecycleNode extends Node {
+
+  /**
+   * Create a managed Node that implements a well-defined life-cycle state
+   * model using the {@link https://github.com/ros2/rcl/tree/master/rcl_lifecycle|ros2 client library (rcl) lifecyle api}.
+   * @param {string} nodeName - The name used to register in ROS.
+   * @param {string} [namespace=''] - The namespace used in ROS.
+   * @param {Context} [context=Context.defaultContext()] - The context to create the node in.
+   * @param {NodeOptions} [options=NodeOptions.defaultOptions] - The options to configure the new node behavior.
+   * @param {boolean} [enableCommunicationsInterface=true] - Enable lifecycle service interfaces, e.g., GetState.
+   * @throws {Error} If the given context is not registered.
+   */
   constructor(
     nodeName,
     namespace = '',
     context = Context.defaultContext(),
-    options = NodeOptions.defaultOptions
+    options = NodeOptions.defaultOptions,
+    enableCommunicationInterface = true
   ) {
     super(nodeName, namespace, context, options);
-    this.init();
+    this.init(enableCommunicationInterface);
   }
 
-  init() {
+  init(enableCommunicationInterface) {
     // initialize native handle to rcl_lifecycle_state_machine
     this._stateMachineHandle = rclnodejs.createLifecycleStateMachine(
-      this.handle
+      this.handle,
+      enableCommunicationInterface
     );
 
     // initialize Map<transitionId,TransitionCallback>
     this._callbackMap = new Map();
+
+    if (!enableCommunicationInterface) {
+      // do not create lifecycle services
+      return;
+    }
 
     // Setup and register the 4 native rcl lifecycle services thar are
     // part of _stateMachineHandle.

--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -22,7 +22,6 @@ const Node = require('./node.js');
 const NodeOptions = require('./node_options.js');
 const Service = require('./service.js');
 
-
 const SHUTDOWN_TRANSITION_LABEL =
   rclnodejs.getLifecycleShutdownTransitionLabel();
 
@@ -266,7 +265,6 @@ class CallbackReturnValue {
  */
 
 class LifecycleNode extends Node {
-
   /**
    * Create a managed Node that implements a well-defined life-cycle state
    * model using the {@link https://github.com/ros2/rcl/tree/master/rcl_lifecycle|ros2 client library (rcl) lifecyle api}.

--- a/lib/node.js
+++ b/lib/node.js
@@ -45,10 +45,19 @@ const PARAMETER_EVENT_TOPIC = 'parameter_events';
 
 /**
  * @class - Class representing a Node in ROS
- * @hideconstructor
  */
 
 class Node extends rclnodejs.ShadowNode {
+
+  /**
+   * Create a ROS2Node.
+   * model using the {@link https://github.com/ros2/rcl/tree/master/rcl_lifecycle|ros2 client library (rcl) lifecyle api}.
+   * @param {string} nodeName - The name used to register in ROS.
+   * @param {string} [namespace=''] - The namespace used in ROS.
+   * @param {Context} [context=Context.defaultContext()] - The context to create the node in.
+   * @param {NodeOptions} [options=NodeOptions.defaultOptions] - The options to configure the new node behavior.
+   * @throws {Error} If the given context is not registered.
+   */
   constructor(
     nodeName,
     namespace = '',

--- a/lib/node.js
+++ b/lib/node.js
@@ -48,7 +48,6 @@ const PARAMETER_EVENT_TOPIC = 'parameter_events';
  */
 
 class Node extends rclnodejs.ShadowNode {
-
   /**
    * Create a ROS2Node.
    * model using the {@link https://github.com/ros2/rcl/tree/master/rcl_lifecycle|ros2 client library (rcl) lifecyle api}.

--- a/src/rcl_lifecycle_bindings.cpp
+++ b/src/rcl_lifecycle_bindings.cpp
@@ -53,6 +53,7 @@ static v8::Local<v8::Object> wrapTransition(
 NAN_METHOD(CreateLifecycleStateMachine) {
   RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(
       Nan::To<v8::Object>(info[0]).ToLocalChecked());
+  bool enableCommunicationInterface = Nan::To<bool>(info[1]).FromJust();
   rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
 
   rcl_lifecycle_state_machine_t* state_machine =
@@ -62,20 +63,21 @@ NAN_METHOD(CreateLifecycleStateMachine) {
 
   const rosidl_message_type_support_t* pn =
       GetMessageTypeSupport("lifecycle_msgs", "msg", "TransitionEvent");
-  const rosidl_service_type_support_t* cs =
-      GetServiceTypeSupport("lifecycle_msgs", "ChangeState");
-  const rosidl_service_type_support_t* gs =
-      GetServiceTypeSupport("lifecycle_msgs", "GetState");
   const rosidl_service_type_support_t* gas =
       GetServiceTypeSupport("lifecycle_msgs", "GetAvailableStates");
   const rosidl_service_type_support_t* gat =
       GetServiceTypeSupport("lifecycle_msgs", "GetAvailableTransitions");
   const rosidl_service_type_support_t* gtg =
       GetServiceTypeSupport("lifecycle_msgs", "GetAvailableTransitions");
-
+  const rosidl_service_type_support_t* cs =
+      GetServiceTypeSupport("lifecycle_msgs", "ChangeState");
+  const rosidl_service_type_support_t* gs =
+      GetServiceTypeSupport("lifecycle_msgs", "GetState");
 #if ROS_VERSION >= 2105
+
   rcl_lifecycle_state_machine_options_t options =
       rcl_lifecycle_get_default_state_machine_options();
+  options.enable_com_interface = enableCommunicationInterface;
 
   THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
                            rcl_lifecycle_state_machine_init(

--- a/src/rcl_lifecycle_bindings.cpp
+++ b/src/rcl_lifecycle_bindings.cpp
@@ -79,15 +79,14 @@ NAN_METHOD(CreateLifecycleStateMachine) {
       rcl_lifecycle_get_default_state_machine_options();
   options.enable_com_interface = enableCommunicationInterface;
 
-  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
-                           rcl_lifecycle_state_machine_init(
-                               state_machine, node,
-                               pn, cs, gs, gas, gat, gtg,
-                               &options),
-                           rcl_get_error_string().str);
+  THROW_ERROR_IF_NOT_EQUAL(
+      RCL_RET_OK,
+      rcl_lifecycle_state_machine_init(state_machine, node, pn, cs, gs, gas,
+                                       gat, gtg, &options),
+      rcl_get_error_string().str);
 
-  auto js_obj = RclHandle::NewInstance(
-      state_machine, node_handle, [node](void* ptr) {
+  auto js_obj =
+      RclHandle::NewInstance(state_machine, node_handle, [node](void* ptr) {
         rcl_lifecycle_state_machine_t* state_machine =
             reinterpret_cast<rcl_lifecycle_state_machine_t*>(ptr);
         rcl_ret_t ret = rcl_lifecycle_state_machine_fini(state_machine, node);

--- a/src/rcl_lifecycle_bindings.cpp
+++ b/src/rcl_lifecycle_bindings.cpp
@@ -53,7 +53,7 @@ static v8::Local<v8::Object> wrapTransition(
 NAN_METHOD(CreateLifecycleStateMachine) {
   RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(
       Nan::To<v8::Object>(info[0]).ToLocalChecked());
-  bool enableCommunicationInterface = Nan::To<bool>(info[1]).FromJust();
+  bool enable_com_interface = Nan::To<bool>(info[1]).FromJust();
   rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
 
   rcl_lifecycle_state_machine_t* state_machine =
@@ -77,7 +77,7 @@ NAN_METHOD(CreateLifecycleStateMachine) {
 
   rcl_lifecycle_state_machine_options_t options =
       rcl_lifecycle_get_default_state_machine_options();
-  options.enable_com_interface = enableCommunicationInterface;
+  options.enable_com_interface = enable_com_interface;
 
   THROW_ERROR_IF_NOT_EQUAL(
       RCL_RET_OK,

--- a/test/test-lifecycle.js
+++ b/test/test-lifecycle.js
@@ -362,4 +362,3 @@ describe('LifecycleNode test suite', function () {
     testNode.destroy();
   });
 });
- 

--- a/test/test-lifecycle.js
+++ b/test/test-lifecycle.js
@@ -16,6 +16,7 @@
 const assert = require('assert');
 
 const rclnodejs = require('../index.js');
+const childProcess = require('child_process');
 const assertUtils = require('./utils.js');
 const assertThrowsError = assertUtils.assertThrowsError;
 
@@ -292,4 +293,73 @@ describe('LifecycleNode test suite', function () {
 
     assert.ok(isSuccess);
   });
+
+  it('LifecycleNode enableCommunicationsInterface', async function () {
+    node.stop();
+
+    node = rclnodejs.createLifecycleNode(NODE_NAME);
+
+    let services = node.getServiceNamesAndTypes();
+    let serviceMsgs = [];
+    services.forEach((service) => {
+      if (
+        service.types.length &&
+        service.types[0].startsWith('lifecycle_msgs')
+      ) {
+        serviceMsgs.push(service.types[0]);
+      }
+    });
+
+    assert.equal(
+      serviceMsgs.length,
+      5,
+      'Incomplete set of lifecycle services found'
+    );
+  });
+
+  it('LifecycleNode disable enableCommunicationsInterface', async function () {
+    // this test is only valid on ROS2 Galactic distro
+    // TODO: refactor the version info to reusable location
+    const GALACTIC_VERSION = 2105;
+    const versionInfo = childProcess
+      .execSync('node scripts/ros_distro.js')
+      .toString('utf-8');
+    const version =
+      versionInfo && versionInfo.length > 0
+        ? parseInt(versionInfo)
+        : GALACTIC_VERSION;
+
+    if (version < GALACTIC_VERSION) return;
+
+    let rosDistro = process.env.ROS_DISTRO;
+    let firstChar = rosDistro.charAt(0);
+    console.log('1st char: ', firstChar);
+    console.log('> ', firstChar > 'g');
+
+    let testNode = new rclnodejs.lifecycle.LifecycleNode(
+      'TEST_NODE',
+      undefined,
+      undefined,
+      undefined,
+      false
+    );
+    testNode.spin();
+
+    let services = testNode.getServiceNamesAndTypes();
+    let serviceMsgs = [];
+    services.forEach((service) => {
+      if (
+        service.name.startsWith('/TEST_NODE') &&
+        service.types &&
+        service.types.length &&
+        service.types[0].startsWith('lifecycle_msgs')
+      ) {
+        serviceMsgs.push(service.types[0]);
+      }
+    });
+
+    assert.equal(serviceMsgs.length, 0, 'Unexpected lifecycle services found');
+    testNode.destroy();
+  });
 });
+ 

--- a/test/test-node-oo.js
+++ b/test/test-node-oo.js
@@ -18,6 +18,7 @@ const IsClose = require('is-close');
 const assert = require('assert');
 const rclnodejs = require('../index.js');
 const assertUtils = require('./utils.js');
+const { util } = require('prettier');
 const assertThrowsError = assertUtils.assertThrowsError;
 
 describe('rclnodejs node test suite', function () {
@@ -405,13 +406,15 @@ describe('rcl node methods testing', function () {
     assert.strictEqual(node.countPublishers('chatter'), 2);
   });
 
-  it('node.countSubscribers', function () {
+  it('node.countSubscribers', async () => {
     assert.strictEqual(node.countSubscribers('chatter'), 0);
 
     node.createSubscription(RclString, 'chatter', () => {});
+    await assertUtils.createDelay(500);
     assert.strictEqual(node.countSubscribers('chatter'), 1);
 
     node.createSubscription(RclString, 'chatter', () => {});
+    await assertUtils.createDelay(500);
     assert.strictEqual(node.countSubscribers('chatter'), 2);
   });
 });

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -409,13 +409,15 @@ describe('rcl node methods testing', function () {
     assert.strictEqual(node.countPublishers('chatter'), 2);
   });
 
-  it('node.countSubscribers', function () {
+  it('node.countSubscribers', async () => {
     assert.strictEqual(node.countSubscribers('chatter'), 0);
 
     node.createSubscription(RclString, 'chatter', () => {});
+    await assertUtils.createDelay(500);
     assert.strictEqual(node.countSubscribers('chatter'), 1);
 
     node.createSubscription(RclString, 'chatter', () => {});
+    await assertUtils.createDelay(500);
     assert.strictEqual(node.countSubscribers('chatter'), 2);
   });
 });

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -91,6 +91,15 @@ node.countSubscribers(TOPIC);
 // $ExpectType LifecycleNode
 const lifecycleNode = rclnodejs.createLifecycleNode(LIFECYCLE_NODE_NAME);
 
+// $ExpectType LifecycleNode
+const lifecycleNode1 = rclnodejs.createLifecycleNode(
+  LIFECYCLE_NODE_NAME + '1',
+  undefined,
+  undefined,
+  undefined,
+  true
+);
+
 // $ExpectType State
 lifecycleNode.currentState;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,6 +13,7 @@ declare module 'rclnodejs' {
    * @param context - The context, default is Context.defaultContext().
    * @param options - The node options, default is NodeOptions.defaultOptions.
    * @returns The new Node instance.
+   * @deprecated since 0.18.0, Use new Node constructor.
    */
   function createNode(
     nodeName: string,
@@ -28,13 +29,16 @@ declare module 'rclnodejs' {
    * @param namespace - The namespace used in ROS, default is an empty string.
    * @param context - The context, default is Context.defaultContext().
    * @param options - The options to configure the new node behavior.
+   * @params enableCommunicationInterface: boolean - Enable lifecycle service interfaces, e.g., GetState.
    * @returns The instance of LifecycleNode.
+   * @deprecated since 0.18.0, Use new LifecycleNode constructor.
    */
   function createLifecycleNode(
     nodeName: string,
     namespace?: string,
     context?: Context,
-    options?: NodeOptions
+    options?: NodeOptions,
+    enableCommunicationInterface?: boolean
   ): lifecycle.LifecycleNode;
 
   /**

--- a/types/lifecycle.d.ts
+++ b/types/lifecycle.d.ts
@@ -190,6 +190,24 @@ declare module 'rclnodejs' {
      *   registerOnError(cb)
      */
     class LifecycleNode extends Node {
+
+      /**
+     * Create a node instance.
+     *
+     * @param nodeName - The name used to register in ROS.
+     * @param namespace - The namespace used in ROS, default is an empty string.
+     * @param context - The context, default is Context.defaultContext().
+     * @param options - The node options, default is NodeOptions.defaultOptions.
+     * @param enableCommunicationInterface - Enable lifecycle service interfaces, e.g., GetState.
+     */
+    constructor(
+      nodeName: string,
+      namespace?: string,
+      context?: Context,
+      options?: NodeOptions,
+      enableCommunicationInterface?: boolean
+    );
+
       /**
        * Access the current lifecycle state.
        * @returns The current state.

--- a/types/lifecycle.d.ts
+++ b/types/lifecycle.d.ts
@@ -190,23 +190,22 @@ declare module 'rclnodejs' {
      *   registerOnError(cb)
      */
     class LifecycleNode extends Node {
-
       /**
-     * Create a node instance.
-     *
-     * @param nodeName - The name used to register in ROS.
-     * @param namespace - The namespace used in ROS, default is an empty string.
-     * @param context - The context, default is Context.defaultContext().
-     * @param options - The node options, default is NodeOptions.defaultOptions.
-     * @param enableCommunicationInterface - Enable lifecycle service interfaces, e.g., GetState.
-     */
-    constructor(
-      nodeName: string,
-      namespace?: string,
-      context?: Context,
-      options?: NodeOptions,
-      enableCommunicationInterface?: boolean
-    );
+       * Create a node instance.
+       *
+       * @param nodeName - The name used to register in ROS.
+       * @param namespace - The namespace used in ROS, default is an empty string.
+       * @param context - The context, default is Context.defaultContext().
+       * @param options - The node options, default is NodeOptions.defaultOptions.
+       * @param enableCommunicationInterface - Enable lifecycle service interfaces, e.g., GetState.
+       */
+      constructor(
+        nodeName: string,
+        namespace?: string,
+        context?: Context,
+        options?: NodeOptions,
+        enableCommunicationInterface?: boolean
+      );
 
       /**
        * Access the current lifecycle state.


### PR DESCRIPTION

lifecycle-node.js
lifecycle-node.d.ts
rcl_lifecycle_binding.cpp
main.ts
* added support for enableCommunicationInterface param

index.js
* added support for enableCommunicationInterface param

index.d.ts
* added support for enableCommunicationInterface param
* added @deprecated tag to createNode() & createLifecycleNode()

test-lifecycle.js
* added 2 test to cover pos and neg versions of
enableCommunicationInterface parameter


Fix #799