### PR TITLE
add new example: ros-graph-example

### DIFF
--- a/example/ros-graph-example.js
+++ b/example/ros-graph-example.js
@@ -1,0 +1,126 @@
+// foo
+
+// Copyright (c) 2021 Wayne Parrott, All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const rclnodejs = require('../index.js');
+
+console.log(
+  'This example creates the following nodes and outputs the corresponding ROS2 graph:'
+);
+console.log('  publisher_node');
+console.log('  subscriber_node');
+console.log('  service_node');
+console.log('  ros_graph_display_node');
+
+rclnodejs
+  .init()
+  .then(() => {
+    const ns = 'ns1';
+
+    let publisherNode = new rclnodejs.Node('publisher_node', ns);
+    publisherNode.createPublisher('std_msgs/msg/String', 'topic');
+
+    let subscriberNode = new rclnodejs.Node('subscriber_node', ns);
+    subscriberNode.createSubscription('std_msgs/msg/String', 'topic', () => {});
+
+    let serviceNode = new rclnodejs.Node('service_node', ns);
+    serviceNode.createService(
+      'example_interfaces/srv/AddTwoInts',
+      'add_two_ints',
+      (request, response) => {
+        let result = response.template;
+        result.sum = request.a + request.b;
+        response.send(result);
+      }
+    );
+
+    let node = rclnodejs.createNode('ros_graph_display_node', ns);
+    let nodeNamesAndNameSpaces = node.getNodeNamesAndNamespaces();
+
+    console.log('NODES');
+    console.log(node.getNodeNames());
+    console.log(nodeNamesAndNameSpaces);
+
+    console.log('TOPICS & TYPES');
+    console.log(node.getTopicNamesAndTypes());
+
+    console.log('SERVICES & TYPES');
+    console.log(node.getServiceNamesAndTypes());
+
+    console.log('PUBLISHERS BY NODE');
+    console.log(
+      JSON.stringify(
+        nodeNamesAndNameSpaces.map((nameNs) => {
+          return {
+            node: {
+              name: nameNs.name,
+              namespace: nameNs.namespace,
+            },
+            info: node.getPublisherNamesAndTypesByNode(
+              nameNs.name,
+              nameNs.namespace
+            ),
+          };
+        }),
+        undefined,
+        '  '
+      )
+    );
+
+    console.log('SUBSCRIPTIONS BY NODE');
+    console.log(
+      JSON.stringify(
+        nodeNamesAndNameSpaces.map((nameNs) => {
+          return {
+            node: {
+              name: nameNs.name,
+              namespace: nameNs.namespace,
+            },
+            info: node.getSubscriptionNamesAndTypesByNode(
+              nameNs.name,
+              nameNs.namespace
+            ),
+          };
+        }),
+        undefined,
+        '  '
+      )
+    );
+
+    console.log('SERVICES BY NODE');
+    console.log(
+      JSON.stringify(
+        nodeNamesAndNameSpaces.map((nameNs) => {
+          return {
+            node: {
+              name: nameNs.name,
+              namespace: nameNs.namespace,
+            },
+            info: node.getServiceNamesAndTypesByNode(
+              nameNs.name,
+              nameNs.namespace
+            ),
+          };
+        }),
+        undefined,
+        '  '
+      )
+    );
+  })
+  .catch((e) => {
+    console.log(`Error: ${e}`);
+  });

--- a/example/ros-graph-example.js
+++ b/example/ros-graph-example.js
@@ -1,5 +1,3 @@
-// foo
-
 // Copyright (c) 2021 Wayne Parrott, All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/node.js
