### PR TITLE
Improved jsdoc for Node ros graph methods, eg. getServiceNamesAndTypes()

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -918,7 +918,7 @@ class Node extends rclnodejs.ShadowNode {
    * @param {string} nodeName - The name of the node.
    * @param {string} namespace - The name of the namespace.
    * @param {boolean} noDemangle - If true topic names and types returned will not be demangled, default: false.
-   * @return {array} - An array of the names and types.
+   * @return {Array<{name: string, types: Array<string>}>} - An array of the names and types.
    */
   getPublisherNamesAndTypesByNode(nodeName, namespace, noDemangle = false) {
     return rclnodejs.getPublisherNamesAndTypesByNode(
@@ -934,7 +934,7 @@ class Node extends rclnodejs.ShadowNode {
    * @param {string} nodeName - The name of the node.
    * @param {string} namespace - The name of the namespace.
    * @param {boolean} noDemangle - If true topic names and types returned will not be demangled, default: false.
-   * @return {array} - An array of the names and types.
+   * @return {Array<{name: string, types: Array<string>}>} - An array of the names and types.
    */
   getSubscriptionNamesAndTypesByNode(nodeName, namespace, noDemangle = false) {
     return rclnodejs.getSubscriptionNamesAndTypesByNode(
@@ -949,7 +949,7 @@ class Node extends rclnodejs.ShadowNode {
    * Get the list of service topics discovered by the provided node for the remote node name.
    * @param {string} nodeName - The name of the node.
    * @param {string} namespace - The name of the namespace.
-   * @return {array} - An array of the names and types.
+   * @return {Array<{name: string, types: Array<string>}>} - An array of the names and types.
    */
   getServiceNamesAndTypesByNode(nodeName, namespace) {
     return rclnodejs.getServiceNamesAndTypesByNode(
@@ -962,7 +962,7 @@ class Node extends rclnodejs.ShadowNode {
   /**
    * Get the list of topics discovered by the provided node.
    * @param {boolean} noDemangle - If true topic names and types returned will not be demangled, default: false.
-   * @return {array} - An array of the names and types.
+   * @return {Array<{name: string, types: Array<string>}>} - An array of the names and types.
    */
   getTopicNamesAndTypes(noDemangle = false) {
     return rclnodejs.getTopicNamesAndTypes(this.handle, noDemangle);
@@ -970,7 +970,7 @@ class Node extends rclnodejs.ShadowNode {
 
   /**
    * Get the list of services discovered by the provided node.
-   * @return {array} - An array of the names and types.
+   * @return {Array<{name: string, types: Array<string>}>} - An array of the names and types.
    */
   getServiceNamesAndTypes() {
     return rclnodejs.getServiceNamesAndTypes(this.handle);
@@ -978,7 +978,7 @@ class Node extends rclnodejs.ShadowNode {
 
   /**
    * Get the list of nodes discovered by the provided node.
-   * @return {array} - An array of the names.
+   * @return {Array<string>} - An array of the names.
    */
   getNodeNames() {
     return this.getNodeNamesAndNamespaces().map((item) => item.name);
@@ -986,7 +986,7 @@ class Node extends rclnodejs.ShadowNode {
 
   /**
    * Get the list of nodes and their namespaces discovered by the provided node.
-   * @return {array} - An array of the names and namespaces.
+   * @return {Array<{name: string, namespace: string}>} An array of the names and namespaces.
    */
   getNodeNamesAndNamespaces() {
     return rclnodejs.getNodeNames(this.handle);
@@ -1028,7 +1028,7 @@ class Node extends rclnodejs.ShadowNode {
    * Get the list of parameter-overrides found on the commandline and
    * in the NodeOptions.parameter_overrides property.
    *
-   * @return {array} - An array of Parameters
+   * @return {Array<Parameter>} - An array of Parameters.
    */
   getParameterOverrides() {
     return Array.from(this._parameterOverrides.values());
@@ -1242,7 +1242,7 @@ class Node extends rclnodejs.ShadowNode {
   /**
    * Get the names of all declared parameters.
    *
-   * @return {string[]} - The declared parameter names or empty array if
+   * @return {Array<string>} - The declared parameter names or empty array if
    *    no parameters have been declared.
    */
   getParameterNames() {


### PR DESCRIPTION
This is a documentation-only change.
Updated jsdoc @return type definitions for the Node api for accessing ROS graph info such as: `getNodeNamesAndNamespaces()`, `getServiceNamesAndTypesByNode()`, ...

