### PR TITLE
Fix issues when using parameters of type array

### DIFF
--- a/lib/parameter.js
+++ b/lib/parameter.js
@@ -89,25 +89,25 @@ class Parameter {
         value = parameterMsg.value.bool_array_value;
         break;
       case ParameterType.PARAMETER_BYTE_ARRAY:
-        value = parameterMsg.value.byte_array_value;
+        value = Array.from(parameterMsg.value.byte_array_value);
         break;
       case ParameterType.PARAMETER_DOUBLE:
         value = parameterMsg.value.double_value;
         break;
       case ParameterType.PARAMETER_DOUBLE_ARRAY:
-        value = parameterMsg.value.double_array_value;
+        value = Array.from(parameterMsg.value.double_array_value);
         break;
       case ParameterType.PARAMETER_INTEGER:
         value = parameterMsg.value.integer_value;
         break;
       case ParameterType.PARAMETER_INTEGER_ARRAY:
-        value = parameterMsg.value.integer_array_value;
+        value = Array.from(parameterMsg.value.integer_array_value);
         break;
       case ParameterType.PARAMETER_STRING:
         value = parameterMsg.value.string_value;
         break;
       case ParameterType.PARAMETER_STRING_ARRAY:
-        value = parameterMsg.value.string_array_value;
+        value = Array.from(parameterMsg.value.string_array_value);
         break;
     }
 

