### PR TITLE
appveyor builds occasionally fail for node 16 & 17 specifically on galactic branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: '{branch}-{build}'
 
 branches:
   only:
-    - galactic-geochelone
+    - develop
 
 image: Visual Studio 2019
 
@@ -10,11 +10,11 @@ environment:
   PYTHON3: "c:\\Python310-x64"
   PYTHON2: "c:\\Python27"
   matrix:
-    - nodejs_version: "10"
-    - nodejs_version: "12"
-    - nodejs_version: "14"
-    - nodejs_version: "16"
     - nodejs_version: "17"
+    - nodejs_version: "16"
+    - nodejs_version: "14"
+    - nodejs_version: "12"
+    - nodejs_version: "10"
 
 clone_folder: c:\proj\rclnodejs
 
@@ -33,11 +33,11 @@ before_build:
   - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2019-10-24/tinyxml2.6.0.0.nupkg
   - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2019-10-24/log4cxx.0.10.0.nupkg
   - choco install -y -s c:\download\ asio bullet cunit eigen tinyxml-usestl tinyxml2 log4cxx
-  - appveyor DownloadFile https://github.com/ros2/ros2/releases/download/release-galactic-20210716/ros2-galactic-20210616-windows-release-amd64.zip
-  - 7z x -y "c:\download\ros2-galactic-20210616-windows-release-amd64.zip" -o"c:\" > nul
+  - appveyor DownloadFile https://ci.ros2.org/view/packaging/job/packaging_windows/lastSuccessfulBuild/artifact/ws/ros2-package-windows-AMD64.zip
+  - 7z x -y "c:\download\ros2-package-windows-AMD64.zip" -o"c:\" > nul
   - setx -m OPENSSL_CONF C:\OpenSSL-v111-Win64\bin\openssl.cfg
   - set PATH=C:\OpenSSL-v111-Win64\bin;%PATH%
-  - setx AMENT_PYTHON_EXECUTABLE "c:\Python39"
+  - setx AMENT_PYTHON_EXECUTABLE "c:\Python310"
   - refreshenv
   - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;%PATH%"
   - python -m pip install -U wheel catkin_pkg cryptography empy ifcfg lark-parser lxml netifaces numpy opencv-python pyparsing pyyaml setuptools colcon-common-extensions


### PR DESCRIPTION
appveyor builds occasionally fail for node 16 & 17
I've been successfully running the appveyor build matrix over the past
36 hrs and now after merging a key PR appveyor builds are failing for
node 16 & 17 on the galactic branch. I do not observe the error below on the develop branch. A common error follows:
```
SET PATH=%PYTHON2%;%PYTHON2%\bin;%PYTHON2%\Scripts;%PATH%
node --version
v16.13.0
npm --version
8.1.0
python --version
Python 2.7.18
npm install
npm ERR! code 1
npm ERR! path C:\proj\rclnodejs\node_modules\@rclnodejs\ref-napi
npm ERR! command failed
npm ERR! command C:\Windows\system32\cmd.exe /d /s /c node-gyp rebuild
npm ERR! gyp:
C:\Users\appveyor\AppData\Local\node-gyp\Cache\16.13.0\common.gypi not
found (cwd: C:\proj\rclnodejs\node_modules\@rclnodejs\ref-napi) while
reading includes of binding.gyp while trying to load binding.gyp
npm ERR! gyp ERR! configure error
npm ERR! gyp ERR! stack Error: `gyp` failed with exit code: 1
npm ERR! gyp ERR! stack     at ChildProcess.onCpExit (C:\Program
Files\nodejs\node_modules\npm\node_modules\node-gyp\lib\configure.js:353:16)
npm ERR! gyp ERR! stack     at ChildProcess.emit (node:events:390:28)
npm ERR! gyp ERR! stack     at Process.ChildProcess._handle.onexit
(node:internal/child_process:290:12)
npm ERR! gyp ERR! System Windows_NT 10.0.17763
npm ERR! gyp ERR! command "C:\\Program Files\\nodejs\\node.exe"
"C:\\Program Files\\nodejs\\node_modules\\npm\\node_modules\\node-gyp\\bin\\node-gyp.js"
"rebuild"
npm ERR! gyp ERR! cwd C:\proj\rclnodejs\node_modules\@rclnodejs\ref-napi
npm ERR! gyp ERR! node -v v16.13.0
npm ERR! gyp ERR! node-gyp -v v8.2.0
npm ERR! gyp ERR! not ok
npm ERR! A complete log of this run can be found in:
...
```
appveyor.yml - reversed the order of node versions to be in decending
order, e.g., 17, 16, ... Doing this will speed up identifying build
failures and debug-fix iterations.
