### PR TITLE
[TypeScript] Provide two types of callback for a subscription

### DIFF
--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -243,7 +243,7 @@ subscription = node.createSubscription(
   TOPIC,
   { isRaw: false },
   (message: rclnodejs.std_msgs.msg.String) => {
-    const receivedMessage: rclnodejs.std_msgs.msg.String = message;
+    const receivedMessage = message;
   }
 );
 
@@ -253,7 +253,7 @@ subscription = node.createSubscription(
   TOPIC,
   { isRaw: true },
   (message: Buffer) => {
-    const receivedRawMessage: Buffer = message;
+    const receivedRawMessage = message;
   }
 );
 

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -237,6 +237,26 @@ subscription = node.createSubscription(
   (msg) => {}
 );
 
+// $ExpectType Subscription
+subscription = node.createSubscription(
+  TYPE_CLASS,
+  TOPIC,
+  { isRaw: false },
+  (message: rclnodejs.std_msgs.msg.String) => {
+    const receivedMessage: rclnodejs.std_msgs.msg.String = message;
+  }
+);
+
+// $ExpectType Subscription receiving raw message
+subscription = node.createSubscription(
+  TYPE_CLASS,
+  TOPIC,
+  { isRaw: true },
+  (message: Buffer) => {
+    const receivedRawMessage: Buffer = message;
+  }
+);
+
 // $ExpectType string
 subscription.topic;
 

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -324,7 +324,7 @@ declare module 'rclnodejs' {
       typeClass: T,
       topic: string,
       options: Options,
-      callback: SubscriptionCallback<T>
+      callback: SubscriptionCallback<T> | SubscriptionWithRawMessageCallback
     ): Subscription;
 
     /**

--- a/types/subscription.d.ts
+++ b/types/subscription.d.ts
@@ -13,7 +13,23 @@ declare module 'rclnodejs' {
    */
   type SubscriptionCallback<T extends TypeClass<MessageTypeClassName>> =
     // * @param message - The published message
-    (message: MessageType<T> | Buffer) => void;
+    (message: MessageType<T>) => void;
+
+  /**
+   * A callback for receiving published raw messages.
+   *
+   * @param message - The published message.
+   *
+   * @remarks
+   * See {@link Node#createSubscription | Node.createSubscription}
+   * See {@link SubscriptionContentFilter}
+   * See {@link Node#createPublisher | Node.createPublisher}
+   * See {@link Publisher}
+   * See {@link Subscription}
+   */
+  type SubscriptionWithRawMessageCallback =
+    // * @param message - The published raw message
+    (message: Buffer) => void;
 
   /**
    * A ROS Subscription for published messages on a topic.


### PR DESCRIPTION
Currently, the type of callback for a subscription is defined as:
```ts
type SubscriptionCallback<T extends TypeClass<MessageTypeClassName>> =
  (message: MessageType<T> | Buffer) => void
```
which causes a type error when pass a callback either for a normal message or raw message.

This patch provides two types of callback for a subscription, which are:

1. For a normal message
```ts
type SubscriptionCallback<T extends TypeClass<MessageTypeClassName>> =
  (message: MessageType<T>) => void;
``` 

2. For a raw message:
```ts
type SubscriptionWithRawMessageCallback =
  (message: Buffer) => void;
```

After this patch, we can use the correct callback type for a subscription, like:
```ts
subscription = node.createSubscription(
  TYPE_CLASS,
  TOPIC,
  { isRaw: true },
  (message: Buffer) => {
    const receivedRawMessage = message;
  }
);
```

Fix: #1013 