--- a/lib/parameter.js
+++ b/lib/parameter.js
@@ -789,7 +789,7 @@ function _validArray(values, type) {
   if (type === ParameterType.PARAMETER_BOOL_ARRAY) {
     arrayElementType = ParameterType.PARAMETER_BOOL;
   } else if (type === ParameterType.PARAMETER_BYTE_ARRAY) {
-    arrayElementType = ParameterType.PARAMETER_BYTE;
+    arrayElementType = ParameterType.PARAMETER_INTEGER;
   }
   if (type === ParameterType.PARAMETER_INTEGER_ARRAY) {
     arrayElementType = ParameterType.PARAMETER_INTEGER;

--- a/lib/parameter.js
+++ b/lib/parameter.js
@@ -71,7 +71,7 @@ class Parameter {
   /**
    * Create a Parameter instance from an rlc_interfaces/msg/Parameter message.
    * @constructs
-   * @param {rlc_interfaces/msg/Parameter} parameterMsg - The message to convert to a parameter.
+   * @param {rcl_interfaces/msg/Parameter} parameterMsg - The message to convert to a parameter.
    * @return {Parameter} - The new instance.
    */
   static fromParameterMessage(parameterMsg) {

--- a/lib/parameter.js
+++ b/lib/parameter.js
@@ -771,6 +771,7 @@ function validValue(value, type) {
     case ParameterType.PARAMETER_BYTE_ARRAY:
     case ParameterType.PARAMETER_INTEGER_ARRAY:
     case ParameterType.PARAMETER_DOUBLE_ARRAY:
+    case ParameterType.PARAMETER_STRING_ARRAY:
       const values = value;
       result = _validArray(values, type);
       break;
@@ -796,6 +797,9 @@ function _validArray(values, type) {
   if (type === ParameterType.PARAMETER_DOUBLE_ARRAY) {
     arrayElementType = ParameterType.PARAMETER_DOUBLE;
   }
+  if (type === ParameterType.PARAMETER_STRING_ARRAY) {
+    arrayElementType = ParameterType.PARAMETER_STRING;
+  }
 
   return values.reduce(
     (compatible, val) =>
@@ -811,7 +815,8 @@ function _isArrayParameterType(type) {
     type === ParameterType.PARAMETER_BOOL_ARRAY ||
     type === ParameterType.PARAMETER_BYTE_ARRAY ||
     type === ParameterType.PARAMETER_INTEGER_ARRAY ||
-    type === ParameterType.PARAMETER_DOUBLE_ARRAY
+    type === ParameterType.PARAMETER_DOUBLE_ARRAY ||
+    type === ParameterType.PARAMETER_STRING_ARRAY
   );
 }
 

--- a/test/test-parameters.js
+++ b/test/test-parameters.js
@@ -19,6 +19,7 @@ const assertUtils = require('./utils.js');
 const assertThrowsError = assertUtils.assertThrowsError;
 const IsClose = require('is-close');
 const rclnodejs = require('../index.js');
+const loader = require('../lib/interface_loader.js');
 
 const ParameterType = rclnodejs.ParameterType;
 const Parameter = rclnodejs.Parameter;
@@ -99,6 +100,177 @@ describe('rclnodejs parameters test suite', function () {
       assert.strictEqual(param.value, 101);
 
       assertThrowsError(() => (param.value = 'hello world'), TypeError);
+    });
+  });
+
+  describe('convert fromParameterMessage test suite', function () {
+    it('should convert PARAMETER_NOT_SET type', function () {
+      let param_msg = new (loader.loadInterface(
+        'rcl_interfaces/msg/Parameter'
+      ))();
+      param_msg.name = 'not_set_param';
+      param_msg.value.type = ParameterType.PARAMETER_NOT_SET;
+
+      let param;
+      assert.doesNotThrow(() => {
+        param = Parameter.fromParameterMessage(param_msg);
+      });
+      assert.strictEqual(param.name, 'not_set_param');
+      assert.strictEqual(param.type, ParameterType.PARAMETER_NOT_SET);
+      assert.strictEqual(param.value, undefined);
+    });
+
+    it('should convert PARAMETER_BOOL type', function () {
+      let param_msg = new (loader.loadInterface(
+        'rcl_interfaces/msg/Parameter'
+      ))();
+      param_msg.name = 'bool_param';
+      param_msg.value.type = ParameterType.PARAMETER_BOOL;
+      param_msg.value.bool_value = false;
+
+      let param;
+      assert.doesNotThrow(() => {
+        param = Parameter.fromParameterMessage(param_msg);
+      });
+      assert.strictEqual(param.name, 'bool_param');
+      assert.strictEqual(param.type, ParameterType.PARAMETER_BOOL);
+      assert.strictEqual(param.value, false);
+    });
+
+    it('should convert PARAMETER_BOOL_ARRAY type', function () {
+      let param_msg = new (loader.loadInterface(
+        'rcl_interfaces/msg/Parameter'
+      ))();
+      param_msg.name = 'bool_array_param';
+      param_msg.value.type = ParameterType.PARAMETER_BOOL_ARRAY;
+      param_msg.value.bool_array_value = [true, false, true];
+
+      let param;
+      assert.doesNotThrow(() => {
+        param = Parameter.fromParameterMessage(param_msg);
+      });
+      assert.strictEqual(param.name, 'bool_array_param');
+      assert.strictEqual(param.type, ParameterType.PARAMETER_BOOL_ARRAY);
+      assert.deepStrictEqual(param.value, [true, false, true]);
+    });
+
+    it('should convert PARAMETER_BYTE_ARRAY type', function () {
+      let param_msg = new (loader.loadInterface(
+        'rcl_interfaces/msg/Parameter'
+      ))();
+      param_msg.name = 'byte_array_param';
+      param_msg.value.type = ParameterType.PARAMETER_BYTE_ARRAY;
+      param_msg.value.byte_array_value = [1, 2, 3];
+
+      let param;
+      assert.doesNotThrow(() => {
+        param = Parameter.fromParameterMessage(param_msg);
+      });
+      assert.strictEqual(param.name, 'byte_array_param');
+      assert.strictEqual(param.type, ParameterType.PARAMETER_BYTE_ARRAY);
+      assert.deepStrictEqual(param.value, [1, 2, 3]);
+    });
+
+    it('should convert PARAMETER_DOUBLE type', function () {
+      let param_msg = new (loader.loadInterface(
+        'rcl_interfaces/msg/Parameter'
+      ))();
+      param_msg.name = 'double_param';
+      param_msg.value.type = ParameterType.PARAMETER_DOUBLE;
+      param_msg.value.double_value = 1.23;
+
+      let param;
+      assert.doesNotThrow(() => {
+        param = Parameter.fromParameterMessage(param_msg);
+      });
+      assert.strictEqual(param.name, 'double_param');
+      assert.strictEqual(param.type, ParameterType.PARAMETER_DOUBLE);
+      assert.strictEqual(param.value, 1.23);
+    });
+
+    it('should convert PARAMETER_DOUBLE_ARRAY type', function () {
+      let param_msg = new (loader.loadInterface(
+        'rcl_interfaces/msg/Parameter'
+      ))();
+      param_msg.name = 'double_array_param';
+      param_msg.value.type = ParameterType.PARAMETER_DOUBLE_ARRAY;
+      param_msg.value.double_array_value = [1.1, 2.2, 3.3, 4.4, 5.5];
+
+      let param;
+      assert.doesNotThrow(() => {
+        param = Parameter.fromParameterMessage(param_msg);
+      });
+      assert.strictEqual(param.name, 'double_array_param');
+      assert.strictEqual(param.type, ParameterType.PARAMETER_DOUBLE_ARRAY);
+      assert.deepStrictEqual(param.value, [1.1, 2.2, 3.3, 4.4, 5.5]);
+    });
+
+    it('should convert PARAMETER_INTEGER type', function () {
+      let param_msg = new (loader.loadInterface(
+        'rcl_interfaces/msg/Parameter'
+      ))();
+      param_msg.name = 'integer_param';
+      param_msg.value.type = ParameterType.PARAMETER_INTEGER;
+      param_msg.value.integer_value = 123;
+
+      let param;
+      assert.doesNotThrow(() => {
+        param = Parameter.fromParameterMessage(param_msg);
+      });
+      assert.strictEqual(param.name, 'integer_param');
+      assert.strictEqual(param.type, ParameterType.PARAMETER_INTEGER);
+      assert.strictEqual(param.value, 123);
+    });
+
+    it('should convert PARAMETER_INTEGER_ARRAY type', function () {
+      let param_msg = new (loader.loadInterface(
+        'rcl_interfaces/msg/Parameter'
+      ))();
+      param_msg.name = 'integer_array_param';
+      param_msg.value.type = ParameterType.PARAMETER_INTEGER_ARRAY;
+      param_msg.value.integer_array_value = [1, 2, 3, 4, 5];
+
+      let param;
+      assert.doesNotThrow(() => {
+        param = Parameter.fromParameterMessage(param_msg);
+      });
+      assert.strictEqual(param.name, 'integer_array_param');
+      assert.strictEqual(param.type, ParameterType.PARAMETER_INTEGER_ARRAY);
+      assert.deepStrictEqual(param.value, [1, 2, 3, 4, 5]);
+    });
+
+    it('should convert PARAMETER_STRING type', function () {
+      let param_msg = new (loader.loadInterface(
+        'rcl_interfaces/msg/Parameter'
+      ))();
+      param_msg.name = 'string_param';
+      param_msg.value.type = ParameterType.PARAMETER_STRING;
+      param_msg.value.string_value = 'hello world';
+
+      let param;
+      assert.doesNotThrow(() => {
+        param = Parameter.fromParameterMessage(param_msg);
+      });
+      assert.strictEqual(param.name, 'string_param');
+      assert.strictEqual(param.type, ParameterType.PARAMETER_STRING);
+      assert.strictEqual(param.value, 'hello world');
+    });
+
+    it('should convert PARAMETER_STRING_ARRAY type', function () {
+      let param_msg = new (loader.loadInterface(
+        'rcl_interfaces/msg/Parameter'
+      ))();
+      param_msg.name = 'string_array_param';
+      param_msg.value.type = ParameterType.PARAMETER_STRING_ARRAY;
+      param_msg.value.string_array_value = ['hello', 'world'];
+
+      let param;
+      assert.doesNotThrow(() => {
+        param = Parameter.fromParameterMessage(param_msg);
+      });
+      assert.strictEqual(param.name, 'string_array_param');
+      assert.strictEqual(param.type, ParameterType.PARAMETER_STRING_ARRAY);
+      assert.deepStrictEqual(param.value, ['hello', 'world']);
     });
   });
 


### PR DESCRIPTION
**Public API Changes**
None


**Description**

This PR fixes the following issues with parameters when the parameter type is an array. (in order of commits)

- the parameter type `PARAMETER_STRING_ARRAY` was not handled everywhere
- values of parameters of type `PARAMETER_[BYTE/INTEGER/DOUBLE]_ARRAY` are of type `TypedArray` which throws a`TypeError('incompatible value')` in the `validate()`  method. This is because `_validArray()` (more specifically `Array.isArray()` returns `false` when given a `TypedArray`
- `arrayElementType` of `PARAMETER_BYTE_ARRAY` was set to `PARAMETER_BYTE` which is a type that does not exist (`undefined`). We can use `PARAMETER_INTEGER` instead.

Unit tests were added to reproduce the bugs, then the next commits fix those bugs.


