### PR TITLE
Use @rclnodejs/ref* deps, fix test, update docs, bump v0.21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ rclnodejs.init().then(() => {
 
 Before installing `rclnodejs` please ensure the following software is installed and configured on your system:
 
-- [Nodejs](https://nodejs.org/en/) version between 10.23.1 - 12.x.
+- [Nodejs](https://nodejs.org/en/) version between 10.23.1 - 16.x.
 
 - [ROS 2 SDK](https://index.ros.org/doc/ros2/Installation/) for details.
   **DON'T FORGET TO [SOURCE THE ROS 2 SETUP FILE](https://index.ros.org/doc/ros2/Tutorials/Configuring-ROS2-Environment/#source-the-setup-files)**
@@ -63,7 +63,7 @@ npm i rclnodejs@x.y.z
 
 |                                                            RCLNODEJS Version                                                            |                                                                                                                       Compatible ROS 2 Release                                                                                                                        |
 | :-------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-| [0.20.0 (current)](https://www.npmjs.com/package/rclnodejs/v/0.20.0) ([API](http://robotwebtools.org/rclnodejs/docs/0.20.0/index.html)) | [Galactic Geochelone](https://github.com/ros2/ros2/releases/tag/release-galactic-20210716) / [Foxy Fitzroy](https://github.com/ros2/ros2/releases/tag/release-foxy-20201211) / [Eloquent Elusor](https://github.com/ros2/ros2/releases/tag/release-eloquent-20200124) |
+| [0.21.0 (current)](https://www.npmjs.com/package/rclnodejs/v/0.21.0) ([API](http://robotwebtools.org/rclnodejs/docs/0.21.0/index.html)) | [Galactic Geochelone](https://github.com/ros2/ros2/releases/tag/release-galactic-20210716) / [Foxy Fitzroy](https://github.com/ros2/ros2/releases/tag/release-foxy-20201211) / [Eloquent Elusor](https://github.com/ros2/ros2/releases/tag/release-eloquent-20200124) |
 |                                [0.10.3](https://github.com/RobotWebTools/rclnodejs/releases/tag/0.10.3)                                 |                                                                                   [Dashing Diademata - Patch 4](https://github.com/ros2/ros2/releases/tag/release-dashing-20191018)                                                                                   |
 
 - **Note:** to install rclnodejs from GitHub: add `"rclnodejs":"RobotWebTools/rclnodejs#<branch>"` to your `package.json` depdendency section.

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -1,4 +1,3 @@
-
 # Build rclnodejs
 
 ### Get ready for ROS 2
@@ -14,9 +13,9 @@ Alternatively, you can build ROS 2 from scratch. Please select the platform you 
 ### Install `Node.js`
 
 **Notice:**
-`rclnodejs` should only be used with node versions between 8.12 - 12.99. The lowest LTS Node.js we used to verify the unit tests is `8.12.0`. And there is a known issue installing rclnodejs with versions of node >= 13.0.
+`rclnodejs` should only be used with node versions between 8.12 - 16.x. The lowest LTS Node.js we used to verify the unit tests is `8.12.0`. And there is a known issue installing rclnodejs with versions of node >= 17.0.
 
-The `Node.js` version we selected is the LTS [`Erbium`](https://nodejs.org/download/release/latest-erbium/) (12.x). You can install it:
+The `Node.js` version we selected is the LTS [`Gallium`](https://nodejs.org/download/release/latest-gallium/) (16.x). You can install it:
 
 - Download from Node.js offical [website](https://nodejs.org/en/), and install it.
 - Use the Node Version Manager ([nvm](https://github.com/creationix/nvm)) to install it.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,2 +1,2 @@
 index.html : ../index.js ../lib/*.js ./jsdoc-template
-	jsdoc --package ../package.json ../index.js ../lib/*.js ../lib/action/*.js -t ./jsdoc-template -d .
+	npx jsdoc --package ../package.json ../index.js ../lib/*.js ../lib/action/*.js -t ./jsdoc-template -d .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rclnodejs",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "ROS2.0 JavaScript client with Node.js",
   "main": "index.js",
   "types": "types/index.d.ts",
@@ -43,11 +43,11 @@
     "clang-format": "^1.4.0",
     "commander": "^6.0.0",
     "deep-equal": "^1.1.1",
-    "dtslint": "^4.1.0",
     "eslint": "^7.5.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
     "husky": "^4.2.5",
+    "jsdoc": "^3.6.7",
     "lint-staged": "^10.2.11",
     "mocha": "^8.0.1",
     "prettier": "^2.0.5",
@@ -56,20 +56,21 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
+    "@rclnodejs/ref-array-di": "^1.2.2",
+    "@rclnodejs/ref-napi": "^4.0.0",
+    "@rclnodejs/ref-struct-di": "^1.1.1",
     "array.prototype.flat": "^1.2.4",
     "bindings": "^1.5.0",
     "compare-versions": "^3.6.0",
     "debug": "^4.1.1",
     "dot": "^1.1.3",
+    "dtslint": "^4.2.1",
     "fs-extra": "^10.0.0",
     "int64-napi": "^1.0.1",
     "is-close": "^1.3.3",
     "mkdirp": "^1.0.4",
     "mz": "^2.7.0",
     "nan": "^2.14.2",
-    "ref-array-di": "minggangw/ref-array-di#master",
-    "ref-napi": "minggangw/ref-napi#latest",
-    "ref-struct-di": "minggangw/ref-struct-di#master",
     "uuid": "^8.2.0",
     "walk": "^2.3.14"
   },
@@ -87,6 +88,6 @@
     ]
   },
   "engines": {
-    "node": ">= 10.23.1 <13.0.0"
+    "node": ">= 10.23.1 <17.0.0"
   }
 }

--- a/rosidl_gen/primitive_types.js
+++ b/rosidl_gen/primitive_types.js
@@ -14,8 +14,8 @@
 
 'use strict';
 
-const ref = require('ref-napi');
-const StructType = require('ref-struct-di')(ref);
+const ref = require('@rclnodejs/ref-napi');
+const StructType = require('@rclnodejs/ref-struct-di')(ref);
 const rclnodejs = require('bindings')('rclnodejs');
 
 /* eslint-disable camelcase */

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -219,9 +219,9 @@ function extractMemberNames(fields) {
 {{? usePlainTypedArray}}
 const rclnodejs = require('bindings')('rclnodejs');
 {{?}}
-const ref = require('ref-napi');
-const StructType = require('ref-struct-di')(ref);
-const ArrayType = require('ref-array-di')(ref);
+const ref = require('@rclnodejs/ref-napi');
+const StructType = require('@rclnodejs/ref-struct-di')(ref);
+const ArrayType = require('@rclnodejs/ref-array-di')(ref);
 const primitiveTypes = require('../../rosidl_gen/primitive_types.js');
 const deallocator = require('../../rosidl_gen/deallocator.js');
 const translator = require('../../rosidl_gen/message_translator.js');

--- a/scripts/npmjs-readme.md
+++ b/scripts/npmjs-readme.md
@@ -18,7 +18,7 @@ rclnodejs.init().then(() => {
 
 **Node.js**
 
-- [Node.js](https://nodejs.org/en/) version between 8.12 - 12.x.
+- [Node.js](https://nodejs.org/en/) version between 8.12 - 16.x.
 
 **ROS 2 SDK**
 
@@ -45,7 +45,7 @@ npm i rclnodejs@x.y.z
 
 |                                                            RCLNODEJS Version                                                            |                                                                                                                       Compatible ROS 2 Release                                                                                                                        |
 | :-------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-| [0.20.0 (current)](https://www.npmjs.com/package/rclnodejs/v/0.20.0) ([API](http://robotwebtools.org/rclnodejs/docs/0.20.0/index.html)) | [Galactic Geochelone](https://github.com/ros2/ros2/releases/tag/release-galactic-20210716) / [Foxy Fitzroy](https://github.com/ros2/ros2/releases/tag/release-foxy-20201211) / [Eloquent Elusor](https://github.com/ros2/ros2/releases/tag/release-eloquent-20200124) |
+| [0.21.0 (current)](https://www.npmjs.com/package/rclnodejs/v/0.21.0) ([API](http://robotwebtools.org/rclnodejs/docs/0.21.0/index.html)) | [Galactic Geochelone](https://github.com/ros2/ros2/releases/tag/release-galactic-20210716) / [Foxy Fitzroy](https://github.com/ros2/ros2/releases/tag/release-foxy-20201211) / [Eloquent Elusor](https://github.com/ros2/ros2/releases/tag/release-eloquent-20200124) |
 |                                [0.10.3](https://github.com/RobotWebTools/rclnodejs/releases/tag/0.10.3)                                 |                                                                                   [Dashing Diademata - Patch 4](https://github.com/ros2/ros2/releases/tag/release-dashing-20191018)                                                                                   |
 
 ## Documentation

--- a/test/test-security-related.js
+++ b/test/test-security-related.js
@@ -38,7 +38,7 @@ describe('Destroying non-existent objects testing', function () {
         node.destroy();
       },
       TypeError,
-      'Cannot read property',
+      'Cannot read propert.*',
       'Trying to destroy an empty node!'
     );
 


### PR DESCRIPTION
0. package.json
* Bumped to version 0.21.0
* Support for node 13-16 required forking and customizing the following
packages:
@rclnodejs/ref-array-di
@rclnodejs/ref-napi
@rclnodejs/ref-struct-di
Revised package dependencies to use the 3 packaged listed above
* Added jsdoc as devDependency

2. test-security-related.js
Fixed minor assertion error caused by change in Nodejs error message.

3. Docs
* Updated README.md, Build.md and npmjs-readme.md to expand valid
versions of node 13-16.
* Modified docs/Makefile to use `npx` to run jsdoc to generate api
documentation

**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->


**Description**
<!-- Describe what has changed, and motivation behind those changes -->


<!-- Link relevant GitHub issues -->
