### PR TITLE
fix: ActionServer CancelCallback type definition

### DIFF
--- a/types/action_server.d.ts
+++ b/types/action_server.d.ts
@@ -84,7 +84,7 @@ declare module 'rclnodejs' {
   type HandleAcceptedCallback<T extends TypeClass<ActionTypeClassName>> = (
     goalHandle: ServerGoalHandle<T>
   ) => void;
-  type CancelCallback = () => CancelResponse;
+  type CancelCallback = () => Promise<CancelResponse> | CancelResponse;
 
   interface ActionServerOptions extends Options<ActionQoS> {
     /**


### PR DESCRIPTION
The internal actionserver code treats the cancelcallback as an awaitable
object. Yet the CancelCallback type definition specifies only a return
type of CancelResponse. The proper CancelCallback function definition
should return a union of CallbackResponse or a Promise that resolves to
a CallbackResponse.

This fix is related to fix #831 contributed by @JGAntunes 