### PR TITLE
Supports subdirectories in msg folder

### DIFF
--- a/rosidl_gen/packages.js
+++ b/rosidl_gen/packages.js
@@ -50,12 +50,21 @@ function getSubFolder(filePath, amentExecuted) {
     filePath = filePath.replace(/\\/g, '/');
   }
 
+  const subFolder = filePath.match(/\w+\/share\/\w+\/(\w+)\//)[1];
+  const ext = path.parse(filePath).ext.substr(1);
+
   if (amentExecuted) {
-    return filePath.match(/\w+\/share\/\w+\/(\w+)\//)[1];
+    // If the .msg file is in a subdirectory of msg/,
+    // the |subFolder| will neither msg/srv/action
+    // so the file extension should be used instead.
+    if (!['msg', 'srv', 'action'].includes(subFolder)) {
+      return ext;
+    }
+    return subFolder;
   }
   // If the |amentExecuted| equals to false, the file's extension will be assigned as
   // the name of sub folder.
-  return path.parse(filePath).ext.substr(1);
+  return ext;
 }
 
 function grabInterfaceInfo(filePath, amentExecuted) {


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None


**Description**

Fixed the `generate-ros-messages` command not working properly if the msg file is in a subdirectory inside the msg directory.

For example, consider the following simple ROS2 package. 
```
tutorial_interfaces/
|-- CMakeLists.txt
|-- msg
|   |-- Foo.msg
|   `-- bar
|       `-- Bar.msg
`-- package.xml
```
This is the example package used in the [ros2 tutorial](https://docs.ros.org/en/rolling/Tutorials/Custom-ROS2-Interfaces.html), but has two message definitions, one is in the subdirectory `bar`.

After the `npx generate-ros-messages` is executed for this package,
```
|-- tutorial_interfaces__bar__Bar.js
`-- tutorial_interfaces__msg__Foo.js
```
which comes from these msg files after build
```
/workspace/ros/install/tutorial_interfaces/share/tutorial_interfaces/msg/Foo.msg
/workspace/ros/install/tutorial_interfaces/share/tutorial_interfaces/bar/Bar.msg
```
are generated under `generated/` folder. The first one should be `tutorial_interfaces__msg__Bar.js`, but is named incorrectly, so the message `Bar` cannot be used in publisher or listener.

So I changed `rosidl_gen/packages.js` so that it works even if some messages are in subdirectories.
Caveats: This modification does not work for services in subdirectories and only supports messages in subdirectories. 

<!-- Describe what has changed, and motivation behind those changes -->


<!-- Link relevant GitHub issues -->
Related issues
https://github.com/RobotWebTools/ros2-web-bridge/issues/175
https://github.com/ros2/rosidl/issues/213