### PR TITLE
Appveyor-Windows build issues #834

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,7 @@ before_build:
   - setx -m OPENSSL_CONF C:\OpenSSL-v111-Win64\bin\openssl.cfg
   - set PATH=C:\OpenSSL-v111-Win64\bin;%PATH%
   - setx AMENT_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
+  - setx COLCON_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
   - refreshenv
   - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;%PATH%"
   - python -m pip install -U wheel catkin_pkg cryptography empy ifcfg lark-parser lxml netifaces numpy opencv-python pyparsing pyyaml setuptools colcon-common-extensions
@@ -56,6 +57,7 @@ test_script:
   - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;C:\\Program Files\\CMake\\bin;%PATH%"
   - set
   - dir \
+  - setx PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
   - python --version
   - cd c:\proj\rclnodejs\test\rclnodejs_test_msgs
   - colcon build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
 image: Visual Studio 2019
 
 environment:
-  PYTHON3: "c:\\Python38"
+  PYTHON3: "c:\\Python310-x64"
   PYTHON2: "c:\\Python27"
   matrix:
     - nodejs_version: "12"
@@ -33,7 +33,7 @@ before_build:
   - 7z x -y "c:\download\ros2-package-windows-AMD64.zip" -o"c:\" > nul
   - setx -m OPENSSL_CONF C:\OpenSSL-v111-Win64\bin\openssl.cfg
   - set PATH=C:\OpenSSL-v111-Win64\bin;%PATH%
-  - setx AMENT_PYTHON_EXECUTABLE "c:\Python38"
+  - setx AMENT_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
   - refreshenv
   - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;%PATH%"
   - python -m pip install -U wheel catkin_pkg cryptography empy ifcfg lark-parser lxml netifaces numpy opencv-python pyparsing pyyaml setuptools colcon-common-extensions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
 image: Visual Studio 2019
 
 environment:
-  PYTHON3: "c:\\Python38"
+  PYTHON3: "c:\\Python310-x64"
   PYTHON2: "c:\\Python27"
   matrix:
     - nodejs_version: "12"
@@ -16,12 +16,12 @@ clone_folder: c:\proj\rclnodejs
 
 before_build:
   - cd c:\
-  - rmdir /s /q c:\python310-x64
-  - rmdir /s /q c:\python310
-  - rmdir /s /q c:\python39-x64
-  - rmdir /s /q c:\python39
-  - rmdir /s /q c:\python38
-  - ren python38-x64 python38
+  # - rmdir /s /q c:\python310-x64
+  # - rmdir /s /q c:\python310
+  # - rmdir /s /q c:\python39-x64
+  # - rmdir /s /q c:\python39
+  # - rmdir /s /q c:\python38
+  # - ren python38-x64 python38
   - md download
   - cd download
   - choco install -y wget cmake
@@ -39,7 +39,7 @@ before_build:
   - 7z x -y "c:\download\ros2-package-windows-AMD64.zip" -o"c:\" > nul
   - setx -m OPENSSL_CONF C:\OpenSSL-v111-Win64\bin\openssl.cfg
   - set PATH=C:\OpenSSL-v111-Win64\bin;%PATH%
-  - setx AMENT_PYTHON_EXECUTABLE "c:\Python38\python.exe"
+  - setx AMENT_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
   - refreshenv
   - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;%PATH%"
   - python -m pip install -U wheel catkin_pkg cryptography empy ifcfg lark-parser lxml netifaces numpy opencv-python pyparsing pyyaml setuptools colcon-common-extensions
@@ -67,7 +67,7 @@ test_script:
   - set
   - dir \
   - python --version
-  - cd c:\proj\rclnodejs\test\rclnodejs_test_msgs
-  - colcon build
+  # - cd c:\proj\rclnodejs\test\rclnodejs_test_msgs
+  # - colcon build
   - cd c:\proj\rclnodejs
   - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
 image: Visual Studio 2019
 
 environment:
-  PYTHON3: "c:\\Python310-x64"
+  PYTHON3: "c:\\Python38-x64"
   PYTHON2: "c:\\Python27"
   matrix:
     - nodejs_version: "16"
@@ -36,7 +36,7 @@ before_build:
   - 7z x -y "c:\download\ros2-package-windows-AMD64.zip" -o"c:\" > nul
   - setx -m OPENSSL_CONF C:\OpenSSL-v111-Win64\bin\openssl.cfg
   - set PATH=C:\OpenSSL-v111-Win64\bin;%PATH%
