### PR TITLE
Add nodejs 22.x as latest LTS

### DIFF
--- a/.github/workflows/linux-build-and-test-compatibility.yml
+++ b/.github/workflows/linux-build-and-test-compatibility.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.X, 20.X]
+        node-version: [20.X, 22.X]
         ros_distribution:
           - jazzy
           - iron

--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.X, 20.X]
+        node-version: [20.X, 22.X]
     steps:
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4.0.3

--- a/.github/workflows/windows-build-and-test-compatibility.yml
+++ b/.github/workflows/windows-build-and-test-compatibility.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.16.0, 20.X]
+        node-version: [22.X]
         ros_distribution:
           - jazzy
           - iron

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -26,9 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Explicit node versions are used to workaround an error
-        # where node-gyp fails due to some silly cacheing
-        node-version: [18.16.0, 20.X]
+        node-version: [22.X]
     steps:
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4.0.3


### PR DESCRIPTION
This patch:

1. Remove 18.x from actions.
2. Add latest 22.x into actions.

Fix: #998