### PR TITLE
Pass the subfolder of the service event location

### DIFF
--- a/rosidl_gen/idl_generator.js
+++ b/rosidl_gen/idl_generator.js
@@ -92,6 +92,9 @@ async function generateServiceEventMsg(serviceInfo, dir) {
 
 async function generateServiceEventJSStruct(msgInfo, dir) {
   const spec = await parser.parseMessageFile(msgInfo.pkgName, msgInfo.filePath);
+  // Pass `msgInfo.subFolder` to the `spec`, because some .srv files of the
+  // package may not be put under srv/ folder, e.g., slam_toolbox.
+  spec.subFolder = msgInfo.subFolder;
 
   // Remove the `.msg` files generated in `generateServiceEventMsg()` to avoid
   // being found later.

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -198,7 +198,7 @@ function getModulePathByType(type, messageInfo) {
 
   /* We should use '__msg__' to require "service_msgs/msg/ServiceEventInfo.msg" for service event message. */
   if (messageInfo && messageInfo.isServiceEvent && (type.type !== 'ServiceEventInfo')) {
-    return type.pkgName + '__srv__' + type.type + '.js';
+    return type.pkgName + `__${it.spec.subFolder}__` + type.type + '.js';
   }
   return type.pkgName + '__msg__' + type.type + '.js';
 }


### PR DESCRIPTION
Per current implementation, when constructing the service event JavaScript file, we suppose the subfolder of the service event is "srv", but some package, e.g., slam_toolbox, the .srv files are put under `srvs/` folder, so when requiring the service event,
slam_toolbox__srvs__AddSubmap_Event.js, it will imports the requst file, which is slam_toolbox__srv__AddSubmap_Request.js, and lead to an error.

This patch passes the subfolder to the spec when creating the service event JS file, so it can require the request/response files by a correct file name.

Fix: #955