### PR TITLE
Fix ActionServer cancelCallback declaration, doc & test

### DIFF
--- a/lib/action/server.js
+++ b/lib/action/server.js
@@ -190,7 +190,7 @@ class ActionServer extends Entity {
    *
    * The purpose of the cancel callback is to decide if a request to cancel an on-going
    * (or queued) goal should be accepted or rejected.
-   * The callback should take one parameter containing the cancel request and must return a
+   * The callback should take one parameter containing the cancel request (a goal handle) and must return a
    * {@link CancelResponse} value.
    *
    * There can only be one cancel callback per {@link ActionServer}, therefore calling this

--- a/test/test-action-server.js
+++ b/test/test-action-server.js
@@ -289,7 +289,7 @@ describe('rclnodejs action server', function () {
       return new Fibonacci.Result();
     }
 
-    function cancelCallback() {
+    function cancelCallback(goalHandle) {
       return rclnodejs.CancelResponse.ACCEPT;
     }
 
@@ -334,7 +334,7 @@ describe('rclnodejs action server', function () {
       return new Fibonacci.Result();
     }
 
-    function cancelCallback() {
+    function cancelCallback(goalHandle) {
       return rclnodejs.CancelResponse.REJECT;
     }
 
@@ -381,7 +381,7 @@ describe('rclnodejs action server', function () {
       serverGoalHandle = goalHandle;
     }
 
-    function cancelCallback() {
+    function cancelCallback(goalHandle) {
       return rclnodejs.CancelResponse.ACCEPT;
     }
 

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -454,13 +454,13 @@ logger.fatal('test msg');
 // f64arr.data;
 
 // $ExpectType FibonacciConstructor
-const Fibonacci = rclnodejs.require('test_msgs/action/Fibonacci');
+const Fibonacci = rclnodejs.require('example_interfaces/action/Fibonacci');
 
 // ---- ActionClient -----
-// $ExpectType ActionClient<"test_msgs/action/Fibonacci">
+// $ExpectType ActionClient<"example_interfaces/action/Fibonacci">
 const actionClient = new rclnodejs.ActionClient(
   node,
-  'test_msgs/action/Fibonacci',
+  'example_interfaces/action/Fibonacci',
   'fibonnaci'
 );
 
@@ -473,7 +473,7 @@ actionClient.waitForServer();
 // $ExpectType void
 actionClient.destroy();
 
-// $ExpectType Promise<ClientGoalHandle<"test_msgs/action/Fibonacci">>
+// $ExpectType Promise<ClientGoalHandle<"example_interfaces/action/Fibonacci">>
 const goalHandlePromise = actionClient.sendGoal(new Fibonacci.Goal());
 
 goalHandlePromise.then((goalHandle) => {
@@ -515,10 +515,10 @@ goalHandlePromise.then((goalHandle) => {
 });
 
 // ---- ActionServer -----
-// $ExpectType ActionServer<"test_msgs/action/Fibonacci">
+// $ExpectType ActionServer<"example_interfaces/action/Fibonacci">
 const actionServer = new rclnodejs.ActionServer(
   node,
-  'test_msgs/action/Fibonacci',
+  'example_interfaces/action/Fibonacci',
   'fibonnaci',
   executeCallback
 );
@@ -539,7 +539,7 @@ actionServer.registerExecuteCallback(() => new Fibonacci.Result());
 actionServer.destroy();
 
 function executeCallback(
-  goalHandle: rclnodejs.ServerGoalHandle<'test_msgs/action/Fibonacci'>
+  goalHandle: rclnodejs.ServerGoalHandle<'example_interfaces/action/Fibonacci'>
 ) {
   // $ExpectType UUID
   goalHandle.goalId;

--- a/types/action_server.d.ts
+++ b/types/action_server.d.ts
@@ -85,7 +85,7 @@ declare module 'rclnodejs' {
     goalHandle: ServerGoalHandle<T>
   ) => void;
   type CancelCallback<T extends TypeClass<ActionTypeClassName>> = (
-    goalHandle: ServerGoalHandle<T>
+    goalHandle?: ServerGoalHandle<T>
   ) => Promise<CancelResponse> | CancelResponse;
 
   interface ActionServerOptions extends Options<ActionQoS> {

--- a/types/action_server.d.ts
+++ b/types/action_server.d.ts
@@ -84,7 +84,9 @@ declare module 'rclnodejs' {
   type HandleAcceptedCallback<T extends TypeClass<ActionTypeClassName>> = (
     goalHandle: ServerGoalHandle<T>
   ) => void;
-  type CancelCallback = () => Promise<CancelResponse> | CancelResponse;
+  type CancelCallback<T extends TypeClass<ActionTypeClassName>> = (
+    goalHandle: ServerGoalHandle<T>
+  ) => Promise<CancelResponse> | CancelResponse;
 
   interface ActionServerOptions extends Options<ActionQoS> {
     /**
@@ -116,7 +118,7 @@ declare module 'rclnodejs' {
       executeCallback: ExecuteCallback<T>,
       goalCallback?: GoalCallback<T>,
       handleAcceptedCallback?: HandleAcceptedCallback<T>,
-      cancelCallback?: CancelCallback,
+      cancelCallback?: CancelCallback<T>,
       options?: ActionServerOptions
     );
 
@@ -153,14 +155,14 @@ declare module 'rclnodejs' {
      *
      * The purpose of the cancel callback is to decide if a request to cancel an on-going
      * (or queued) goal should be accepted or rejected.
-     * The callback should take one parameter containing the cancel request and must return a
+     * The callback should take one parameter containing the cancel request ( a GoalHandle) and must return a
      * {@link CancelResponse} value.
      *
      * There can only be one cancel callback per {@link ActionServer}, therefore calling this
      * function will replace any previously registered callback.
      * @param cancelCallback - Callback function, if not provided, then unregisters any previously registered callback.
      */
-    registerCancelCallback(cancelCallback?: CancelCallback): void;
+    registerCancelCallback(cancelCallback?: CancelCallback<T>): void;
 
     /**
      * Register a callback for executing action goals.


### PR DESCRIPTION
While the ActionServer implementation will pass it's CancelCallback function a ServerGoalHandler argument, this fact is not clearly documented, not illustrated in the actionserver tests and the TS CancelCallback function declaration does not include a ServerGoalHandle parameter.
 
This PR updates docs, test suite and modifies the TypeScript CancelCallback function declaration to include a required ServerGoalHandle parameter. The change breaks existing TypeScript ActionServers that implement a custom CancelCallback function with a compilation error.  

Question: To make this a non-breaking change we can make the ServerGoalHandle optional. Thoughts?

Fix #866