+++ b/lib/node.js
@@ -918,7 +918,7 @@ class Node extends rclnodejs.ShadowNode {
    * @param {string} nodeName - The name of the node.
    * @param {string} namespace - The name of the namespace.
    * @param {boolean} noDemangle - If true topic names and types returned will not be demangled, default: false.
-   * @return {array} - An array of the names and types.
+   * @return {Array<{name: string, types: Array<string>}>} - An array of the names and types.
    */
   getPublisherNamesAndTypesByNode(nodeName, namespace, noDemangle = false) {
     return rclnodejs.getPublisherNamesAndTypesByNode(
@@ -934,7 +934,7 @@ class Node extends rclnodejs.ShadowNode {
    * @param {string} nodeName - The name of the node.
    * @param {string} namespace - The name of the namespace.
    * @param {boolean} noDemangle - If true topic names and types returned will not be demangled, default: false.
-   * @return {array} - An array of the names and types.
+   * @return {Array<{name: string, types: Array<string>}>} - An array of the names and types.
    */
   getSubscriptionNamesAndTypesByNode(nodeName, namespace, noDemangle = false) {
     return rclnodejs.getSubscriptionNamesAndTypesByNode(
@@ -949,7 +949,7 @@ class Node extends rclnodejs.ShadowNode {
    * Get the list of service topics discovered by the provided node for the remote node name.
    * @param {string} nodeName - The name of the node.
    * @param {string} namespace - The name of the namespace.
-   * @return {array} - An array of the names and types.
+   * @return {Array<{name: string, types: Array<string>}>} - An array of the names and types.
    */
   getServiceNamesAndTypesByNode(nodeName, namespace) {
     return rclnodejs.getServiceNamesAndTypesByNode(
@@ -962,7 +962,7 @@ class Node extends rclnodejs.ShadowNode {
   /**
    * Get the list of topics discovered by the provided node.
    * @param {boolean} noDemangle - If true topic names and types returned will not be demangled, default: false.
-   * @return {array} - An array of the names and types.
+   * @return {Array<{name: string, types: Array<string>}>} - An array of the names and types.
    */
   getTopicNamesAndTypes(noDemangle = false) {
     return rclnodejs.getTopicNamesAndTypes(this.handle, noDemangle);
@@ -970,7 +970,7 @@ class Node extends rclnodejs.ShadowNode {
 
   /**
    * Get the list of services discovered by the provided node.
-   * @return {array} - An array of the names and types.
+   * @return {Array<{name: string, types: Array<string>}>} - An array of the names and types.
    */
   getServiceNamesAndTypes() {
     return rclnodejs.getServiceNamesAndTypes(this.handle);
@@ -978,7 +978,7 @@ class Node extends rclnodejs.ShadowNode {
 
   /**
    * Get the list of nodes discovered by the provided node.
-   * @return {array} - An array of the names.
+   * @return {Array<string>} - An array of the names.
    */
   getNodeNames() {
     return this.getNodeNamesAndNamespaces().map((item) => item.name);
@@ -986,7 +986,7 @@ class Node extends rclnodejs.ShadowNode {
 
   /**
    * Get the list of nodes and their namespaces discovered by the provided node.
-   * @return {array} - An array of the names and namespaces.
+   * @return {Array<{name: string, namespace: string}>} An array of the names and namespaces.
    */
   getNodeNamesAndNamespaces() {
     return rclnodejs.getNodeNames(this.handle);
@@ -1028,7 +1028,7 @@ class Node extends rclnodejs.ShadowNode {
    * Get the list of parameter-overrides found on the commandline and
    * in the NodeOptions.parameter_overrides property.
    *
-   * @return {array} - An array of Parameters
+   * @return {Array<Parameter>} - An array of Parameters.
    */
   getParameterOverrides() {
     return Array.from(this._parameterOverrides.values());
@@ -1242,7 +1242,7 @@ class Node extends rclnodejs.ShadowNode {
   /**
    * Get the names of all declared parameters.
    *
-   * @return {string[]} - The declared parameter names or empty array if
+   * @return {Array<string>} - The declared parameter names or empty array if
    *    no parameters have been declared.
    */
   getParameterNames() {


### PR DESCRIPTION
The ros-graph-example.js demonstrates use of the Node api for accessing ROS2 graph info. When executed the example creates 4 nodes: a publisher node, a subscription node, a service node and a ros-info node that outputs detail of the other 3 nodes to stdout.