### PR TITLE
Fix raw msg processing bug

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -185,7 +185,7 @@ class Node extends rclnodejs.ShadowNode {
         if (rawMessage) {
           subscription.processResponse(rawMessage);
         }
-        return;
+        continue;
       }
 
       this._runWithMessageType(


### PR DESCRIPTION
This PR replaces a premature `return` statement in `node#execute()` with a `continue` statement when processing raw messages.

Note: CI build may fail on windows atm due to a change in rcl include file dependencies that will be updated in a separate PR #913.

Fix #911
