### PR TITLE
do not convert bool to string for parameter msg

### DIFF
--- a/lib/parameter.js
+++ b/lib/parameter.js
@@ -225,12 +225,10 @@ class Parameter {
       case ParameterType.PARAMETER_NOT_SET:
         break;
       case ParameterType.PARAMETER_BOOL:
-        msg.bool_value = this.value ? 'true' : 'false';
+        msg.bool_value = this.value;
         break;
       case ParameterType.PARAMETER_BOOL_ARRAY:
-        msg.bool_array_value = this.value.map((val) =>
-          val ? 'true' : 'false'
-        );
+        msg.bool_array_value = this.value;
         break;
       case ParameterType.PARAMETER_BYTE_ARRAY:
         msg.byte_array_value = this.value.map((val) => Math.trunc(val));


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
Remove conversion of bool values to strings for `ParameterType.PARAMETER_BOOL` and `ParameterType.PARAMETER_BOOL_ARRAY` in `Parameter.toParameterMessage()`. The rclcpp methods `Parameter::as_bool()` and `Parameter::as_bool_array()` do not convert these messages correctly if they contain bools as strings.

<!-- Link relevant GitHub issues -->
fixes: [850](https://github.com/RobotWebTools/rclnodejs/issues/850)