### PR TITLE
Fix CFT test suite fail

### DIFF
--- a/test/test-subscription-content-filter.js
+++ b/test/test-subscription-content-filter.js
@@ -254,14 +254,14 @@ describe('subscription content-filtering', function () {
         expression: 'data = 5',
       };
       subscription.setContentFilter(contentFilter5);
-    }, 500);
+    }, TIME1);
 
     setTimeout(() => {
       publisher1.kill('SIGINT');
       publisher2.kill('SIGINT');
       assert.ok(!fail && msgCnt5 && !msgCnt0);
       done();
-    }, 1000);
+    }, TIME2);
 
     node.spin();
   });
@@ -385,7 +385,7 @@ describe('subscription content-filtering', function () {
       publisher.kill('SIGINT');
       assert.ok(msgCnt > 0);
       done();
-    }, 2000);
+    }, TIME1);
 
     node.spin(node);
   });


### PR DESCRIPTION
CI frequently fails due to what I believe are timing challenges between various timers and child-processes. This PR extends the timing intervals for the setContentFilter test-case in test-subscription-content-filter.js which I've seen fail periodically.
