### PR TITLE
Add Jazzy support for Github actions

### DIFF
--- a/.github/workflows/identify-ros-distro.yml
+++ b/.github/workflows/identify-ros-distro.yml
@@ -11,10 +11,9 @@ on:
         value: ${{ jobs.identify-ros-distro.outputs.linuxos }}
 env:
   ROLLING_VAR: ${{ contains(github.ref, 'develop') }}
+  JAZZY_VAR: ${{ contains(github.ref, 'jazzy') }}
   IRON_VAR: ${{ contains(github.ref, 'iron') }}
   HUMBLE_VAR: ${{ contains(github.ref, 'humble') }}
-  GALACTIC_VAR: ${{ contains(github.ref, 'galactic') }}
-  FOXY_VAR: ${{ contains(github.ref, 'foxy') }}
 
 jobs:
   identify-ros-distro:
@@ -28,21 +27,18 @@ jobs:
         run: |
           if ${ROLLING_VAR} == true; then
             echo "::set-output name=distro::rolling"
-            echo "::set-output name=linuxos::ubuntu-22.04"
+            echo "::set-output name=linuxos::ubuntu-24.04"
+          elif ${JAZZY_VAR} == true; then
+            echo "::set-output name=distro::jazzy"
+            echo "::set-output name=linuxos::ubuntu-24.04"
           elif ${IRON_VAR} == true; then
             echo "::set-output name=distro::iron"
             echo "::set-output name=linuxos::ubuntu-22.04"
           elif ${HUMBLE_VAR} == true; then
             echo "::set-output name=distro::humble"
             echo "::set-output name=linuxos::ubuntu-22.04"
-          elif ${GALACTIC_VAR} == true; then
-            echo "::set-output name=distro::galactic"
-            echo "::set-output name=linuxos::ubuntu-20.04"
-          elif ${FOXY_VAR} == true; then
-            echo "::set-output name=distro::foxy"
-            echo "::set-output name=linuxos::ubuntu-20.04"
           else
             echo "Unable to map branch name to ROS distro, using ROLLING as default"
             echo "::set-output name=distro::rolling"
-            echo "::set-output name=linuxos::ubuntu-22.04"
+            echo "::set-output name=linuxos::ubuntu-24.04"
           fi

--- a/.github/workflows/linux-build-and-test-compatibility.yml
+++ b/.github/workflows/linux-build-and-test-compatibility.yml
@@ -11,23 +11,24 @@ jobs:
       matrix:
         node-version: [18.X, 20.X]
         ros_distribution:
+          - jazzy
           - iron
           - humble
           - rolling
 
     steps:
     - name: Setup ROS2
-      uses: ros-tooling/setup-ros@v0.7
+      uses: ros-tooling/setup-ros@0.7.6
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
 
     - name: Install test-msgs on Linux
       run: |
         sudo apt install ros-${{ matrix.ros_distribution }}-test-msgs
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -5,17 +5,15 @@ on:
   push:
     branches:
       - develop
+      - jazzy
       - iron-irwini
       - humble-hawksbill
-      - galactic-geochelone
-      - foxy-fitzroy
   pull_request:
     branches:
       - develop
+      - jazzy
       - iron-irwini
       - humble-hawksbill
-      - galactic-geochelone
-      - foxy-fitzroy
   workflow_dispatch:
 
 jobs:
@@ -31,12 +29,12 @@ jobs:
         node-version: [18.X, 20.X]
     steps:
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 
     - name: Setup ROS2
-      uses: ros-tooling/setup-ros@v0.7
+      uses: ros-tooling/setup-ros@0.7.6
       with:
         required-ros-distributions: ${{ needs.identify-ros-distro.outputs.distro }}
 

--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -16,6 +16,10 @@ on:
       - humble-hawksbill
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   identify-ros-distro:
     uses: ./.github/workflows/identify-ros-distro.yml
@@ -23,6 +27,8 @@ jobs:
   build:
     needs: identify-ros-distro
     runs-on: ${{ needs.identify-ros-distro.outputs.linuxos }}
+    container:
+      image: osrf/ros:${{ needs.identify-ros-distro.outputs.distro }}-desktop
     strategy:
       fail-fast: false
       matrix:
@@ -35,8 +41,6 @@ jobs:
 
     - name: Setup ROS2
       uses: ros-tooling/setup-ros@0.7.6
-      with:
-        required-ros-distributions: ${{ needs.identify-ros-distro.outputs.distro }}
 
     - name: Install test-msgs on Linux
       run: |

--- a/.github/workflows/windows-build-and-test-compatibility.yml
+++ b/.github/workflows/windows-build-and-test-compatibility.yml
@@ -12,17 +12,18 @@ jobs:
       matrix:
         node-version: [18.16.0, 20.X]
         ros_distribution:
+          - jazzy
           - iron
           - humble
           - rolling
     steps:
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 
     - name: Setup ROS2
-      uses: ros-tooling/setup-ros@v0.7
+      uses: ros-tooling/setup-ros@0.7.6
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
 
@@ -36,7 +37,7 @@ jobs:
     - name: Prebuild - Setup VS Dev Environment
       uses: seanmiddleditch/gha-setup-vsdevenv@v4
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Build rclnodejs
       shell: cmd

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -5,17 +5,15 @@ on:
   push:
     branches:
       - develop
+      - jazzy
       - iron-irwini
       - humble-hawksbill
-      - galactic-geochelone
-      - foxy-fitzroy
   pull_request:
     branches:
       - develop
+      - jazzy
       - iron-irwini
       - humble-hawksbill
-      - galactic-geochelone
-      - foxy-fitzroy
   workflow_dispatch:
 
 jobs:
@@ -33,12 +31,12 @@ jobs:
         node-version: [18.16.0, 20.X]
     steps:
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 
     - name: Setup ROS2
-      uses: ros-tooling/setup-ros@v0.7
+      uses: ros-tooling/setup-ros@0.7.6
       with:
         required-ros-distributions: ${{ needs.identify-ros-distro.outputs.distro }}
 
@@ -52,7 +50,7 @@ jobs:
     - name: Prebuild - Setup VS Dev Environment
       uses: seanmiddleditch/gha-setup-vsdevenv@v4
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Build rclnodejs
       shell: cmd


### PR DESCRIPTION
This patch:

1. Add the Jazzy support into actions.
2. Remove the support of the following ROS2 releases:
    - galactic
    - foxy
3. Upgrade the followings:
    - setup-node => v4.0.2
    - setup-ros => v0.7.6
    - checkout => v4.1.6

Meanwhile, this patch starts to leverage [osrf/ros](https://hub.docker.com/r/osrf/ros/) image to build/test `rclnodejs` package.
Fix: #965