### PR TITLE
Add types to ParameterService

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1274,6 +1274,26 @@ class Node extends rclnodejs.ShadowNode {
   }
 
   /**
+   * Get the types of given parameters.
+   *
+   * Return the types of given parameters.
+   *
+   * @param {string[]} [names] - The names of the declared parameters.
+   * @return {Uint8Array} - The types.
+   */
+  getParameterTypes(names = []) {
+    let types = [];
+
+    for (const name of names) {
+      const descriptor = this._parameterDescriptors.get(name);
+      if (descriptor) {
+        types.push(descriptor.type);
+      }
+    }
+    return types;
+  }
+
+  /**
    * Get the names of all declared parameters.
    *
    * @return {Array<string>} - The declared parameter names or empty array if

--- a/lib/parameter_service.js
+++ b/lib/parameter_service.js
@@ -110,6 +110,16 @@ class ParameterService {
       }
     );
 
+    // Create GetParameterTypes service.
+    const getParameterTypesServiceName = nodeName + '/get_parameter_types';
+    this._node.createService(
+      'rcl_interfaces/srv/GetParameterTypes',
+      getParameterTypesServiceName,
+      (request, response) => {
+        this._handleGetParameterTypes(request, response);
+      }
+    );
+
     // create SetParametersAtomically service
     const setParametersAtomicallyServiceName =
       nodeName + '/set_parameters_atomically';
@@ -263,6 +273,23 @@ class ParameterService {
 
     const msg = response.template;
     msg.results = this._node.setParameters(parameters);
+    response.send(msg);
+  }
+
+  /**
+   * Get a list of parameter types.
+   *
+   * request.names identifies the parameter types to get.
+   *
+   * @param {GetParameterTypes_Request} request - The client request.
+   * @param {GetParameterTypes_Response} response - The service response with
+   *    Uint8Array.
+   * @return {undefined} -
+   */
+  _handleGetParameterTypes(request, response) {
+    const types = this._node.getParameterTypes(request.names);
+    const msg = response.template;
+    msg.types = types;
     response.send(msg);
   }
 

--- a/test/test-extra-destroy-methods.js
+++ b/test/test-extra-destroy-methods.js
@@ -93,7 +93,7 @@ describe('Node extra destroy methods testing', function () {
     const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
     // const AddTwoInts = rclnodejs.require('example_interfaces/srv/AddTwoInts');
     var service = node.createService(AddTwoInts, 'add_two_ints', () => {});
-    assert.deepStrictEqual(node._services.length, 6);
+    assert.deepStrictEqual(node._services.length, 7);
 
     assertThrowsError(
       function () {

--- a/test/test-extra-destroy-methods.js
+++ b/test/test-extra-destroy-methods.js
@@ -105,7 +105,7 @@ describe('Node extra destroy methods testing', function () {
     );
 
     node.destroyService(service);
-    assert.deepStrictEqual(node._services.length, 5);
+    assert.deepStrictEqual(node._services.length, 6);
   });
 
   it('destroyTimer()', function () {

--- a/test/test-parameter-service.js
+++ b/test/test-parameter-service.js
@@ -367,4 +367,34 @@ describe('Parameter_server tests', function () {
       `Expected 3 parameter-events, received ${eventCount} events.`
     );
   });
+
+  it('Get_parameter_types', async function () {
+    const client = clientNode.createClient(
+      'rcl_interfaces/srv/GetParameterTypes',
+      'test_node/get_parameter_types'
+    );
+    await client.waitForService();
+
+    const ParamTypes = rclnodejs.require('rcl_interfaces/msg/ParameterType');
+    const request = new (rclnodejs.require(
+      'rcl_interfaces/srv/GetParameterTypes'
+    ).Request)();
+    request.names = ['p1', 'p2', 'A.p3'];
+    let success = false;
+
+    client.sendRequest(request, (response) => {
+      assert.deepEqual(response.types.length, 3);
+      assert.deepEqual(
+        response.types,
+        Uint8Array.from([
+          ParamTypes.PARAMETER_STRING,
+          ParamTypes.PARAMETER_INTEGER,
+          ParamTypes.PARAMETER_BOOL,
+        ])
+      );
+      success = true;
+    });
+    await assertUtils.createDelay(STD_WAIT);
+    assert.ok(success);
+  });
 });


### PR DESCRIPTION
Since ROS2 Jazzy, parameter services support a service type of `rcl_interfaces/srv/GetParameterTypes`, which can get a list of parameter types associated with the requested parameters.

This patch implements:

1. Add service `/node_name/get_parameters`, which is used to get the parameter types.
2. Add unit test, `Get_parameter_types`, into test-parameter-service.js.

Meanwhile, this patch fixes the timeout issue when executing:
```bash
ros2 param list node_name
```
Due to absence of `/node_name/get_parameters` service.

**Reference**

[1] https://docs.ros.org/en/jazzy/Concepts/Basic/About-Parameters.html
[2] https://docs.ros.org/en/jazzy/How-To-Guides/Using-ros2-param.html

Fix: #1024
