### PR TITLE
Adapt C++20

### DIFF
--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.X, 22.X]
+        node-version: [20.X, 22.X, 23.X]
     steps:
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4

--- a/binding.gyp
+++ b/binding.gyp
@@ -60,7 +60,7 @@
               'OS_LINUX'
             ],
             'cflags_cc': [
-              '-std=c++17'
+              '-std=c++20'
             ],
             'include_dirs': 
             [
@@ -104,7 +104,7 @@
               'OS_WINDOWS'
             ],
             'cflags_cc': [
-              '-std=c++17'
+              '-std=c++20'
             ],
             'include_dirs': [
               './src/third_party/dlfcn-win32/',


### PR DESCRIPTION
Currently, we adapt C++17 to compile the C++ addon, but nodejs 23.X needs C++20 to develop addon, this patch:

1. Adapt C++20 for Windows & Linux platforms, keeping macOS as C++17.
2. Add checking for nodejs 23.X into actions for Linux platform.