### PR TITLE
add .gitattributes to project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,117 @@
+# Based on https://github.com/alexkaratarakis/gitattributes/blob/master/Web.gitattributes
+
+# Auto detect
+##   Handle line endings automatically for files detected as
+##   text and leave all files detected as binary untouched.
+##   This will handle all files NOT defined below.
+*                 text=auto
+
+# Source code
+*.bash            text eol=lf
+*.bat             text eol=crlf
+*.c               text eol=lf
+*.cmd             text eol=crlf
+*.cpp             text eol=lf
+*.css             text diff=css
+*.hpp             text eol=lf
+*.htm             text diff=html
+*.html            text diff=html
+*.inc             text
+*.ini             text
+*.js              text eol=lf
+*.json            text eol=lf
+*.jsx             text eol=lf
+*.less            text
+*.ls              text
+*.map             text -diff
+*.ps1             text eol=crlf
+*.py              text diff=python
+*.sh              text eol=lf
+*.ts              text eol=lf
+*.tsx             text eol=lf
+*.xml             text eol=lf
+*.xhtml           text diff=html
+
+# Templates
+*.em              text eol=lf
+
+# Docker
+Dockerfile        text
+
+# Documentation
+*.ipynb           text
+*.markdown        text diff=markdown
+*.md              text diff=markdown
+*.mdwn            text diff=markdown
+*.mdown           text diff=markdown
+*.mkd             text diff=markdown
+*.mkdn            text diff=markdown
+*.mdtxt           text
+*.mdtext          text
+*.txt             text
+AUTHORS           text
+CHANGELOG         text
+CHANGES           text
+CONTRIBUTING      text
+COPYING           text
+copyright         text
+*COPYRIGHT*       text
+license           text
+LICENSE           text
+readme            text
+*README*          text
+TODO              text
+
+# Configs
+*.cnf             text
+*.conf            text
+*.config          text
+.editorconfig     text
+.env              text
+.gitattributes    text
+.gitconfig        text
+.htaccess         text
+*.lock            text -diff
+*.gyp             text
+package.json      text eol=lf
+package-lock.json text -diff
+pnpm-lock.yaml    text eol=lf -diff
+yarn.lock         text -diff
+*.toml            text
+*.yaml            text eol=lf
+*.yml             text eol=lf
+Makefile          text
+makefile          text
+
+# Graphics
+*.bmp             binary
+*.gif             binary
+*.ico             binary
+*.jng             binary
+*.jp2             binary
+*.jpg             binary
+*.jpeg            binary
+*.jpx             binary
+*.jxr             binary
+*.pdf             binary
+*.png             binary
+# SVG treated as an asset (binary) by default.
+*.svg             text
+# If you want to treat it as binary,
+# use the following line instead.
+# *.svg           binary
+*.svgz            binary
+*.tif             binary
+*.tiff            binary
+*.wbmp            binary
+*.webp            binary
+
+# Executables
+*.exe             binary
+*.pyc             binary
+
+# RC files (like .babelrc or .eslintrc)
+*.*rc             text
+
+# Ignore files (like .npmignore or .gitignore)
+*.*ignore         text


### PR DESCRIPTION
Presently when a developer pulls code on windows his editor may show a zillion prettier errors due to the Windows default EOL does not match the default prettier EOL of LF. By adding a .gitattributes we can enforce the EOL to be LF (compatible with prettier) on all platforms by default.

This .gitattributes file is based on this [example](https://github.com/alexkaratarakis/gitattributes/blob/master/Web.gitattributes). I added some additional EOL config for *.[json|yaml|cpp|hpp] and a few others.  Please review and propose any changes you feel better suit the project and developer experience.