### PR TITLE
Fix wrong clock message type

### DIFF
--- a/lib/time_source.js
+++ b/lib/time_source.js
@@ -176,7 +176,7 @@ class TimeSource {
   }
 
   _clockCallback(msg) {
-    this._lastTimeSet = Time.fromMsg(msg);
+    this._lastTimeSet = Time.fromMsg(msg.clock);
     this._associatedClocks.forEach((clock) => {
       clock.rosTimeOverride = this._lastTimeSet;
     });
@@ -185,7 +185,7 @@ class TimeSource {
   _subscribeToClockTopic() {
     if (!this._clockSubscription && this._node) {
       this._clockSubscription = this._node.createSubscription(
-        'builtin_interfaces/msg/Time',
+        'rosgraph_msgs/msg/Clock',
         CLOCK_TOPIC,
         this._clockCallback.bind(this)
       );

--- a/test/test-time-source.js
+++ b/test/test-time-source.js
@@ -45,10 +45,10 @@ describe('rclnodejs TimeSource testing', function () {
   });
 
   function publishClockMessage(node) {
-    let pub = node.createPublisher('builtin_interfaces/msg/Time', '/clock');
+    let pub = node.createPublisher('rosgraph_msgs/msg/Clock', '/clock');
     let count = 0;
     timer = setInterval(() => {
-      pub.publish({ sec: count, nanosec: 0 });
+      pub.publish({ clock: { sec: count, nanosec: 0 } });
       count += 1;
     }, 1000);
   }


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Changes the subscription type on `/clock` from `builtin_interfaces/msg/Time` to `rosgraph_msgs/msg/Clock`.


https://github.com/RobotWebTools/rclnodejs/issues/927
