### PR TITLE
Update node.js

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1293,7 +1293,7 @@ class Node extends rclnodejs.ShadowNode {
    * @return {ParameterDescriptor[]} - The parameter descriptors.
    */
   getParameterDescriptors(names = []) {
-    const descriptors = [];
+    let descriptors = [];
 
     if (names.length == 0) {
       // get all parameters


### PR DESCRIPTION
use let instead of const to fix `Cannot assign to "descriptors" because it is a constant` during bundling

