### PR TITLE
Accomodate TS 4.7's new union order in dtslint tests

### DIFF
--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -315,10 +315,10 @@ time1.secondsAndNanoseconds;
 // $ExpectType Time
 time1.add(duration1);
 
-// $ExpectType Duration | Time
+// $ExpectType Duration | Time || Time | Duration
 time1.sub(duration1);
 
-// $ExpectType Duration | Time
+// $ExpectType Duration | Time || Time | Duration
 time1.sub(time2);
 
 // $ExpectType boolean


### PR DESCRIPTION
Similar to our test failures, others have struggled with dtslint failing
(false negative) due to inconsistent union type ordering. It appears
that $ExpectType <union> can be extended to list different orderings for
union types (permutations). In our case we have encountered issues with
this rule:
```
// $ExpectType Duration | Time
```
Extending this rule with an alternative ordering:
```
// $ExpectType Duration | Time || Time | Duration
```
