### PR TITLE
Enable ActionUuid for TypeScript

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ const validator = require('./lib/validator.js');
 const Time = require('./lib/time.js');
 const ActionClient = require('./lib/action/client.js');
 const ActionServer = require('./lib/action/server.js');
+const ActionUuid = require('./lib/action/uuid.js');
 const ClientGoalHandle = require('./lib/action/client_goal_handle.js');
 const { CancelResponse, GoalResponse } = require('./lib/action/response.js');
 const ServerGoalHandle = require('./lib/action/server_goal_handle.js');
@@ -149,6 +150,9 @@ let rcl = {
 
   /** {@link ActionServer} class */
   ActionServer: ActionServer,
+
+  /** {@link ActionUuid} class */
+  ActionUuid: ActionUuid,
 
   /** {@link ClientGoalHandle} class */
   ClientGoalHandle: ClientGoalHandle,

--- a/lib/action/client.js
+++ b/lib/action/client.js
@@ -100,7 +100,7 @@ class ActionClient extends Entity {
       );
 
       if (goalHandle.accepted) {
-        let uuid = ActionUuid.fromBytes(goalHandle.goalId.uuid).toString();
+        let uuid = ActionUuid.fromMessage(goalHandle.goalId).toString();
         if (this._goalHandles.has(uuid)) {
           throw new Error(`Two goals were accepted with the same ID (${uuid})`);
         }
@@ -150,7 +150,7 @@ class ActionClient extends Entity {
   }
 
   processFeedbackMessage(message) {
-    let uuid = ActionUuid.fromBytes(message.goal_id.uuid).toString();
+    let uuid = ActionUuid.fromMessage(message.goal_id).toString();
     if (this._feedbackCallbacks.has(uuid)) {
       this._feedbackCallbacks.get(uuid)(
         message.toPlainObject(this.typedArrayEnabled).feedback
@@ -161,8 +161,8 @@ class ActionClient extends Entity {
   processStatusMessage(message) {
     // Update the status of all goal handles maintained by this Action Client
     for (const statusMessage of message.status_list.data) {
-      let uuid = ActionUuid.fromBytes(
-        statusMessage.goal_info.goal_id.uuid
+      let uuid = ActionUuid.fromMessage(
+        statusMessage.goal_info.goal_id
       ).toString();
       let status = statusMessage.status;
 
@@ -200,7 +200,7 @@ class ActionClient extends Entity {
    */
   sendGoal(goal, feedbackCallback, goalUuid) {
     let request = new this._typeClass.impl.SendGoalService.Request();
-    request['goal_id'] = goalUuid || this._createRandomUuid();
+    request['goal_id'] = goalUuid || ActionUuid.randomMessage();
     request.goal = goal;
 
     let sequenceNumber = rclnodejs.actionSendGoalRequest(
@@ -215,7 +215,7 @@ class ActionClient extends Entity {
     }
 
     if (feedbackCallback) {
-      let uuid = ActionUuid.fromBytes(request.goal_id.uuid).toString();
+      let uuid = ActionUuid.fromMessage(request.goal_id).toString();
       this._feedbackCallbacks.set(uuid, feedbackCallback);
     }
 
@@ -343,20 +343,6 @@ class ActionClient extends Entity {
     this._pendingResultRequests.set(sequenceNumber, deferred);
 
     return deferred.promise;
-  }
-
-  /**
-   * Creates a new random UUID message.
-   * @ignore
-   * @returns {object} - The new UUID message.
-   */
-  _createRandomUuid() {
-    let uuid = ActionUuid.random();
-
-    let uuidMsg = new ActionInterfaces.UUID();
-    uuidMsg.uuid = uuid.bytes;
-
-    return uuidMsg;
   }
 
   _removePendingGoalRequest(sequenceNumber) {

--- a/lib/action/server.js
+++ b/lib/action/server.js
@@ -190,7 +190,7 @@ class ActionServer extends Entity {
    *
    * The purpose of the cancel callback is to decide if a request to cancel an on-going
    * (or queued) goal should be accepted or rejected.
-   * The callback should take one parameter containing the cancel request and must return a
+   * The callback should take one parameter containing the cancel request (a goal handle) and must return a
    * {@link CancelResponse} value.
    *
    * There can only be one cancel callback per {@link ActionServer}, therefore calling this

--- a/lib/action/uuid.js
+++ b/lib/action/uuid.js
@@ -14,13 +14,13 @@
 
 'use strict';
 
+const ActionInterfaces = require('./interfaces.js');
 const { v4: uuidv4 } = require('uuid');
 
 /**
  * @class - Represents a unique identifier used by actions.
  * @ignore
  */
-
 class ActionUuid {
   /**
    * Creates a new instance of ActionUuid.
@@ -72,6 +72,33 @@ class ActionUuid {
    */
   toString() {
     return [].slice.call(this._bytes).join(',');
+  }
+
+  /**
+   * Create an instance from a ROS2 UUID message
+   * @param {unique_identifier_msgs.msg.UUID} msg - The ROS2 UUID message
+   * @returns {ActionUuid} - The new instance.
+   */
+  static fromMessage(msg) {
+    return ActionUuid.fromBytes(msg.uuid);
+  }
+
+  /**
+   * Create a ROS2 UUID message from this instance.
+   * @returns {unique_identifier_msgs.msg.UUID} - The new ROS2 UUID message
+   */
+  toMessage() {
+    const uuidMsg = new ActionInterfaces.UUID();
+    uuidMsg.uuid = this.bytes;
+    return uuidMsg;
+  }
+
+  /**
+   * Create a ROS2 UUID message with random uuid data
+   * @returns {ActionUuid} - The new instance.
+   */
+  static randomMessage() {
+    return ActionUuid.random().toMessage();
   }
 }
 

--- a/lib/interface_loader.js
+++ b/lib/interface_loader.js
@@ -114,7 +114,7 @@ let interfaceLoader = {
       }
     }
     throw new Error(
-      `The message required does not exist: ${packageName}, ${type}, ${messageName}`
+      `The message required does not exist: ${packageName}, ${type}, ${messageName} at ${generator.generatedRoot}`
     );
   },
 };

--- a/test/test-action-server.js
+++ b/test/test-action-server.js
@@ -289,7 +289,7 @@ describe('rclnodejs action server', function () {
       return new Fibonacci.Result();
     }
 
-    function cancelCallback() {
+    function cancelCallback(goalHandle) {
       return rclnodejs.CancelResponse.ACCEPT;
     }
 
@@ -334,7 +334,7 @@ describe('rclnodejs action server', function () {
       return new Fibonacci.Result();
     }
 
-    function cancelCallback() {
+    function cancelCallback(goalHandle) {
       return rclnodejs.CancelResponse.REJECT;
     }
 
@@ -381,7 +381,7 @@ describe('rclnodejs action server', function () {
       serverGoalHandle = goalHandle;
     }
 
-    function cancelCallback() {
+    function cancelCallback(goalHandle) {
       return rclnodejs.CancelResponse.ACCEPT;
     }
 

--- a/test/test-action-uuid.js
+++ b/test/test-action-uuid.js
@@ -1,0 +1,92 @@
+// Copyright (c) 2022 Wayne Parrott. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const rclnodejs = require('../index.js');
+
+describe('ActionUuid tests', () => {
+  before(function () {
+    // need to ensure msgs have been generated before running
+    return rclnodejs.init();
+  });
+
+  after(function () {
+    // need to ensure msgs have been generated before running
+    return rclnodejs.shutdownAll();
+  });
+
+  it('constructor - defaults', () => {
+    let uuid = new rclnodejs.ActionUuid();
+    assert.ok(uuid);
+    assert.ok(uuid._bytes instanceof Uint8Array);
+  });
+
+  it('constructor - custom bytes', () => {
+    let bytes = Uint8Array.from([0, 1]);
+    let uuid = new rclnodejs.ActionUuid(bytes);
+    assert.ok(uuid);
+    assert.deepEqual(uuid._bytes, bytes);
+  });
+
+  it('static random constructor', () => {
+    let uuid = rclnodejs.ActionUuid.random();
+    assert.ok(uuid);
+    assert.ok(uuid._bytes instanceof Uint8Array);
+  });
+
+  it('static fromBytes() constructor', () => {
+    let bytes = Uint8Array.from([0, 1]);
+    let uuid = rclnodejs.ActionUuid.fromBytes(bytes);
+    assert.ok(uuid);
+    assert.deepEqual(uuid._bytes, bytes);
+  });
+
+  it('bytes getter', () => {
+    let bytes = Uint8Array.from([0, 1]);
+    let uuid = new rclnodejs.ActionUuid(bytes);
+    assert.ok(uuid);
+    assert.deepEqual(uuid.bytes, bytes);
+  });
+
+  it('toString', () => {
+    let bytes = Uint8Array.from([0, 1]);
+    let uuid = new rclnodejs.ActionUuid(bytes);
+    assert.ok(uuid);
+    assert.equal(uuid.toString(), '0,1');
+  });
+
+  it('no duplicates', () => {
+    let uuid1 = new rclnodejs.ActionUuid();
+    let uuid2 = new rclnodejs.ActionUuid();
+    assert.notDeepEqual(uuid1.bytes, uuid2.bytes);
+  });
+
+  it('toMsg', () => {
+    let uuid = new rclnodejs.ActionUuid();
+    let msg = uuid.toMessage();
+    assert.ok(msg);
+    assert.deepEqual(uuid._bytes, msg.uuid);
+  });
+
+  it('fromMsg', () => {
+    let uuid1 = new rclnodejs.ActionUuid();
+    let msg = uuid1.toMessage();
+    let uuid2 = rclnodejs.ActionUuid.fromMessage(msg);
+
+    assert.ok(uuid2);
+    assert.deepEqual(uuid1.bytes, uuid2.bytes);
+  });
+});

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -56,6 +56,9 @@ nodeOptions.parameterOverrides;
 // $ExpectType Node
 const node = rclnodejs.createNode(NODE_NAME);
 
+// $ExpectType Node
+const node1 = new rclnodejs.Node(NODE_NAME + '1');
+
 // $ExpectType string
 node.name();
 
@@ -114,6 +117,20 @@ const lifecycleNode = rclnodejs.createLifecycleNode(LIFECYCLE_NODE_NAME);
 // $ExpectType LifecycleNode
 const lifecycleNode1 = rclnodejs.createLifecycleNode(
   LIFECYCLE_NODE_NAME + '1',
+  undefined,
+  undefined,
+  undefined,
+  true
+);
+
+// $ExpectType LifecycleNode
+const lifecycleNode2 = new rclnodejs.lifecycle.LifecycleNode(
+  LIFECYCLE_NODE_NAME
+);
+
+// $ExpectType LifecycleNode
+const lifecycleNode3 = new rclnodejs.lifecycle.LifecycleNode(
+  LIFECYCLE_NODE_NAME + '3',
   undefined,
   undefined,
   undefined,
@@ -573,3 +590,25 @@ function executeCallback(
 
   return new Fibonacci.Result();
 }
+
+// ---- ActionUuid -----
+// $ExpectType ActionUuid
+const actionUuid = new rclnodejs.ActionUuid();
+
+// $ExpectType ActionUuid
+const actionUuid1 = rclnodejs.ActionUuid.random();
+
+// $ExpectType ActionUuid
+const actionUuid2 = rclnodejs.ActionUuid.fromBytes(new Uint8Array([21, 31]));
+
+// $ExpectType string
+actionUuid.toString();
+
+// $ExpectType Uint8Array
+actionUuid.bytes;
+
+// $ExpectType UUID
+actionUuid.toMessage();
+
+// $ExpectType UUID
+rclnodejs.ActionUuid.randomMessage();

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -454,13 +454,13 @@ logger.fatal('test msg');
 // f64arr.data;
 
 // $ExpectType FibonacciConstructor
-const Fibonacci = rclnodejs.require('test_msgs/action/Fibonacci');
+const Fibonacci = rclnodejs.require('example_interfaces/action/Fibonacci');
 
 // ---- ActionClient -----
-// $ExpectType ActionClient<"test_msgs/action/Fibonacci">
+// $ExpectType ActionClient<"example_interfaces/action/Fibonacci">
 const actionClient = new rclnodejs.ActionClient(
   node,
-  'test_msgs/action/Fibonacci',
+  'example_interfaces/action/Fibonacci',
   'fibonnaci'
 );
 
@@ -473,7 +473,7 @@ actionClient.waitForServer();
 // $ExpectType void
 actionClient.destroy();
 
-// $ExpectType Promise<ClientGoalHandle<"test_msgs/action/Fibonacci">>
+// $ExpectType Promise<ClientGoalHandle<"example_interfaces/action/Fibonacci">>
 const goalHandlePromise = actionClient.sendGoal(new Fibonacci.Goal());
 
 goalHandlePromise.then((goalHandle) => {
@@ -515,10 +515,10 @@ goalHandlePromise.then((goalHandle) => {
 });
 
 // ---- ActionServer -----
-// $ExpectType ActionServer<"test_msgs/action/Fibonacci">
+// $ExpectType ActionServer<"example_interfaces/action/Fibonacci">
 const actionServer = new rclnodejs.ActionServer(
   node,
-  'test_msgs/action/Fibonacci',
+  'example_interfaces/action/Fibonacci',
   'fibonnaci',
   executeCallback
 );
@@ -539,7 +539,7 @@ actionServer.registerExecuteCallback(() => new Fibonacci.Result());
 actionServer.destroy();
 
 function executeCallback(
-  goalHandle: rclnodejs.ServerGoalHandle<'test_msgs/action/Fibonacci'>
+  goalHandle: rclnodejs.ServerGoalHandle<'example_interfaces/action/Fibonacci'>
 ) {
   // $ExpectType UUID
   goalHandle.goalId;

--- a/types/action_server.d.ts
+++ b/types/action_server.d.ts
@@ -84,7 +84,9 @@ declare module 'rclnodejs' {
   type HandleAcceptedCallback<T extends TypeClass<ActionTypeClassName>> = (
     goalHandle: ServerGoalHandle<T>
   ) => void;
-  type CancelCallback = () => Promise<CancelResponse> | CancelResponse;
+  type CancelCallback<T extends TypeClass<ActionTypeClassName>> = (
+    goalHandle?: ServerGoalHandle<T>
+  ) => Promise<CancelResponse> | CancelResponse;
 
   interface ActionServerOptions extends Options<ActionQoS> {
     /**
@@ -116,7 +118,7 @@ declare module 'rclnodejs' {
       executeCallback: ExecuteCallback<T>,
       goalCallback?: GoalCallback<T>,
       handleAcceptedCallback?: HandleAcceptedCallback<T>,
-      cancelCallback?: CancelCallback,
+      cancelCallback?: CancelCallback<T>,
       options?: ActionServerOptions
     );
 
@@ -153,14 +155,14 @@ declare module 'rclnodejs' {
      *
      * The purpose of the cancel callback is to decide if a request to cancel an on-going
      * (or queued) goal should be accepted or rejected.
-     * The callback should take one parameter containing the cancel request and must return a
+     * The callback should take one parameter containing the cancel request ( a GoalHandle) and must return a
      * {@link CancelResponse} value.
      *
      * There can only be one cancel callback per {@link ActionServer}, therefore calling this
      * function will replace any previously registered callback.
      * @param cancelCallback - Callback function, if not provided, then unregisters any previously registered callback.
      */
-    registerCancelCallback(cancelCallback?: CancelCallback): void;
+    registerCancelCallback(cancelCallback?: CancelCallback<T>): void;
 
     /**
      * Register a callback for executing action goals.

--- a/types/action_uuid.d.ts
+++ b/types/action_uuid.d.ts
@@ -1,0 +1,58 @@
+declare module 'rclnodejs' {
+  /**
+   * @class - Represents a unique identifier used by actions.
+   * @ignore
+   */
+
+  export class ActionUuid {
+    /**
+     * Creates a new instance of ActionUuid.
+     * @param bytes - The bytes to create the UUID from.
+     *                A new random UUID will be created, if not provided.
+     */
+    constructor(bytes?: Uint8Array);
+
+    /**
+     * Creates a new {@link ActionUuid} from the given bytes.
+     * @param bytes - The bytes to create the UUID from.
+     * @returns The new UUID.
+     */
+    static fromBytes(byte: Uint8Array): ActionUuid;
+
+    /**
+     * Creates a new random {@link ActionUuid}.
+     * @returns The new UUID.
+     */
+    static random(): ActionUuid;
+
+    /**
+     * Gets the bytes from the UUID.
+     */
+    get bytes(): Uint8Array;
+
+    /**
+     * Returns the UUID as a string.
+     * @returns String representation of the UUID.
+     */
+    toString(): string;
+
+    /**
+     * Create an instance from a ROS2 UUID message
+     * @param msg - The ROS2 UUID message
+     * @returns The new instance.
+     */
+    static fromMessage(msg: unique_identifier_msgs.msg.UUID): ActionUuid;
+
+    /**
+     * Create a ROS2 UUID message from this instance.
+     * @returns The new ROS2 UUID message
+     */
+    toMessage(): unique_identifier_msgs.msg.UUID;
+
+    /**
+     * Create a ROS2 UUID message with random uuid data
+     * @returns The new instance.
+     */
+    static randomMessage(): unique_identifier_msgs.msg.UUID;
+  }
+}

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -1,6 +1,7 @@
 /* eslint-disable spaced-comment */
 /// <reference path="action_client.d.ts" />
 /// <reference path="action_server.d.ts" />
+/// <reference path="action_uuid.d.ts" />
 /// <reference path="client.d.ts" />
 /// <reference path="clock_type.d.ts" />
 /// <reference path="clock.d.ts" />


### PR DESCRIPTION
While working with rclnodejs actions I found myself copy-paste code for working with UUIDs in client-side goals. Rather than repeat this pattern multiple times I decided to update and externalize the ActionUuid found in lib/action/uuid.js for general use.

Changes:
* Add action_uuid.d.ts - typings for ActionUuid
* Updated uuid.js - adds ROS2 UUID convenience methods
* Add test-action-uuid.js - tests for ActionUuid
* Update test-action-client.js - replaced internal uuid code with ActionUuid. 
* Updated dtslint main.ts - added TypeScript type tests for ActionUuid

Fix #870