### PR TITLE
[TypeScript] Add declaration for removeSignalHandlers()

### DIFF
--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -21,6 +21,9 @@ rclnodejs.isShutdown();
 // $ExpectType void
 rclnodejs.shutdown();
 
+// $ExpectType void
+rclnodejs.removeSignalHandlers();
+
 // ---- DistroUtil ----
 
 // $ExpectType DistroId

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -145,6 +145,13 @@ declare module 'rclnodejs' {
   ): MessageType<T>;
 
   /**
+   * Removes the default signal handler installed by rclnodejs. After calling this, rclnodejs
+   * will no longer clean itself up when a SIGINT is received, it is the application's
+   * responsibility to properly shut down all nodes and contexts.
+   */
+  function removeSignalHandlers(): void;
+
+  /**
    * Get a list of action names and types for action clients associated with a node.
    * @param node - The node used for discovery.
    * @param nodeName - The name of a remote node to get action clients for.


### PR DESCRIPTION
This patch adds the declaration for `removeSignalHandlers()` method into index.d.ts.

Fix: #1022