-  - setx AMENT_PYTHON_EXECUTABLE "c:\Python310"
+  - setx AMENT_PYTHON_EXECUTABLE "c:\Python38"
   - refreshenv
   - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;%PATH%"
   - python -m pip install -U wheel catkin_pkg cryptography empy ifcfg lark-parser lxml netifaces numpy opencv-python pyparsing pyyaml setuptools colcon-common-extensions
@@ -57,4 +57,6 @@ build_script:
 test_script:
   - cmd: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat"
   - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;C:\\Program Files\\CMake\\bin;%PATH%"
+  - set
+  - dir \
   - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,11 +58,11 @@ build_script:
   # - npm run lint
 
 test_script:
-  # - dir \python310-x64
+  - dir \python310-x64
   - cmd: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat"
-  # - setx PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
-  # - setx COLCON_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
-  # - setx AMENT_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
+  - setx PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
+  - setx COLCON_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
+  - setx AMENT_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
   - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;C:\\Program Files\\CMake\\bin;%PATH%"
   - set
   - dir \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
 image: Visual Studio 2019
 
 environment:
-  PYTHON3: "c:\\Python310-x64"
+  PYTHON3: "c:\\Python38"
   PYTHON2: "c:\\Python27"
   matrix:
     - nodejs_version: "12"
@@ -16,6 +16,12 @@ clone_folder: c:\proj\rclnodejs
 
 before_build:
   - cd c:\
+  - rmdir /s /q c:\python310-x64
+  - rmdir /s /q c:\python310
+  - rmdir /s /q c:\python39-x64
+  - rmdir /s /q c:\python39
+  - rmdir /s /q c:\python38
+  - ren c:\python38-x64 c:\python38
   - md download
   - cd download
   - choco install -y wget cmake
@@ -33,8 +39,7 @@ before_build:
   - 7z x -y "c:\download\ros2-package-windows-AMD64.zip" -o"c:\" > nul
   - setx -m OPENSSL_CONF C:\OpenSSL-v111-Win64\bin\openssl.cfg
   - set PATH=C:\OpenSSL-v111-Win64\bin;%PATH%
-  - setx AMENT_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
-  - setx COLCON_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
+  # - setx AMENT_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
   - refreshenv
   - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;%PATH%"
   - python -m pip install -U wheel catkin_pkg cryptography empy ifcfg lark-parser lxml netifaces numpy opencv-python pyparsing pyyaml setuptools colcon-common-extensions
@@ -53,11 +58,14 @@ build_script:
   # - npm run lint
 
 test_script:
+  # - dir \python310-x64
   - cmd: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat"
-  - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;C:\\Program Files\\CMake\\bin;%PATH%"
+  # - setx PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
+  # - setx COLCON_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
+  # - setx AMENT_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
+  # - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;C:\\Program Files\\CMake\\bin;%PATH%"
   - set
   - dir \
-  - setx PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
   - python --version
   - cd c:\proj\rclnodejs\test\rclnodejs_test_msgs
   - colcon build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,7 @@ environment:
   PYTHON3: "c:\\Python38-x64"
   PYTHON2: "c:\\Python27"
   matrix:
-    - nodejs_version: "16"
-    - nodejs_version: "14"
     - nodejs_version: "12"
-    - nodejs_version: "10"
 
 clone_folder: c:\proj\rclnodejs
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,11 +49,15 @@ build_script:
   - npm --version
   - python --version
   - npm install
-  - npm run lint
+  # - npm run lint
 
 test_script:
   - cmd: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat"
   - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;C:\\Program Files\\CMake\\bin;%PATH%"
   - set
   - dir \
+  - python --version
+  - cd c:\proj\rclnodejs\test\rclnodejs_test_msgs
+  - colcon build
+  - cd c:\proj\rclnodejs
   - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ before_build:
   - rmdir /s /q c:\python39-x64
   - rmdir /s /q c:\python39
   - rmdir /s /q c:\python38
-  - ren c:\python38-x64 c:\python38
+  - ren python38-x64 python38
   - md download
   - cd download
   - choco install -y wget cmake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
 image: Visual Studio 2019
 
 environment:
