### PR TITLE
[Iron] Add the iron release into distro.js

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -88,6 +88,7 @@
                     "<!@(node -e \"console.log(process.env.AMENT_PREFIX_PATH.replace(/:/g, '/include/rcl_lifecycle/ ') + '/include/rcl_lifecycle/')\")",
                     "<!@(node -e \"console.log(process.env.AMENT_PREFIX_PATH.replace(/:/g, '/include/lifecycle_msgs/ ') + '/include/lifecycle_msgs/')\")",
                     "<!@(node -e \"console.log(process.env.AMENT_PREFIX_PATH.replace(/:/g, '/include/rosidl_runtime_c/ ') + '/include/rosidl_runtime_c/')\")",
+                    "<!@(node -e \"console.log(process.env.AMENT_PREFIX_PATH.replace(/:/g, '/include/rosidl_dynamic_typesupport/ ') + '/include/rosidl_dynamic_typesupport/')\")",
                   ],
                 }
               ],

--- a/lib/distro.js
+++ b/lib/distro.js
@@ -23,6 +23,7 @@ const DistroId = {
   FOXY: 2006,
   GALACTIC: 2105,
   HUMBLE: 2205,
+  IRON: 2305,
   ROLLING: 5000,
 };
 
@@ -31,6 +32,7 @@ DistroNameIdMap.set('eloquent', DistroId.ELOQUENT);
 DistroNameIdMap.set('foxy', DistroId.FOXY);
 DistroNameIdMap.set('galactic', DistroId.GALACTIC);
 DistroNameIdMap.set('humble', DistroId.HUMBLE);
+DistroNameIdMap.set('iron', DistroId.IRON);
 DistroNameIdMap.set('rolling', DistroId.ROLLING);
 
 const DistroUtils = {

--- a/test/test-distro.js
+++ b/test/test-distro.js
@@ -17,7 +17,7 @@ describe('rclnodejs distro utils', function () {
     );
     assert.equal(
       distroNames.length,
-      5,
+      6,
       'Incorrect number of known distro names'
     );
 


### PR DESCRIPTION
This patch adds the iron release into distro.js and updates the unit test accordingly.

Fix: #919
