### PR TITLE
Fixes linux-galactic workflow to load the proper test-msgs version

### DIFF
--- a/.github/workflows/linux-build-and-test-galactic.yml
+++ b/.github/workflows/linux-build-and-test-galactic.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install test-msgs on Linux
       run: |
-        sudo apt install ros-rolling-test-msgs
+        sudo apt install ros-galactic-test-msgs
 
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
The linux-build-and-test-galactic.yml workflow loading the wrong test_msgs (ros-rolling-test-msgs). This change fixes the workflow to load ros-galactic-test-msgs.  