### PR TITLE
Deploy github workflows on galactic branch

### DIFF
--- a/.github/workflows/linux-build-and-test-galactic.yml
+++ b/.github/workflows/linux-build-and-test-galactic.yml
@@ -1,0 +1,44 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Linux Build and Test on Galactic
+
+on:
+  push:
+    branches: [ galactic-geochelone ]
+  pull_request:
+    branches: [ galactic-geochelone ]
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [10.X, 12.x, 14.X, 16.X, 17.X]
+
+    steps:
+    - name: Setup ROS2
+      uses: ros-tooling/setup-ros@v0.3
+      with:
+        required-ros-distributions: galactic
+
+    - name: Install test-msgs on Linux
+      run: |
+        sudo apt install ros-rolling-test-msgs
+
+    - uses: actions/checkout@v3
+      with:
+        ref: galactic-geochelone
+    - name: Setup Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Run test suite on Linux
+      run: |
+        source /opt/ros/galactic/setup.bash
+        npm i
+        npm test


### PR DESCRIPTION
This patch copies the .yml configuration from
https://github.com/RobotWebTools/rclnodejs/blob/develop/.github/workflows/linux-build-and-test.yml
and changes the distro to galactic.

Besides, this patch removes the previous CIs configurations for
travis/appveyor/circleci.

Fix: #None