### PR TITLE
Reverted linux & window galactic CI builds to use ros galactic binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,23 @@ RUN chmod 755 /ros2
 ENV ROS2_WS=/ros2
 WORKDIR $ROS2_WS
 
-RUN wget https://ci.ros2.org/view/packaging/job/packaging_linux/lastSuccessfulBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2 \
-    && tar xf ros2-package-linux-x86_64.tar.bz2
+RUN wget https://github.com/ros2/ros2/releases/download/release-galactic-20210716/ros2-galactic-20210616-linux-focal-amd64.tar.bz2 \
+    && tar xf ros2-galactic-20210616-linux-focal-amd64.tar.bz2
 
 # [Ubuntu 20.04]
-RUN rosdep install --from-paths $ROS2_WS/ros2-linux/share --ignore-src --rosdistro foxy -y --skip-keys "console_bridge fastcdr fastrtps osrf_testing_tools_cpp poco_vendor rmw_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_connext_cpp rti-connext-dds-5.3.1 tinyxml_vendor tinyxml2_vendor urdfdom urdfdom_headers"
+RUN rosdep install --from-paths $ROS2_WS/ros2-linux/share --ignore-src --rosdistro galactic -y --skip-keys "console_bridge fastcdr fastrtps osrf_testing_tools_cpp poco_vendor rmw_connextdds rti-connext-dds-5.3.1 tinyxml_vendor tinyxml2_vendor urdfdom urdfdom_headers"
+
+RUN echo "source $ROS2_WS/ros2-linux/local_setup.bash" >> $HOME/.bashrc
+
+# Install nvm, Node.js and node-gyp
+ENV NODE_VERSION v12.20.0
+RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | bash
+ENV NODE_VERSION v12.22.1
+RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash \
+    && . $HOME/.nvm/nvm.sh \
+    && nvm install $NODE_VERSION && nvm alias default $NODE_VERSION
+
+ENV PATH /bin/versions/node/$NODE_VERSION/bin:$PATH
 
 # set ros2 mode 777 only to support copy of compiled test msgs and libs into ros2 installation
 RUN chmod 777 ${ROS2_WS}/ros2-linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,8 +32,8 @@ before_build:
   - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2019-10-24/tinyxml2.6.0.0.nupkg
   - appveyor DownloadFile https://github.com/ros2/choco-packages/releases/download/2019-10-24/log4cxx.0.10.0.nupkg
   - choco install -y -s c:\download\ asio bullet cunit eigen tinyxml-usestl tinyxml2 log4cxx
-  - appveyor DownloadFile https://ci.ros2.org/view/packaging/job/packaging_windows/lastSuccessfulBuild/artifact/ws/ros2-package-windows-AMD64.zip
-  - 7z x -y "c:\download\ros2-package-windows-AMD64.zip" -o"c:\" > nul
+  - appveyor DownloadFile https://github.com/ros2/ros2/releases/download/release-galactic-20210716/ros2-galactic-20210616-windows-release-amd64.zip
+  - 7z x -y "c:\download\ros2-galactic-20210616-windows-release-amd64.zip" -o"c:\" > nul
   - setx -m OPENSSL_CONF C:\OpenSSL-v111-Win64\bin\openssl.cfg
   - set PATH=C:\OpenSSL-v111-Win64\bin;%PATH%
   - setx AMENT_PYTHON_EXECUTABLE "c:\Python310"


### PR DESCRIPTION
Restore galactic branch CI builds to use galactic binaries on win and linux os'es . See [ros binaries](https://github.com/ros2/ros2/releases)

Fix #830