### PR TITLE
Fix crashing on Electron > 21

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,6 +9,7 @@
   },
   'variables': {
     'ros_version': '<!(node scripts/ros_distro.js)',
+    'runtime%': 'node',
   },
   'targets': [
     {
@@ -174,7 +175,10 @@
               '-lrosidl_runtime_c'
             ]
           }
-        ]
+        ],
+        ['runtime=="electron"', {
+          "defines": ["NODE_RUNTIME_ELECTRON=1"]
+        }],
       ]
     }
   ]


### PR DESCRIPTION
Since Electron 21, the V8 sandboxed pointers was enabled, which disables creating a new BackingStore and taking over an external memory block. Instead, we must copy the data into a newly-allocated memory that is inside V8 memory cage.

See more details: https://www.electronjs.org/blog/v8-memory-cage

This patch fixed the crashing when running on Electron > 21.

**Testing**

1. Electron v25.0.1 with Iron
 
   - Automated test: `electron --expose-gc ./scripts/run_test.js`
   - Manually tested: `electron example/subscription-message-example.js` & `node example/publisher-message-example.js`

 2. Nodejs v18.16.0 with Iron
 
    - Automated test: `npm test`

Fix #864