### PR TITLE
Change timer period to type of bigint in nanoseconds

### DIFF
--- a/example/action-client-cancel-example.js
+++ b/example/action-client-cancel-example.js
@@ -49,7 +49,7 @@ class FibonacciActionClient {
     this._node.getLogger().info('Goal accepted');
 
     // Start a 2 second timer
-    this._timer = this._node.createTimer(2000, () =>
+    this._timer = this._node.createTimer(BigInt(2000000), () =>
       this.timerCallback(goalHandle)
     );
   }

--- a/example/action-server-defer-example.js
+++ b/example/action-server-defer-example.js
@@ -83,7 +83,9 @@ class FibonacciActionServer {
   handleAcceptedCallback(goalHandle) {
     this._node.getLogger().info('Deferring execution...');
     this._goalHandle = goalHandle;
-    this._timer = this._node.createTimer(3000, () => this.timerCallback());
+    this._timer = this._node.createTimer(BigInt(3000000), () =>
+      this.timerCallback()
+    );
   }
 
   cancelCallback(goalHandle) {

--- a/example/lifecycle-node-example.js
+++ b/example/lifecycle-node-example.js
@@ -88,7 +88,7 @@ class App {
   onActivate() {
     console.log('Lifecycle: ACTIVATE');
     this._publisher.activate();
-    this._timer = this._node.createTimer(1000, () => {
+    this._timer = this._node.createTimer(BigInt(1000000), () => {
       this._publisher.publish(`${this._count--}`);
     });
     return rclnodejs.lifecycle.CallbackReturnCode.SUCCESS;

--- a/example/lifecycle-node-example.js
+++ b/example/lifecycle-node-example.js
@@ -88,7 +88,7 @@ class App {
   onActivate() {
     console.log('Lifecycle: ACTIVATE');
     this._publisher.activate();
-    this._timer = this._node.createTimer(BigInt(1000000), () => {
+    this._timer = this._node.createTimer(BigInt('1000000000'), () => {
       this._publisher.publish(`${this._count--}`);
     });
     return rclnodejs.lifecycle.CallbackReturnCode.SUCCESS;

--- a/example/timer-example.js
+++ b/example/timer-example.js
@@ -21,7 +21,7 @@ rclnodejs
   .then(() => {
     let node = rclnodejs.createNode('timer_example_node');
 
-    let timer = node.createTimer(1000, () => {
+    let timer = node.createTimer(BigInt(1000000), () => {
       console.log('One second escaped!');
 
       console.log('Cancel this timer.');

--- a/lib/node.js
+++ b/lib/node.js
@@ -507,7 +507,7 @@ class Node extends rclnodejs.ShadowNode {
 
   /**
    * Create a Timer.
-   * @param {number} period - The number representing period in millisecond.
+   * @param {bigint} period - The number representing period in nanoseconds.
    * @param {function} callback - The callback to be called when timeout.
    * @param {Clock} [clock] - The clock which the timer gets time from.
    * @return {Timer} - An instance of Timer.
@@ -519,22 +519,11 @@ class Node extends rclnodejs.ShadowNode {
       clock = arguments[3];
     }
 
-    if (typeof period !== 'number' || typeof callback !== 'function') {
+    if (typeof period !== 'bigint' || typeof callback !== 'function') {
       throw new TypeError('Invalid argument');
     }
 
-    // The period unit is millisecond in JavaScript side. When being passed to the
-    // C++ side, the value will be converted to nanosecond, which goes into a uint64_t
-    // with maxmium value of 2^64-1. So the maxmium is UINT64_MAX in ns, that's 0x10c6f7a0b5ed in ms.
-    const MAX_TIMER_PERIOD_IN_MILLISECOND = 0x10c6f7a0b5ed;
-    if (period > 0x10c6f7a0b5ed || period < 0) {
-      throw new RangeError(
-        `Parameter must be between 0.0 and ${MAX_TIMER_PERIOD_IN_MILLISECOND}`
-      );
-    }
-
     const timerClock = clock || this._clock;
-
     let timerHandle = rclnodejs.createTimer(
       timerClock.handle,
       this.context.handle,
@@ -573,7 +562,7 @@ class Node extends rclnodejs.ShadowNode {
     }
 
     const period = Math.round(1000 / hz);
-    const timer = this._rateTimerServer.createTimer(period);
+    const timer = this._rateTimerServer.createTimer(BigInt(period) * 1000000n);
     const rate = new Rates.Rate(hz, timer);
 
     return rate;

--- a/lib/rate.js
+++ b/lib/rate.js
@@ -166,7 +166,7 @@ class RateTimerServer {
   /**
    * Create a new timer instance with callback set to NOP.
    *
-   * @param {number} period - The period in milliseconds
+   * @param {bigint} period - The period in nanoseconds.
    * @returns {Timer} - The new timer instance.
    */
   createTimer(period) {

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -29,7 +29,7 @@ class Timer {
   }
 
   /**
-   * @type {number}
+   * @type {bigint} - The period of the timer in nanoseconds.
    */
   get period() {
     return this._period;
@@ -73,18 +73,18 @@ class Timer {
 
   /**
    * Get the interval since the last call of this timer.
-   * @return {number} - the interval value - ms.
+   * @return {bigint} - the interval value in nanoseconds.
    */
   timeSinceLastCall() {
-    return parseInt(rclnodejs.timerGetTimeSinceLastCall(this._handle), 10);
+    return rclnodejs.timerGetTimeSinceLastCall(this._handle);
   }
 
   /**
    * Get the interval until the next call will happen.
-   * @return {number} - the interval value - ms.
+   * @return {bigint} - the interval value in nanoseconds.
    */
   timeUntilNextCall() {
-    return parseInt(rclnodejs.timerGetTimeUntilNextCall(this._handle), 10);
+    return rclnodejs.timerGetTimeUntilNextCall(this._handle);
   }
 }
 

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -319,8 +319,12 @@ NAN_METHOD(CreateTimer) {
       Nan::To<v8::Object>(info[1]).ToLocalChecked());
   rcl_context_t* context =
       reinterpret_cast<rcl_context_t*>(context_handle->ptr());
-  int64_t period_ms = Nan::To<int64_t>(info[2]).FromJust();
-
+  if (!info[2]->IsBigInt()) {
+    Nan::ThrowTypeError("Timer period must be a BigInt");
+    return;
+  }
+  v8::Local<v8::BigInt> bigInt = info[2].As<v8::BigInt>();
+  int64_t period_nsec = bigInt->Int64Value();
   rcl_timer_t* timer =
       reinterpret_cast<rcl_timer_t*>(malloc(sizeof(rcl_timer_t)));
   *timer = rcl_get_zero_initialized_timer();
@@ -328,15 +332,14 @@ NAN_METHOD(CreateTimer) {
 #if ROS_VERSION > 2305  // After Iron.
   THROW_ERROR_IF_NOT_EQUAL(
       RCL_RET_OK,
-      rcl_timer_init2(timer, clock, context, RCL_MS_TO_NS(period_ms), nullptr,
+      rcl_timer_init2(timer, clock, context, period_nsec, nullptr,
                       rcl_get_default_allocator(), /*autostart=*/true),
       rcl_get_error_string().str);
 #else
-  THROW_ERROR_IF_NOT_EQUAL(
-      RCL_RET_OK,
-      rcl_timer_init(timer, clock, context, RCL_MS_TO_NS(period_ms), nullptr,
-                     rcl_get_default_allocator()),
-      rcl_get_error_string().str);
+  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
+                           rcl_timer_init(timer, clock, context, period_nsec,
+                                          nullptr, rcl_get_default_allocator()),
+                           rcl_get_error_string().str);
 #endif
 
   auto js_obj = RclHandle::NewInstance(timer, clock_handle, [](void* ptr) {
@@ -410,9 +413,9 @@ NAN_METHOD(TimerGetTimeUntilNextCall) {
       RCL_RET_OK, rcl_timer_get_time_until_next_call(timer, &remaining_time),
       rcl_get_error_string().str);
 
-  info.GetReturnValue().Set(
-      Nan::New<v8::String>(std::to_string(RCL_NS_TO_MS(remaining_time)))
-          .ToLocalChecked());
+  v8::Local<v8::BigInt> bigInt =
+      v8::BigInt::New(v8::Isolate::GetCurrent(), remaining_time);
+  info.GetReturnValue().Set(bigInt);
 }
 
 NAN_METHOD(TimerGetTimeSinceLastCall) {
@@ -425,9 +428,9 @@ NAN_METHOD(TimerGetTimeSinceLastCall) {
       RCL_RET_OK, rcl_timer_get_time_since_last_call(timer, &elapsed_time),
       rcl_get_error_string().str);
 
-  info.GetReturnValue().Set(
-      Nan::New<v8::String>(std::to_string(RCL_NS_TO_MS(elapsed_time)))
-          .ToLocalChecked());
+  v8::Local<v8::BigInt> bigInt =
+      v8::BigInt::New(v8::Isolate::GetCurrent(), elapsed_time);
+  info.GetReturnValue().Set(bigInt);
 }
 
 NAN_METHOD(CreateTimePoint) {

--- a/test/publisher_array_setup.js
+++ b/test/publisher_array_setup.js
@@ -39,7 +39,7 @@ rclnodejs
       effort: [4, 5, 6],
     };
 
-    var timer = node.createTimer(100, () => {
+    var timer = node.createTimer(BigInt('100000000'), () => {
       publisher.publish(state);
     });
     rclnodejs.spin(node);

--- a/test/publisher_msg.js
+++ b/test/publisher_msg.js
@@ -32,7 +32,7 @@ rclnodejs
     msg.data = rclValue;
 
     var publisher = node.createPublisher(msgType, rclType + '_channel');
-    var timer = node.createTimer(100, () => {
+    var timer = node.createTimer(BigInt('100000000'), () => {
       publisher.publish(msg);
     });
 

--- a/test/publisher_msg_colorrgba.js
+++ b/test/publisher_msg_colorrgba.js
@@ -29,7 +29,7 @@ rclnodejs
     };
 
     var publisher = node.createPublisher(ColorRGBA, 'ColorRGBA_channel');
-    var timer = node.createTimer(100, () => {
+    var timer = node.createTimer(BigInt('100000000'), () => {
       publisher.publish(msg);
     });
 

--- a/test/publisher_msg_header.js
+++ b/test/publisher_msg_header.js
@@ -33,7 +33,7 @@ rclnodejs
     };
 
     var publisher = node.createPublisher(Header, 'Header_channel');
-    var timer = node.createTimer(100, () => {
+    var timer = node.createTimer(BigInt('100000000'), () => {
       publisher.publish(header);
     });
 

--- a/test/publisher_msg_jointstate.js
+++ b/test/publisher_msg_jointstate.js
@@ -39,7 +39,7 @@ rclnodejs
     };
 
     var publisher = node.createPublisher(JointState, 'JointState_channel');
-    var timer = node.createTimer(100, () => {
+    var timer = node.createTimer(BigInt('100000000'), () => {
       publisher.publish(state);
     });
 

--- a/test/publisher_setup.js
+++ b/test/publisher_setup.js
@@ -25,7 +25,7 @@ rclnodejs
     const msg = 'Greeting from publisher';
 
     var publisher = node.createPublisher(RclString, 'topic');
-    var timer = node.createTimer(100, () => {
+    var timer = node.createTimer(BigInt('100000000'), () => {
       publisher.publish(msg);
     });
     rclnodejs.spin(node);

--- a/test/test-destruction.js
+++ b/test/test-destruction.js
@@ -61,8 +61,8 @@ describe('Node & Entity destroy testing', function () {
     var defaultServicesCount = node._services.length;
 
     // timers
-    var timer1 = node.createTimer(0.1, () => {});
-    var timer2 = node.createTimer(1, () => {});
+    var timer1 = node.createTimer(BigInt(1000), () => {});
+    var timer2 = node.createTimer(BigInt(100), () => {});
     assert.deepStrictEqual(2, node._timers.length);
     node.destroyTimer(timer1);
     assert.deepStrictEqual(1, node._timers.length);
@@ -129,7 +129,7 @@ describe('Node & Entity destroy testing', function () {
     var node = rclnodejs.createNode('my_node7');
 
     // timers
-    var timer = node.createTimer(0.1, () => {});
+    var timer = node.createTimer(BigInt(100), () => {});
     node.destroyTimer(timer);
     node.destroyTimer(timer);
 

--- a/test/test-existance.js
+++ b/test/test-existance.js
@@ -246,7 +246,7 @@ describe('rclnodejs class existance testing', function () {
 
     before(function () {
       node = rclnodejs.createNode('Timer');
-      timer = node.createTimer(10, () => {});
+      timer = node.createTimer(BigInt(10000), () => {});
     });
 
     after(function () {
@@ -255,8 +255,8 @@ describe('rclnodejs class existance testing', function () {
     });
 
     it('period property should exist', function () {
-      assertMember('period', timer, timer.period, 'number');
-      assert.deepStrictEqual(timer.period, 10);
+      assertMember('period', timer, timer.period, 'bigint');
+      assert.deepStrictEqual(timer.period, BigInt(10000));
     });
 
     it('cancel method should exist', function () {

--- a/test/test-extra-destroy-methods.js
+++ b/test/test-extra-destroy-methods.js
@@ -110,7 +110,7 @@ describe('Node extra destroy methods testing', function () {
 
   it('destroyTimer()', function () {
     var node = rclnodejs.createNode('node5');
-    var timer = node.createTimer(1000, () => {});
+    var timer = node.createTimer(BigInt(1000000), () => {});
     assert.deepStrictEqual(node._timers.length, 1);
 
     assertThrowsError(

--- a/test/test-msg-type-cpp-node.js
+++ b/test/test-msg-type-cpp-node.js
@@ -58,7 +58,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
         }
       );
 
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -82,7 +82,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
         }
       );
 
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -106,7 +106,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
         }
       );
 
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -130,7 +130,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
         }
       );
 
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -155,7 +155,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
         }
       );
 
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -179,7 +179,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
         }
       );
 
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -203,7 +203,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
         }
       );
 
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -227,7 +227,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -251,7 +251,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
         }
       );
 
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -274,7 +274,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -297,7 +297,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -321,7 +321,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -344,7 +344,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -367,7 +367,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -402,7 +402,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
         }
       );
 
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -441,7 +441,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -472,7 +472,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
         }
       );
 
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -512,7 +512,7 @@ describe('Rclnodejs - Cpp message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);

--- a/test/test-msg-type-py-node.js
+++ b/test/test-msg-type-py-node.js
@@ -58,7 +58,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -86,7 +86,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -114,7 +114,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -142,7 +142,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -170,7 +170,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -198,7 +198,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -226,7 +226,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -254,7 +254,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -282,7 +282,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -310,7 +310,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -338,7 +338,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -366,7 +366,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -394,7 +394,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -422,7 +422,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -470,7 +470,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -506,7 +506,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -541,7 +541,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);
@@ -585,7 +585,7 @@ describe('Rclnodejs - Python message type testing', function () {
           done();
         }
       );
-      var timer = node.createTimer(100, () => {
+      var timer = node.createTimer(BigInt(100000), () => {
         publisher.publish(msg);
       });
       rclnodejs.spin(node);

--- a/test/test-promise-gc.js
+++ b/test/test-promise-gc.js
@@ -76,7 +76,9 @@ describe('Test promise wrapper with garbage collection', function () {
       const topic = `promise_gc_channel_${i}`;
 
       const publisher = node.createPublisher(typeClass, topic);
-      const timer = node.createTimer(100, () => publisher.publish(msg));
+      const timer = node.createTimer(BigInt(100000), () =>
+        publisher.publish(msg)
+      );
 
       const result = await new Promise((res) =>
         node.createSubscription(typeClass, topic, (msg) => {

--- a/test/test-security-related.js
+++ b/test/test-security-related.js
@@ -142,7 +142,7 @@ describe('Destroying non-existent objects testing', function () {
     );
 
     var count = 0;
-    var timer = node.createTimer(100, () => {
+    var timer = node.createTimer(BigInt(100000), () => {
       count++;
     });
     node.destroyTimer(timer);
@@ -232,7 +232,7 @@ describe('Fuzzing API calls testing', function () {
     var node = rclnodejs.createNode('node3', '/inconsistent');
     const invalidParams = [
       ['100', () => {}],
-      [100, null],
+      [BigInt(100), null],
     ];
     invalidParams.forEach((param) => {
       assertThrowsError(

--- a/test/test-security-related.js
+++ b/test/test-security-related.js
@@ -232,7 +232,7 @@ describe('Fuzzing API calls testing', function () {
     var node = rclnodejs.createNode('node3', '/inconsistent');
     const invalidParams = [
       ['100', () => {}],
-      [BigInt(100), null],
+      [BigInt('100000000'), null],
     ];
     invalidParams.forEach((param) => {
       assertThrowsError(

--- a/test/test-service-with-async-callback.js
+++ b/test/test-service-with-async-callback.js
@@ -55,7 +55,7 @@ describe('Test creating a service with an async callback', function () {
     var client = clientNode.createClient(AddTwoInts, 'single_ps_channel2');
     const request = { a: 1n, b: 2n };
 
-    var timer = clientNode.createTimer(100, () => {
+    var timer = clientNode.createTimer(BigInt(100000000), () => {
       client.sendRequest(request, (response) => {
         timer.cancel();
         assert.deepStrictEqual(response.sum, 3n);

--- a/test/test-signals.js
+++ b/test/test-signals.js
@@ -27,7 +27,7 @@ function forkDoPublish(context) {
     .then(() => {
       const node = rclnodejs.createNode('test_pub', undefined, context);
       const publisher = node.createPublisher('std_msgs/msg/String', 'test');
-      node.createTimer(100, () => {
+      node.createTimer(BigInt(100000), () => {
         publisher.publish({ data: 'hello' });
       });
       rclnodejs.spin(node);

--- a/test/test-single-process.js
+++ b/test/test-single-process.js
@@ -50,7 +50,7 @@ describe('Test rclnodejs nodes in a single process', function () {
       RclString,
       'single_ps_channel1'
     );
-    var timer = publisherNode.createTimer(100, () => {
+    var timer = publisherNode.createTimer(BigInt(100000000), () => {
       publisher.publish(msg);
     });
     rclnodejs.spin(subscriptionNode);
@@ -75,7 +75,7 @@ describe('Test rclnodejs nodes in a single process', function () {
     );
 
     var publisher = node.createPublisher(RclString, 'new_style_require1');
-    var timer = node.createTimer(100, () => {
+    var timer = node.createTimer(BigInt(100000000), () => {
       publisher.publish(msg);
     });
 
@@ -101,7 +101,7 @@ describe('Test rclnodejs nodes in a single process', function () {
     var client = clientNode.createClient(AddTwoInts, 'single_ps_channel2');
     const request = { a: 1n, b: 2n };
 
-    var timer = clientNode.createTimer(100, () => {
+    var timer = clientNode.createTimer(BigInt(100000000), () => {
       client.sendRequest(request, (response) => {
         timer.cancel();
         assert.deepStrictEqual(response.sum, 3n);
@@ -133,7 +133,7 @@ describe('Test rclnodejs nodes in a single process', function () {
     var client = clientNode.createClient(AddTwoInts, 'single_ps_channel2_2');
     const request = { a: 1n, b: 2n };
 
-    var timer = clientNode.createTimer(100, () => {
+    var timer = clientNode.createTimer(BigInt(100000000), () => {
       client.sendRequest(request, (response) => {
         timer.cancel();
         assert.deepStrictEqual(response.sum, 3n);
@@ -163,7 +163,7 @@ describe('Test rclnodejs nodes in a single process', function () {
     var client = clientNode.createClient(AddTwoInts, 'single_ps_channel2_3');
     const request = { a: 1n, b: 2n };
 
-    var timer = clientNode.createTimer(100, () => {
+    var timer = clientNode.createTimer(BigInt(100000000), () => {
       client.sendRequest(request, (response) => {
         timer.cancel();
         assert.deepStrictEqual(response.sum, 3n);
@@ -196,7 +196,7 @@ describe('Test rclnodejs nodes in a single process', function () {
     request.a = 1n;
     request.b = 2n;
 
-    var timer = node.createTimer(100, () => {
+    var timer = node.createTimer(BigInt(100000000), () => {
       client.sendRequest(request, (response) => {
         timer.cancel();
         assert.deepStrictEqual(response.sum, 3n);

--- a/test/test-timer.js
+++ b/test/test-timer.js
@@ -59,7 +59,7 @@ describe('rclnodejs Timer class testing', function () {
         assert.deepEqual(timer.period, TIMER_INTERVAL);
         assert.throws(
           () => {
-            timer.period = TIMER_INTERVAL * 2;
+            timer.period = TIMER_INTERVAL * 2n;
           },
           function (err) {
             if (

--- a/test/test-timer.js
+++ b/test/test-timer.js
@@ -17,7 +17,7 @@
 const assert = require('assert');
 const rclnodejs = require('../index.js');
 
-const TIMER_INTERVAL = Math.pow(10, 2);
+const TIMER_INTERVAL = '100000000';
 describe('rclnodejs Timer class testing', function () {
   this.timeout(60 * 1000);
 
@@ -33,7 +33,7 @@ describe('rclnodejs Timer class testing', function () {
     it('node.createTimer', function (done) {
       var times = 0;
       var node = rclnodejs.createNode('timer');
-      var timer = node.createTimer(TIMER_INTERVAL, function () {
+      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
         times += 1;
         timer.cancel();
         node.destroy();
@@ -55,7 +55,7 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.period should be readonly', function (done) {
-      var timer = node.createTimer(TIMER_INTERVAL, function () {
+      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
         assert.deepEqual(timer.period, TIMER_INTERVAL);
         assert.throws(
           () => {
@@ -79,7 +79,7 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.cancel', function (done) {
-      var timer = node.createTimer(TIMER_INTERVAL, function () {
+      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
         timer.cancel();
         assert.ok(timer.isCanceled());
         done();
@@ -88,7 +88,7 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.isCanceled', function (done) {
-      var timer = node.createTimer(TIMER_INTERVAL, function () {
+      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
         assert.ok(!timer.isCanceled());
         timer.cancel();
         assert.ok(timer.isCanceled());
@@ -98,7 +98,7 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.isReady', function (done) {
-      var timer = node.createTimer(TIMER_INTERVAL, function () {
+      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
         assert.ok(!timer.isReady());
         timer.cancel();
         done();
@@ -107,7 +107,7 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.reset', function (done) {
-      var timer = node.createTimer(TIMER_INTERVAL, function () {
+      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
         timer.cancel();
         done();
       });
@@ -119,8 +119,8 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.timeSinceLastCall', function (done) {
-      var timer = node.createTimer(TIMER_INTERVAL, function () {
-        assert.deepStrictEqual(typeof timer.timeSinceLastCall(), 'number');
+      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
+        assert.deepStrictEqual(typeof timer.timeSinceLastCall(), 'bigint');
         timer.cancel();
         done();
       });
@@ -128,9 +128,9 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.timeUntilNextCall', function (done) {
-      var timer = node.createTimer(TIMER_INTERVAL, function () {
+      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
         var nextCallInterval = timer.timeUntilNextCall();
-        assert.deepStrictEqual(typeof nextCallInterval, 'number');
+        assert.deepStrictEqual(typeof nextCallInterval, 'bigint');
         assert.ok(nextCallInterval <= TIMER_INTERVAL);
         timer.cancel();
         done();

--- a/test/test-timer.js
+++ b/test/test-timer.js
@@ -17,7 +17,7 @@
 const assert = require('assert');
 const rclnodejs = require('../index.js');
 
-const TIMER_INTERVAL = '100000000';
+const TIMER_INTERVAL = BigInt('100000000');
 describe('rclnodejs Timer class testing', function () {
   this.timeout(60 * 1000);
 
@@ -33,7 +33,7 @@ describe('rclnodejs Timer class testing', function () {
     it('node.createTimer', function (done) {
       var times = 0;
       var node = rclnodejs.createNode('timer');
-      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
+      var timer = node.createTimer(TIMER_INTERVAL, function () {
         times += 1;
         timer.cancel();
         node.destroy();
@@ -55,7 +55,7 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.period should be readonly', function (done) {
-      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
+      var timer = node.createTimer(TIMER_INTERVAL, function () {
         assert.deepEqual(timer.period, TIMER_INTERVAL);
         assert.throws(
           () => {
@@ -79,7 +79,7 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.cancel', function (done) {
-      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
+      var timer = node.createTimer(TIMER_INTERVAL, function () {
         timer.cancel();
         assert.ok(timer.isCanceled());
         done();
@@ -88,7 +88,7 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.isCanceled', function (done) {
-      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
+      var timer = node.createTimer(TIMER_INTERVAL, function () {
         assert.ok(!timer.isCanceled());
         timer.cancel();
         assert.ok(timer.isCanceled());
@@ -98,7 +98,7 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.isReady', function (done) {
-      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
+      var timer = node.createTimer(TIMER_INTERVAL, function () {
         assert.ok(!timer.isReady());
         timer.cancel();
         done();
@@ -107,7 +107,7 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.reset', function (done) {
-      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
+      var timer = node.createTimer(TIMER_INTERVAL, function () {
         timer.cancel();
         done();
       });
@@ -119,7 +119,7 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.timeSinceLastCall', function (done) {
-      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
+      var timer = node.createTimer(TIMER_INTERVAL, function () {
         assert.deepStrictEqual(typeof timer.timeSinceLastCall(), 'bigint');
         timer.cancel();
         done();
@@ -128,7 +128,7 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.timeUntilNextCall', function (done) {
-      var timer = node.createTimer(BigInt(TIMER_INTERVAL), function () {
+      var timer = node.createTimer(TIMER_INTERVAL, function () {
         var nextCallInterval = timer.timeUntilNextCall();
         assert.deepStrictEqual(typeof nextCallInterval, 'bigint');
         assert.ok(nextCallInterval <= TIMER_INTERVAL);

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -324,7 +324,7 @@ client.isDestroyed();
 const timerCallback = () => {};
 
 // $ExpectType Timer
-const timer = node.createTimer(100, timerCallback);
+const timer = node.createTimer(BigInt(100000), timerCallback);
 
 // $ExpectType number
 timer.period;

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -267,7 +267,7 @@ declare module 'rclnodejs' {
      * @returns New instance of Timer.
      */
     createTimer(
-      period: number,
+      period: bigint,
       callback: TimerRequestCallback,
       clock?: Clock
     ): Timer;


### PR DESCRIPTION
Per current implementation, the timer period is in milliseconds, because the range limitation of integer that JavaScript can [represents](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). While, after [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) introduced, we can change the timer period to type of `bigint` in nanoseconds, which aligns with other ROS2 clients, like `rclpy`.

This patch implements:

1. Change the timer period to type of `bigint` in nanoseconds for JavaScript side.
2. Get the period from `v8::BigInt` object as `int64_t` and pass it to `rcl` from C++ side.
3. Update the related unit tests accordingly.

Fix: #1037
