### PR TITLE
Fixes error undefined, throw error instead

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -70,8 +70,9 @@ class Client extends Entity {
       this._sequenceNumberToCallbackMap.delete(sequenceNumber);
       callback(response.toPlainObject(this.typedArrayEnabled));
     } else {
-      error(`Client has received an unexpected ${this._serviceName}
-             response with sequence number ${sequenceNumber}.`);
+      throw new Error(
+        `Client has received an unexpected ${this._serviceName} with sequence number ${sequenceNumber}.`
+      );
     }
   }
 


### PR DESCRIPTION
**Public API Changes**
Throw an error instead of node crash


**Description**
Since the error method is undefined, prefer to throw a clean error


Related to #894 
