### PR TITLE
Fixes action ClientGoalHandler getResult() and status update bug, #813

### DIFF
--- a/example/action-client-example.js
+++ b/example/action-client-example.js
@@ -42,7 +42,7 @@ class FibonacciActionClient {
       this.feedbackCallback(feedback)
     );
 
-    if (!goalHandle.accepted) {
+    if (!goalHandle.isAccepted()) {
       this._node.getLogger().info('Goal rejected');
       return;
     }
@@ -50,12 +50,11 @@ class FibonacciActionClient {
     this._node.getLogger().info('Goal accepted');
 
     const result = await goalHandle.getResult();
-    const status = result.status;
 
-    if (status === GoalStatus.STATUS_SUCCEEDED) {
+    if (goalHandle.isSucceeded()) {
       this._node
         .getLogger()
-        .info(`Goal suceeded with result: ${result.result.sequence}`);
+        .info(`Goal suceeded with result: ${result.sequence}`);
     } else {
       this._node.getLogger().info(`Goal failed with status: ${status}`);
     }
@@ -63,10 +62,8 @@ class FibonacciActionClient {
     rclnodejs.shutdown();
   }
 
-  feedbackCallback(feedbackMessage) {
-    this._node
-      .getLogger()
-      .info(`Received feedback: ${feedbackMessage.feedback.sequence}`);
+  feedbackCallback(feedback) {
+    this._node.getLogger().info(`Received feedback: ${feedback.sequence}`);
   }
 }
 

--- a/lib/action/client.js
+++ b/lib/action/client.js
@@ -153,7 +153,7 @@ class ActionClient extends Entity {
     let uuid = ActionUuid.fromBytes(message.goal_id.uuid).toString();
     if (this._feedbackCallbacks.has(uuid)) {
       this._feedbackCallbacks.get(uuid)(
-        message.toPlainObject(this.typedArrayEnabled)
+        message.toPlainObject(this.typedArrayEnabled).feedback
       );
     }
   }
@@ -166,10 +166,10 @@ class ActionClient extends Entity {
       ).toString();
       let status = statusMessage.status;
 
-      if (!this._goalHandles.has(uuid)) {
+      if (this._goalHandles.has(uuid)) {
         let goalHandle = this._goalHandles.get(uuid);
         if (goalHandle) {
-          goalHandle._status = status;
+          goalHandle.status = status;
 
           // Remove done handles from the list
           // eslint-disable-next-line max-depth
@@ -332,11 +332,15 @@ class ActionClient extends Entity {
     }
 
     let deferred = new Deferred();
-    this._pendingResultRequests.set(sequenceNumber, deferred);
-
+    deferred.beforeSetResultCallback((result) => {
+      goalHandle.status = result.status;
+      return result.result;
+    });
     deferred.setDoneCallback(() =>
       this._removePendingResultRequest(sequenceNumber)
     );
+
+    this._pendingResultRequests.set(sequenceNumber, deferred);
 
     return deferred.promise;
   }

--- a/lib/action/client_goal_handle.js
+++ b/lib/action/client_goal_handle.js
@@ -26,7 +26,9 @@ class ClientGoalHandle {
     this._actionClient = actionClient;
     this._goalId = goalId;
     this._goalResponse = goalResponse;
-    this._status = ActionInterfaces.GoalStatus.STATUS_UNKNOWN;
+    this._status = this.accepted
+      ? ActionInterfaces.GoalStatus.STATUS_ACCEPTED
+      : ActionInterfaces.GoalStatus.STATUS_UNKNOWN;
   }
 
   /**
@@ -45,9 +47,58 @@ class ClientGoalHandle {
 
   /**
    * Gets if the goal response was accepted.
+   * @deprecated use isAccepted()
    */
   get accepted() {
+    return this.isAccepted();
+  }
+
+  /**
+   * Determine if goal is currently executing
+   * @returns {bool} - True if goal is executing; otherwise return false.
+   */
+  isAccepted() {
     return this._goalResponse.accepted;
+  }
+
+  /**
+   * Determine if goal is currently executing
+   * @returns {bool} - True if goal is executing; otherwise return false.
+   */
+  isExecuting() {
+    return this.status === ActionInterfaces.GoalStatus.STATUS_EXECUTING;
+  }
+
+  /**
+   * Determine if goal is in the process of canceling.
+   * @returns {bool} - True if goal is canceling; otherwise return false.
+   */
+  isCanceling() {
+    return this.status === ActionInterfaces.GoalStatus.STATUS_CANCELING;
+  }
+
+  /**
+   * Determine if goal completed successfullly.
+   * @returns {bool} - True if goal completed successfully; otherwise return false.
+   */
+  isSucceeded() {
+    return this.status === ActionInterfaces.GoalStatus.STATUS_SUCCEEDED;
+  }
+
+  /**
+   * Determine if goal has been canceled.
+   * @returns {bool} - True if goal has been aborted; otherwise return false.
+   */
+  isCanceled() {
+    return this.status === ActionInterfaces.GoalStatus.STATUS_CANCELED;
+  }
+
+  /**
+   * Determine if goal has been aborted.
+   * @returns {bool} - True if goal was aborted; otherwise return false.
+   */
+  isAborted() {
+    return this.status === ActionInterfaces.GoalStatus.STATUS_ABORTED;
   }
 
   /**
@@ -55,6 +106,21 @@ class ClientGoalHandle {
    */
   get status() {
     return this._status;
+  }
+
+  /**
+   * Update status to the latest state of goal computation.
+   * When status is in a final state it can not be revered to an
+   * earlier state, e.g., can not change from SUCCEEDED to ACCEPTED.
+   * @param {number} newStatus - The new status of this goal.
+   */
+  set status(newStatus) {
+    if (
+      this._status < ActionInterfaces.GoalStatus.STATUS_SUCCEEDED &&
+      newStatus > this._status
+    ) {
+      this._status = newStatus;
+    }
   }
 
   /**

--- a/lib/action/deferred.js
+++ b/lib/action/deferred.js
@@ -36,14 +36,29 @@ class Deferred {
   }
 
   /**
+   * Sets a function to be called before result updated
+   * @param {function} callback - Function to be called.
+   * @returns {undefined}
+   */
+  beforeSetResultCallback(callback) {
+    if (typeof callback !== 'function') {
+      throw new TypeError('Invalid parameter');
+    }
+
+    this._beforeSetResultCallback = callback;
+  }
+
+  /**
    * Resolves the deferred promise.
    * @param {*} result - The value to resolve the promise with.
    * @returns {undefined}
    */
   setResult(result) {
     if (this._resolve) {
-      this._result = result;
-      this._resolve(result);
+      this._result = this._beforeSetResultCallback
+        ? this._beforeSetResultCallback(result)
+        : result;
+      this._resolve(this._result);
       this._resolve = null;
     }
   }

--- a/lib/action/interfaces.js
+++ b/lib/action/interfaces.js
@@ -32,9 +32,8 @@ class ActionInterfaces {
    */
   static get CancelGoal() {
     if (!ActionInterfaces._cancelGoalInterface) {
-      ActionInterfaces._cancelGoalInterface = loader.loadInterface(
-        CANCEL_GOAL_SERVICE
-      );
+      ActionInterfaces._cancelGoalInterface =
+        loader.loadInterface(CANCEL_GOAL_SERVICE);
     }
 
     return ActionInterfaces._cancelGoalInterface;
@@ -45,9 +44,8 @@ class ActionInterfaces {
    */
   static get GoalInfo() {
     if (!ActionInterfaces._goalInfoInterface) {
-      ActionInterfaces._goalInfoInterface = loader.loadInterface(
-        GOAL_INFO_MESSAGE
-      );
+      ActionInterfaces._goalInfoInterface =
+        loader.loadInterface(GOAL_INFO_MESSAGE);
     }
 
     return ActionInterfaces._goalInfoInterface;
@@ -58,9 +56,8 @@ class ActionInterfaces {
    */
   static get GoalStatus() {
     if (!ActionInterfaces._goalStatusInterface) {
-      ActionInterfaces._goalStatusInterface = loader.loadInterface(
-        GOAL_STATUS_MESSAGE
-      );
+      ActionInterfaces._goalStatusInterface =
+        loader.loadInterface(GOAL_STATUS_MESSAGE);
     }
 
     return ActionInterfaces._goalStatusInterface;

--- a/lib/action/interfaces.js
+++ b/lib/action/interfaces.js
@@ -32,7 +32,9 @@ class ActionInterfaces {
    */
   static get CancelGoal() {
     if (!ActionInterfaces._cancelGoalInterface) {
-      ActionInterfaces._cancelGoalInterface = loader.loadInterface(CANCEL_GOAL_SERVICE);
+      ActionInterfaces._cancelGoalInterface = loader.loadInterface(
+        CANCEL_GOAL_SERVICE
+      );
     }
 
     return ActionInterfaces._cancelGoalInterface;
@@ -43,7 +45,9 @@ class ActionInterfaces {
    */
   static get GoalInfo() {
     if (!ActionInterfaces._goalInfoInterface) {
-      ActionInterfaces._goalInfoInterface = loader.loadInterface(GOAL_INFO_MESSAGE);
+      ActionInterfaces._goalInfoInterface = loader.loadInterface(
+        GOAL_INFO_MESSAGE
+      );
     }
 
     return ActionInterfaces._goalInfoInterface;
@@ -54,7 +58,9 @@ class ActionInterfaces {
    */
   static get GoalStatus() {
     if (!ActionInterfaces._goalStatusInterface) {
-      ActionInterfaces._goalStatusInterface = loader.loadInterface(GOAL_STATUS_MESSAGE);
+      ActionInterfaces._goalStatusInterface = loader.loadInterface(
+        GOAL_STATUS_MESSAGE
+      );
     }
 
     return ActionInterfaces._goalStatusInterface;

--- a/lib/action/interfaces.js
+++ b/lib/action/interfaces.js
@@ -32,8 +32,7 @@ class ActionInterfaces {
    */
   static get CancelGoal() {
     if (!ActionInterfaces._cancelGoalInterface) {
-      ActionInterfaces._cancelGoalInterface =
-        loader.loadInterface(CANCEL_GOAL_SERVICE);
+      ActionInterfaces._cancelGoalInterface = loader.loadInterface(CANCEL_GOAL_SERVICE);
     }
 
     return ActionInterfaces._cancelGoalInterface;
@@ -44,8 +43,7 @@ class ActionInterfaces {
    */
   static get GoalInfo() {
     if (!ActionInterfaces._goalInfoInterface) {
-      ActionInterfaces._goalInfoInterface =
-        loader.loadInterface(GOAL_INFO_MESSAGE);
+      ActionInterfaces._goalInfoInterface = loader.loadInterface(GOAL_INFO_MESSAGE);
     }
 
     return ActionInterfaces._goalInfoInterface;
@@ -56,8 +54,7 @@ class ActionInterfaces {
    */
   static get GoalStatus() {
     if (!ActionInterfaces._goalStatusInterface) {
-      ActionInterfaces._goalStatusInterface =
-        loader.loadInterface(GOAL_STATUS_MESSAGE);
+      ActionInterfaces._goalStatusInterface = loader.loadInterface(GOAL_STATUS_MESSAGE);
     }
 
     return ActionInterfaces._goalStatusInterface;

--- a/test/test-action-client.js
+++ b/test/test-action-client.js
@@ -165,7 +165,7 @@ describe('rclnodejs action client', function () {
     assert.ok(result);
 
     let goalHandle = await client.sendGoal(new Fibonacci.Goal());
-    assert.ok(goalHandle.accepted);
+    assert.ok(goalHandle.isAccepted());
 
     result = await goalHandle.getResult();
     assert.ok(result);
@@ -192,9 +192,10 @@ describe('rclnodejs action client', function () {
       feedbackCallback,
       goalUuid
     );
-    assert.ok(goalHandle.accepted);
+    assert.ok(goalHandle.isAccepted());
 
     await goalHandle.getResult();
+    assert.ok(goalHandle.isSucceeded());
     assert.ok(result);
 
     assert.ok(feedbackCallback.calledOnce);
@@ -285,7 +286,7 @@ describe('rclnodejs action client', function () {
     assert.ok(result);
 
     let goalHandle = await client.sendGoal(new Fibonacci.Goal());
-    assert.ok(goalHandle.accepted);
+    assert.ok(goalHandle.isAccepted());
 
     result = await goalHandle.cancelGoal();
     assert.ok(result);

--- a/test/test-action-server.js
+++ b/test/test-action-server.js
@@ -411,7 +411,7 @@ describe('rclnodejs action server', function () {
     serverGoalHandle.execute();
 
     result = await handle.getResult();
-    assert.strictEqual(result.status, GoalStatus.STATUS_CANCELED);
+    assert.strictEqual(handle.status, GoalStatus.STATUS_CANCELED);
     assert.strictEqual(serverGoalHandle.status, GoalStatus.STATUS_CANCELED);
 
     server.destroy();
@@ -445,8 +445,8 @@ describe('rclnodejs action server', function () {
 
     let result = await handle.getResult();
     assert.ok(result);
-    assert.ok(result.status, GoalStatus.STATUS_SUCCEEDED);
-    assert.ok(deepEqual(result.result.sequence, testSequence));
+    assert.ok(handle.status, GoalStatus.STATUS_SUCCEEDED);
+    assert.ok(deepEqual(result.sequence, testSequence));
 
     server.destroy();
   });
@@ -479,8 +479,8 @@ describe('rclnodejs action server', function () {
 
     let result = await handle.getResult();
     assert.ok(result);
-    assert.ok(result.status, GoalStatus.STATUS_ABORTED);
-    assert.ok(deepEqual(result.result.sequence, testSequence));
+    assert.ok(handle.status, GoalStatus.STATUS_ABORTED);
+    assert.ok(deepEqual(result.sequence, testSequence));
 
     server.destroy();
   });
@@ -514,8 +514,8 @@ describe('rclnodejs action server', function () {
     let result = await handle.getResult();
     assert.ok(result);
     // Goal status should default to aborted
-    assert.ok(result.status, GoalStatus.STATUS_ABORTED);
-    assert.ok(deepEqual(result.result.sequence, testSequence));
+    assert.ok(handle.status, GoalStatus.STATUS_ABORTED);
+    assert.ok(deepEqual(result.sequence, testSequence));
 
     server.destroy();
   });
@@ -542,8 +542,8 @@ describe('rclnodejs action server', function () {
     let result = await handle.getResult();
     assert.ok(result);
     // Goal status should default to aborted
-    assert.ok(result.status, GoalStatus.STATUS_ABORTED);
-    assert.ok(deepEqual(result.result.sequence, []));
+    assert.ok(handle.status, GoalStatus.STATUS_ABORTED);
+    assert.ok(deepEqual(result.sequence, []));
 
     server.destroy();
   });
@@ -660,7 +660,7 @@ describe('rclnodejs action server', function () {
     await assertUtils.createDelay(50);
 
     assert.ok(feedbackMessage);
-    assert.ok(deepEqual(sequence, feedbackMessage.feedback.sequence));
+    assert.ok(deepEqual(sequence, feedbackMessage.sequence));
 
     server.destroy();
   });
@@ -704,7 +704,7 @@ describe('rclnodejs action server', function () {
     await assertUtils.createDelay(50);
 
     assert.ok(feedbackMessage);
-    assert.ok(deepEqual(sequence, feedbackMessage.feedback.sequence));
+    assert.ok(deepEqual(sequence, feedbackMessage.sequence));
 
     server.destroy();
   });

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -462,7 +462,7 @@ const goalHandlePromise = actionClient.sendGoal(new Fibonacci.Goal());
 
 goalHandlePromise.then((goalHandle) => {
   // $ExpectType boolean
-  goalHandle.accepted;
+  goalHandle.accepted; // deprecated
 
   // $ExpectType UUID
   goalHandle.goalId;
@@ -470,7 +470,7 @@ goalHandlePromise.then((goalHandle) => {
   // $ExpectType Time
   goalHandle.stamp;
 
-  // $ExpectType string
+  // $ExpectType number
   goalHandle.status;
 
   // $ExpectType Promise<CancelGoal_Response>
@@ -478,6 +478,24 @@ goalHandlePromise.then((goalHandle) => {
 
   // $ExpectType Promise<Fibonacci_Result>
   goalHandle.getResult();
+
+  // $ExpectType boolean
+  goalHandle.isAccepted();
+
+  // $ExpectType boolean
+  goalHandle.isExecuting();
+
+  // $ExpectType boolean
+  goalHandle.isSucceeded();
+
+  // $ExpectType boolean
+  goalHandle.isCanceling();
+
+  // $ExpectType boolean
+  goalHandle.isCanceled();
+
+  // $ExpectType boolean
+  goalHandle.isAborted();
 });
 
 // ---- ActionServer -----

--- a/types/action_client.d.ts
+++ b/types/action_client.d.ts
@@ -26,13 +26,50 @@ declare module 'rclnodejs' {
 
     /**
      * Gets if the goal response was accepted.
+     * @deprecated Use isAccepted()
      */
     get accepted(): boolean;
 
     /**
+     * Determine if goal is currently executing
+     * @returns {bool} - True if goal is executing; otherwise return false.
+     */
+    isAccepted(): boolean;
+
+    /**
+     * Determine if goal is currently executing
+     * @returns {bool} - True if goal is executing; otherwise return false.
+     */
+    isExecuting(): boolean;
+
+    /**
+     * Determine if goal is in the process of canceling.
+     * @returns True if goal is canceling; otherwise return false.
+     */
+    isCanceling(): boolean;
+
+    /**
+     * Determine if goal completed successfullly.
+     * @returns True if goal completed successfully; otherwise return false.
+     */
+    isSucceeded(): boolean;
+
+    /**
+     * Determine if goal has been canceled.
+     * @returns True if goal has been aborted; otherwise return false.
+     */
+    isCanceled(): boolean;
+
+    /**
+     * Determine if goal has been aborted.
+     * @returns True if goal was aborted; otherwise return false.
+     */
+    isAborted(): boolean;
+
+    /**
      * Gets the goal status.
      */
-    get status(): string;
+    get status(): number;
 
     /**
      * Send a cancel request for the goal.


### PR DESCRIPTION
**Public API Changes**
ClientGoalHandler (client_goal_handler.js, action_client.d.ts)
1. deprecated `accepting` getter
2. added convenience methods: `isAccepting()`, `isExecuting()`, `isCanceling()`, `isSucceeded()`, `isCanceled()`, `isAborted()`. *These methods are not essential. Thus will leave it to the reviewer's discretion of whether they stay or go. The same for #1 above.*
3. `status` property is now properly updated with the goal lifecycle state codes, see ActionInterfaces.GoalStatus for codes
3. `getResult()` now returns a ActionResult<T>. Previously it returned an internal message with structure `{status: number, result: ActionResult<T>}`.
4. `ClientGoalHandle` feedback function now only receives a `ActionFeedback<T>` argument. Previously `ActionFallback<T> function was receiving an internal msg with structure `{goal_id: UUID,  feedback: ActionFeedback<T>}`.

**Description**
A bug was submitted where `ClientGoalHandler.getResult()` was returning an internal message that did not conform to the TypeScript declarations. Additionally the `ClientGoalHandler.status` was never being updated and always return UNKNOWN. Lastly while fixing the `getResult()` bug it was discovered that the feedbackCallback function was being sent an internal message and not the expected `ActionFeedback<T>` type. This fix resolves all 3 issues.

I added `beforeSetResult(result)` method to Deferred.js class. This is used by the ActionClient _getResult(resultMsg) method to update the `ClientGoalHandler.status` and to return only the `msg.result` property of type `ActionResult<t>`. 

Updated all action related tests and examples.

Fixed several prettier/lint issues.

Fix #813 