### PR TITLE
Custom filter for omitting ROS2 interfaces from the message-generation process

### DIFF
--- a/.github/workflows/windows-build-and-test-compatibility.yml
+++ b/.github/workflows/windows-build-and-test-compatibility.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.X, 12.X, 14.X, 16.11.X, 17.X, 18.X, 19.X]
+        node-version: [10.X, 12.X, 14.X, 16.11.X, 17.X, 18.12.X, 19.X]
         ros_distribution:
           # - foxy
           - galactic

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.X, 12.X, 14.X, 16.11.X, 17.X, 18.X, 19.X]
+        node-version: [10.X, 12.X, 14.X, 16.11.X, 17.X, 18.12.0, 19.X]
     steps:
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2

--- a/rosidl_gen/blocklist.json
+++ b/rosidl_gen/blocklist.json
@@ -1,0 +1,5 @@
+[
+  {
+    "pkgName": "rosbag2_storage_mcap_testdata"
+  }
+]

--- a/rosidl_gen/filter.js
+++ b/rosidl_gen/filter.js
@@ -1,0 +1,104 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// blocklist.json format
+//  [
+//    {
+//      pkgName: RegExString,
+//      interfaceName: RegExString,
+//      os: RegExString
+//    },
+//    ...
+//  ]
+//
+// examples
+//  [
+//    {
+//      "pkgName": "action*"
+//    },
+//    {
+//      "pkgName": "std_msgs",
+//    },
+//    {
+//      "pkgName": "std_msgs",
+//      "interfaceName": "String"
+//    },
+//    {
+//      "os": "Linux"
+//    },
+//  ]
+
+const RosPackageFilters = {
+  filters: [],
+  _loaded: false,
+
+  addFilter: function (pkgName, interfaceName, os) {
+    this.filters.push({
+      pkgName: pkgName,
+      interfaceName: interfaceName,
+      os: os,
+    });
+  },
+
+  _matches: function (filter, pkgInfo) {
+    if (filter.os && filter.os.test(os.type())) {
+      return true;
+    }
+
+    if (filter.pkgName) {
+      if (filter.pkgName.test(pkgInfo.pkgName)) {
+        if (!filter.interfaceName) {
+          return true;
+        }
+      } else {
+        return false;
+      }
+    }
+
+    if (
+      filter.interfaceName &&
+      filter.interfaceName.test(pkgInfo.interfaceName)
+    ) {
+      return true;
+    }
+
+    return false;
+  },
+
+  load: function (
+    blocklistPath = path.join(__dirname, '../rosidl_gen/blocklist.json')
+  ) {
+    this._loaded = true;
+
+    if (!fs.existsSync(blocklistPath)) return;
+
+    // eslint-disable-next-line
+    let blocklistData = JSON.parse(fs.readFileSync(blocklistPath, 'utf8'));
+
+    let filters = blocklistData.map((pkgFilterData) => {
+      let filter = {};
+      if (pkgFilterData['pkgName']) {
+        filter.pkgName = new RegExp(pkgFilterData.pkgName);
+      }
+      if (pkgFilterData['interfaceName']) {
+        filter.interfaceName = new RegExp(pkgFilterData.interfaceName);
+      }
+      if (pkgFilterData['os']) {
+        filter.os = new RegExp(pkgFilterData.os);
+      }
+      return filter;
+    });
+
+    this.filters = filters.filter(
+      (filter) => !filter.os || filter.os.test(os.type())
+    );
+  },
+
+  matchesAny: function (pkgInfo) {
+    if (!this._loaded) this.load();
+    return this.filters.some((filter) => this._matches(filter, pkgInfo));
+  },
+};
+
+module.exports = RosPackageFilters;

--- a/rosidl_gen/index.js
+++ b/rosidl_gen/index.js
@@ -26,7 +26,9 @@ const installedPackagePaths = process.env.AMENT_PREFIX_PATH.split(
 
 async function generateInPath(path) {
   const pkgs = await packages.findPackagesInDirectory(path);
+
   const pkgsInfo = Array.from(pkgs.values());
+
   await Promise.all(
     pkgsInfo.map((pkgInfo) => generateJSStructFromIDL(pkgInfo, generatedRoot))
   );
@@ -42,6 +44,7 @@ async function generateAll(forcedGenerating) {
       path.join(__dirname, 'generator.json'),
       path.join(generatedRoot, 'generator.json')
     );
+
     await Promise.all(
       installedPackagePaths.map((path) => generateInPath(path))
     );

--- a/rostsd_gen/index.js
+++ b/rostsd_gen/index.js
@@ -31,6 +31,7 @@ declare module "rclnodejs" {
 const path = require('path');
 const fs = require('fs');
 const loader = require('../lib/interface_loader.js');
+const pkgFilters = require('../rosidl_gen/filter.js');
 
 async function generateAll() {
   // load pkg and interface info (msgs and srvs)
@@ -63,7 +64,14 @@ function getPkgInfos(rootDir) {
 
     for (let filename of files) {
       const typeClass = fileName2Typeclass(filename);
-      if (!typeClass.type) continue;
+      if (
+        !typeClass.type ||
+        pkgFilters.matchesAny({
+          pkgName: typeClass.package,
+          interfaceName: typeClass.name,
+        })
+      )
+        continue;
 
       const rosInterface = loader.loadInterface(typeClass);
 


### PR DESCRIPTION
In response to the the blocking issue #890, I've introduced a simple mechanism for filtering ros2 interfaces out of the message generation process. The mechanism reads and external blocklist.json file containing filters that are used by `rosidl_gen/package.js` to determine which ROS2 interface files to excluded during the message-generation process. The user is informed of the ROS interfaces that are omitted with a `console.log` message. 

An ideal solution to #890 is to generate javascript message files from idl files. This will take some time during which we are blocked. This mechanism provides a quick work-around. And we can always disable this feature by removing the `rosidl_gen/blocklist.json` file in the future.
 
Also I switched the windows workflows to use node 18.12.0 in place of 18.13.0. There is a repeatable issue with node-gyp configuration on node 18.13. It seems to be related to the node cache. Switching to 18.12 avoids using a cached version of node 18 and the issue no longer occurs.

Fix #890
