### PR TITLE
Free memory allocated for typed arrays

### DIFF
--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -1330,6 +1330,7 @@ NAN_METHOD(CreateArrayBufferFromAddress) {
   memcpy(backing->Data(), addr, length);
   auto array_buffer =
       v8::ArrayBuffer::New(v8::Isolate::GetCurrent(), std::move(backing));
+  free(addr);
 #endif
 
   info.GetReturnValue().Set(array_buffer);


### PR DESCRIPTION
This patch fixed the memory leak when using typed arrays on nodejs > 10

Fix: #842
