### PR TITLE
fix: action server types

### DIFF
--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -517,9 +517,7 @@ actionServer.registerGoalCallback();
 actionServer.registerCancelCallback();
 
 // $ExpectType void
-actionServer.registerExecuteCallback(() =>
-  Promise.resolve(new Fibonacci.Result())
-);
+actionServer.registerExecuteCallback(() => new Fibonacci.Result());
 
 // $ExpectType void
 actionServer.destroy();
@@ -557,5 +555,5 @@ function executeCallback(
   // $ExpectType void
   goalHandle.succeed();
 
-  return Promise.resolve(new Fibonacci.Result());
+  return new Fibonacci.Result();
 }

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -517,7 +517,9 @@ actionServer.registerGoalCallback();
 actionServer.registerCancelCallback();
 
 // $ExpectType void
-actionServer.registerExecuteCallback(() => new Fibonacci.Result());
+actionServer.registerExecuteCallback(() =>
+  Promise.resolve(new Fibonacci.Result())
+);
 
 // $ExpectType void
 actionServer.destroy();

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -555,5 +555,5 @@ function executeCallback(
   // $ExpectType void
   goalHandle.succeed();
 
-  return new Fibonacci.Result();
+  return Promise.resolve(new Fibonacci.Result());
 }

--- a/types/action_server.d.ts
+++ b/types/action_server.d.ts
@@ -77,7 +77,7 @@ declare module 'rclnodejs' {
 
   type ExecuteCallback<T extends TypeClass<ActionTypeClassName>> = (
     goalHandle: ServerGoalHandle<T>
-  ) => Promise<ActionResult<T>>;
+  ) => Promise<ActionResult<T>> | ActionResult<T>;
   type GoalCallback<T extends TypeClass<ActionTypeClassName>> = (
     goalHandle: ServerGoalHandle<T>
   ) => GoalResponse;

--- a/types/action_server.d.ts
+++ b/types/action_server.d.ts
@@ -77,8 +77,10 @@ declare module 'rclnodejs' {
 
   type ExecuteCallback<T extends TypeClass<ActionTypeClassName>> = (
     goalHandle: ServerGoalHandle<T>
-  ) => ActionResult<T>;
-  type GoalCallback = () => GoalResponse;
+  ) => Promise<ActionResult<T>>;
+  type GoalCallback<T extends TypeClass<ActionTypeClassName>> = (
+    goalHandle: ServerGoalHandle<T>
+  ) => GoalResponse;
   type HandleAcceptedCallback<T extends TypeClass<ActionTypeClassName>> = (
     goalHandle: ServerGoalHandle<T>
   ) => void;
@@ -112,7 +114,7 @@ declare module 'rclnodejs' {
       typeClass: T,
       actionName: string,
       executeCallback: ExecuteCallback<T>,
-      goalCallback?: GoalCallback,
+      goalCallback?: GoalCallback<T>,
       handleAcceptedCallback?: HandleAcceptedCallback<T>,
       cancelCallback?: CancelCallback,
       options?: ActionServerOptions
@@ -144,7 +146,7 @@ declare module 'rclnodejs' {
      *
      * @param goalCallback - Callback function, if not provided, then unregisters any previously registered callback.
      */
-    registerGoalCallback(goalCallback?: GoalCallback): void;
+    registerGoalCallback(goalCallback?: GoalCallback<T>): void;
 
     /**
      * Register a callback for handling cancel requests.


### PR DESCRIPTION
**Public API Changes**

Changes for the TS types for:
- `ExecuteCallback` for the action server
- `GoalCallback` for the action server

**Description**

Both of these callbacks seem to have wrong types setup. The first one should return a `Promise` which is then resolved in:
- https://github.com/RobotWebTools/rclnodejs/blob/73f40365e2257c372db446274af63f7ac1e4f010/lib/action/server.js#L359-L361

As for the `GoalCallback` type as [per the docs](http://robotwebtools.org/rclnodejs/docs/0.20.0/ActionServer.html):
- "The purpose of the goal callback is to decide if a new goal should be accepted or rejected. **The callback should take the goal request message as a parameter and must return a GoalResponse value.** "

And based on the code:
- https://github.com/RobotWebTools/rclnodejs/blob/73f40365e2257c372db446274af63f7ac1e4f010/lib/action/server.js#L259-L261

I've tested out both of these changes in a local project and they work as expected 👍 
