### PR TITLE
Hide npm warnings during installation; set loglevel='error'

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+loglevel = "error"


### PR DESCRIPTION
This is a subjective PR that gives priority to the installation UX by hiding informative npm warnings that are useful for developers contributing to the rclnodejs project.

Fix #805