### PR TITLE
[CI] Stop running test by dtslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "postinstall": "npm run generate-messages",
     "docs": "cd docs && make",
     "test": "node --expose-gc ./scripts/run_test.js && npm run dtslint",
-    "dtslint": "node scripts/generate_tsd.js && dtslint test/types",
+    "dtslint": "node scripts/generate_tsd.js",
     "lint": "eslint --max-warnings=0 --ext js,ts index.js types scripts lib example rosidl_gen rosidl_parser test benchmark/rclnodejs && node ./scripts/cpplint.js",
     "format": "clang-format -i -style=file ./src/*.cpp ./src/*.hpp && prettier --write \"{lib,rosidl_gen,rostsd_gen,rosidl_parser,types,example,test,scripts,benchmark}/**/*.{js,md,ts}\" ./*.{js,md,ts}"
   },


### PR DESCRIPTION
This patch stops running `dtslint test/types`, because `dtslint` being deprecated and not supporting Node 20.
