### PR TITLE
Added overload method declarations for node

### DIFF
--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -193,19 +193,24 @@ lifecyclePublisher.isActivated();
 
 // ---- Subscription ----
 // $ExpectType Subscription
-const subscription = node.createSubscription(
-  TYPE_CLASS,
-  TOPIC,
-  {},
-  (msg) => {}
-);
+let subscription = node.createSubscription(TYPE_CLASS, TOPIC, (msg) => {});
+
+// $ExpectType Subscription
+subscription = node.createSubscription(TYPE_CLASS, TOPIC, {}, (msg) => {});
 
 // $ExpectType string
 subscription.topic;
 
 // ---- Service ----
 // $ExpectType AddTwoIntsConstructor
-const service = node.createService(
+let service = node.createService(
+  'example_interfaces/srv/AddTwoInts',
+  'add_two_ints',
+  (request, response) => {}
+);
+
+// $ExpectType AddTwoIntsConstructor
+service = node.createService(
   'example_interfaces/srv/AddTwoInts',
   'add_two_ints',
   {},

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -253,6 +253,21 @@ declare module 'rclnodejs' {
      *
      * @param typeClass - Type of ROS messages the subscription will subscribe to
      * @param topic - Name of the topic the subcription will subscribe to.
+     * @param callback - Called when a new message is received.
+     *                   The serialized message will be null-terminated.
+     * @returns New instance of Subscription.
+     */
+    createSubscription<T extends TypeClass<MessageTypeClassName>>(
+      typeClass: T,
+      topic: string,
+      callback: SubscriptionCallback<T>
+    ): Subscription;
+
+    /**
+     * Create a Subscription.
+     *
+     * @param typeClass - Type of ROS messages the subscription will subscribe to
+     * @param topic - Name of the topic the subcription will subscribe to.
      * @param options - Configuration options, see DEFAULT_OPTIONS
      * @param callback - Called when a new message is received. The serialized message will be null-terminated.
      * @returns New instance of Subscription.
@@ -277,6 +292,20 @@ declare module 'rclnodejs' {
       serviceName: string,
       options?: Options
     ): Client<T>;
+
+    /**
+     * Create a Service.
+     *
+     * @param typeClass - Service type
+     * @param serviceName - Name of the service.
+     * @param callback - Callback function for notification of incoming requests.
+     * @returns An instance of Service.
+     */
+    createService<T extends TypeClass<ServiceTypeClassName>>(
+      typeClass: T,
+      serviceName: string,
+      callback: ServiceRequestHandler<T>
+    ): ServiceType<T>;
 
     /**
      * Create a Service.


### PR DESCRIPTION
Adds overloaded declarations that omit the `options` parameter for methods:
```
Node.createSubscription()
Node.createService()
```

Fix #873