-  PYTHON3: "c:\\Python38-x64"
+  PYTHON3: "c:\\Python38"
   PYTHON2: "c:\\Python27"
   matrix:
     - nodejs_version: "12"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ before_build:
   - 7z x -y "c:\download\ros2-package-windows-AMD64.zip" -o"c:\" > nul
   - setx -m OPENSSL_CONF C:\OpenSSL-v111-Win64\bin\openssl.cfg
   - set PATH=C:\OpenSSL-v111-Win64\bin;%PATH%
-  # - setx AMENT_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
+  - setx AMENT_PYTHON_EXECUTABLE "c:\Python38\python.exe"
   - refreshenv
   - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;%PATH%"
   - python -m pip install -U wheel catkin_pkg cryptography empy ifcfg lark-parser lxml netifaces numpy opencv-python pyparsing pyyaml setuptools colcon-common-extensions
@@ -63,7 +63,7 @@ test_script:
   # - setx PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
   # - setx COLCON_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
   # - setx AMENT_PYTHON_EXECUTABLE "c:\Python310-x64\python.exe"
-  # - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;C:\\Program Files\\CMake\\bin;%PATH%"
+  - "SET PATH=%PYTHON3%;%PYTHON3%\\bin;%PYTHON3%\\Scripts;C:\\Program Files\\CMake\\bin;%PATH%"
   - set
   - dir \
   - python --version

--- a/scripts/compile_tests.js
+++ b/scripts/compile_tests.js
@@ -20,8 +20,8 @@ const os = require('os');
 const path = require('path');
 const child = require('child_process');
 
-var rootDir = path.dirname(__dirname);
-var testCppDir = path.join(rootDir, 'test', 'cpp');
+const rootDir = path.dirname(__dirname);
+const testCppDir = path.join(rootDir, 'test', 'cpp');
 
 function getExecutable(input) {
   if (os.platform() === 'win32') return input + '.exe';
@@ -29,22 +29,12 @@ function getExecutable(input) {
   return input;
 }
 
-var publisher = getExecutable('publisher_msg');
-var subscription = getExecutable('subscription_msg');
-var listener = getExecutable('listener');
-var client = getExecutable('add_two_ints_client');
-
 function getExecutablePath(input) {
   var releaseDir = '';
   if (os.platform() === 'win32') releaseDir = 'Release';
 
   return path.join(rootDir, 'build', 'cpp_nodes', releaseDir, input);
 }
-
-var publisherPath = getExecutablePath(publisher);
-var subscriptionPath = getExecutablePath(subscription);
-var listenerPath = getExecutablePath(listener);
-var clientPath = getExecutablePath(client);
 
 function copyFile(platform, srcFile, destFile) {
   if (!fs.existsSync(destFile)) {
@@ -75,7 +65,12 @@ function copyPkgToRos2(pkgName) {
   }
 }
 
-var subProcess = child.spawn('colcon', [
+// main
+
+console.log('COMPILE TEST ENV: ', process.env);
+
+// run colcon to build rclnodejs_test_msgs
+const subProcess = child.spawn('colcon', [
   'build',
   '--event-handlers',
   'console_cohesion+',
@@ -91,6 +86,16 @@ subProcess.stdout.on('data', (data) => {
 subProcess.stderr.on('data', (data) => {
   console.log(`${data}`);
 });
+
+const publisher = getExecutable('publisher_msg');
+const subscription = getExecutable('subscription_msg');
+const listener = getExecutable('listener');
+const client = getExecutable('add_two_ints_client');
+
+const publisherPath = getExecutablePath(publisher);
+const subscriptionPath = getExecutablePath(subscription);
+const listenerPath = getExecutablePath(listener);
+const clientPath = getExecutablePath(client);
 
 if (
   !fs.existsSync(publisherPath) &&

--- a/types/action_server.d.ts
+++ b/types/action_server.d.ts
@@ -84,7 +84,7 @@ declare module 'rclnodejs' {
   type HandleAcceptedCallback<T extends TypeClass<ActionTypeClassName>> = (
     goalHandle: ServerGoalHandle<T>
   ) => void;
-  type CancelCallback = () => CancelResponse;
+  type CancelCallback = () => Promise<CancelResponse> | CancelResponse;
 
   interface ActionServerOptions extends Options<ActionQoS> {
     /**


### PR DESCRIPTION
Wip - debug wrong python3 path environment when compiling rclnodejs_test_msgs. Let's figure out why colcon is looking for c:\python38 when PATH and AMENT_PYTHON_EXECUTABLE are set to c:\python310-x64.