### PR TITLE
typeclass check

### DIFF
--- a/rostsd_gen/index.js
+++ b/rostsd_gen/index.js
@@ -64,6 +64,7 @@ function getPkgInfos(rootDir) {
 
     for (let filename of files) {
       const typeClass = fileName2Typeclass(filename);
+      if (typeClass.type !== 'srv' && typeClass.type !== 'action' && typeClass.type !== 'msg') continue;
       if (
         !typeClass.type ||
         pkgFilters.matchesAny({


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Fixes described issue:
https://github.com/RobotWebTools/rclnodejs/issues/955

For now, it looks like this package does not support a custom folder scheme like the "srvs" folder in slam-toolbox. That's why i propose this temporary solution.
