### PR TITLE
Leverage BigInt for Time/Duration

### DIFF
--- a/lib/action/server.js
+++ b/lib/action/server.js
@@ -266,10 +266,12 @@ class ActionServer extends Entity {
     let goalHandle;
     if (accepted) {
       // Stamp time of acceptance
-      const secondsAndNanos = this._node.getClock().now().secondsAndNanoseconds;
+      const { seconds, nanoseconds } = this._node
+        .getClock()
+        .now().secondsAndNanoseconds;
       goalInfo.stamp = {
-        sec: Number(secondsAndNanos.seconds),
-        nanosec: Number(secondsAndNanos.nanoseconds),
+        sec: Number(seconds),
+        nanosec: Number(nanoseconds),
       };
 
       try {

--- a/lib/action/server.js
+++ b/lib/action/server.js
@@ -268,8 +268,8 @@ class ActionServer extends Entity {
       // Stamp time of acceptance
       const secondsAndNanos = this._node.getClock().now().secondsAndNanoseconds;
       goalInfo.stamp = {
-        sec: secondsAndNanos.seconds,
-        nanosec: secondsAndNanos.nanoseconds,
+        sec: Number(secondsAndNanos.seconds),
+        nanosec: Number(secondsAndNanos.nanoseconds),
       };
 
       try {

--- a/lib/clock.js
+++ b/lib/clock.js
@@ -52,8 +52,8 @@ class Clock {
    * @return {Time} Return the current time.
    */
   now() {
-    const nowNanosec = rclnodejs.clockGetNow(this._handle);
-    return new Time(0n, nowNanosec, this._clockType);
+    const nowInNanosec = rclnodejs.clockGetNow(this._handle);
+    return new Time(0n, nowInNanosec, this._clockType);
   }
 }
 

--- a/lib/clock.js
+++ b/lib/clock.js
@@ -52,8 +52,8 @@ class Clock {
    * @return {Time} Return the current time.
    */
   now() {
-    let time = rclnodejs.clockGetNow(this._handle);
-    return new Time(time.sec, time.nanosec, this._clockType);
+    const nowNanosec = rclnodejs.clockGetNow(this._handle);
+    return new Time(0n, nowNanosec, this._clockType);
   }
 }
 

--- a/lib/duration.js
+++ b/lib/duration.js
@@ -65,7 +65,7 @@ class Duration {
    */
   eq(other) {
     if (other instanceof Duration) {
-      return this._nanoseconds == other.nanoseconds;
+      return this._nanoseconds === other.nanoseconds;
     }
     throw new TypeError(
       `Can't compare duration with object of type: ${other.constructor.name}`

--- a/lib/duration.js
+++ b/lib/duration.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const rclnodejs = require('bindings')('rclnodejs');
-const int64 = require('int64-napi');
+const S_TO_NS = 10n ** 9n;
 
 /**
  * @class - Class representing a Duration in ROS
@@ -24,51 +24,38 @@ const int64 = require('int64-napi');
 class Duration {
   /**
    * Create a Duration.
-   * @param {number|string} [seconds=0] - The second part of the duration.
-   * @param {number|string} [nanoseconds=0] - The nanosecond part of the duration.
+   * @param {bigint} [seconds=0] - The second part of the duration.
+   * @param {bigint} [nanoseconds=0] - The nanosecond part of the duration.
    */
-  constructor(seconds = 0, nanoseconds = 0) {
-    if (typeof seconds !== 'number' && typeof seconds !== 'string') {
+  constructor(seconds = 0n, nanoseconds = 0n) {
+    if (typeof seconds !== 'bigint') {
       throw new TypeError('Invalid argument of seconds');
     }
 
-    if (typeof nanoseconds !== 'number' && typeof nanoseconds !== 'string') {
+    if (typeof nanoseconds !== 'bigint') {
       throw new TypeError('Invalid argument of nanoseconds');
     }
 
-    let secondInt64 = int64.from(seconds);
-    let nanoInt64 = int64.from(nanoseconds);
+    const total = seconds * S_TO_NS + nanoseconds;
+    if (total >= 2n ** 63n) {
+      throw new RangeError(
+        'Total nanoseconds value is too large to store in C time point.'
+      );
+    }
 
-    if (typeof seconds === 'string' && seconds.startsWith('-')) {
-      secondInt64 = int64.negative(secondInt64);
-    }
-    if (typeof nanoseconds === 'string' && nanoseconds.startsWith('-')) {
-      nanoInt64 = int64.negative(nanoInt64);
-    }
-    this._nanoseconds = secondInt64.multiply(1e9).add(nanoInt64);
-    this._handle = rclnodejs.createDuration(this._nanoseconds.toString());
+    this._nanoseconds = total;
+    this._handle = rclnodejs.createDuration(this._nanoseconds);
   }
 
   /**
    * Get the nanosecond part of the Duration.
    * @name Duration#get:nanoseconds
    * @function
-   * @return {number|string} - value in nanosecond, if the value is greater than Number.MAX_SAFE_INTEGER (2^53-1), will be presented in string of decimal format.
+   * @return {bigint} - value in nanosecond.
    */
 
   get nanoseconds() {
-    let nanoStr = rclnodejs.getDurationNanoseconds(this._handle);
-    let nano;
-
-    if (nanoStr.startsWith('-')) {
-      nano = int64.negative(int64.from(nanoStr));
-    } else {
-      nano = int64.from(nanoStr);
-    }
-    if (Number.isFinite(nano.toNumber())) {
-      return nano.toNumber();
-    }
-    return nano.toString();
+    return rclnodejs.getDurationNanoseconds(this._handle);
   }
 
   /**
@@ -78,7 +65,7 @@ class Duration {
    */
   eq(other) {
     if (other instanceof Duration) {
-      return this._nanoseconds.eq(other.nanoseconds);
+      return this._nanoseconds == other.nanoseconds;
     }
     throw new TypeError(
       `Can't compare duration with object of type: ${other.constructor.name}`
@@ -92,7 +79,7 @@ class Duration {
    */
   ne(other) {
     if (other instanceof Duration) {
-      return this._nanoseconds.ne(other.nanoseconds);
+      return this._nanoseconds !== other.nanoseconds;
     }
     throw new TypeError('Invalid argument');
   }
@@ -104,7 +91,7 @@ class Duration {
    */
   lt(other) {
     if (other instanceof Duration) {
-      return this._nanoseconds.lt(other.nanoseconds);
+      return this._nanoseconds < other.nanoseconds;
     }
     throw new TypeError('Invalid argument');
   }
@@ -116,7 +103,7 @@ class Duration {
    */
   lte(other) {
     if (other instanceof Duration) {
-      return this._nanoseconds.lte(other.nanoseconds);
+      return this._nanoseconds <= other.nanoseconds;
     }
     throw new TypeError('Invalid argument');
   }
@@ -128,7 +115,7 @@ class Duration {
    */
   gt(other) {
     if (other instanceof Duration) {
-      return this._nanoseconds.gt(other.nanoseconds);
+      return this._nanoseconds > other.nanoseconds;
     }
     throw new TypeError('Invalid argument');
   }
@@ -140,7 +127,7 @@ class Duration {
    */
   gte(other) {
     if (other instanceof Duration) {
-      return this._nanoseconds.gte(other.nanoseconds);
+      return this._nanoseconds >= other.nanoseconds;
     }
     throw new TypeError('Invalid argument');
   }

--- a/lib/node.js
+++ b/lib/node.js
@@ -1471,8 +1471,8 @@ class Node extends rclnodejs.ShadowNode {
 
     const secondsAndNanos = this._clock.now().secondsAndNanoseconds;
     parameterEvent.stamp = {
-      sec: secondsAndNanos.seconds,
-      nanosec: secondsAndNanos.nanoseconds,
+      sec: Number(secondsAndNanos.seconds),
+      nanosec: Number(secondsAndNanos.nanoseconds),
     };
 
     parameterEvent.node =

--- a/lib/node.js
+++ b/lib/node.js
@@ -1469,10 +1469,10 @@ class Node extends rclnodejs.ShadowNode {
       PARAMETER_EVENT_MSG_TYPE
     ))();
 
-    const secondsAndNanos = this._clock.now().secondsAndNanoseconds;
+    const { seconds, nanoseconds } = this._clock.now().secondsAndNanoseconds;
     parameterEvent.stamp = {
-      sec: Number(secondsAndNanos.seconds),
-      nanosec: Number(secondsAndNanos.nanoseconds),
+      sec: Number(seconds),
+      nanosec: Number(nanoseconds),
     };
 
     parameterEvent.node =

--- a/lib/time.js
+++ b/lib/time.js
@@ -17,7 +17,7 @@
 const rclnodejs = require('bindings')('rclnodejs');
 const Duration = require('./duration.js');
 const ClockType = require('./clock_type.js');
-const int64 = require('int64-napi');
+const S_TO_NS = 10n ** 9n;
 
 /**
  * @class - Class representing a Time in ROS
@@ -26,16 +26,20 @@ const int64 = require('int64-napi');
 class Time {
   /**
    * Create a Time.
-   * @param {number|string} [seconds=0] - The second part of the time.
-   * @param {number|string} [nanoseconds=0] - The nanosecond part of the time.
+   * @param {bigint} [seconds=0] - The second part of the time.
+   * @param {bigint} [nanoseconds=0] - The nanosecond part of the time.
    * @param {ClockType} [clockType=Clock.ClockType.SYSTEM_TIME] - The clock type.
    */
-  constructor(seconds = 0, nanoseconds = 0, clockType = ClockType.SYSTEM_TIME) {
-    if (typeof seconds !== 'number' && typeof seconds !== 'string') {
+  constructor(
+    seconds = 0n,
+    nanoseconds = 0n,
+    clockType = ClockType.SYSTEM_TIME
+  ) {
+    if (typeof seconds !== 'bigint') {
       throw new TypeError('Invalid argument of seconds');
     }
 
-    if (typeof nanoseconds !== 'number' && typeof nanoseconds !== 'string') {
+    if (typeof nanoseconds !== 'bigint') {
       throw new TypeError('Invalid argument of nanoseconds');
     }
 
@@ -43,25 +47,22 @@ class Time {
       throw new TypeError('Invalid argument of clockType');
     }
 
-    if (
-      int64.lt(seconds, 0) ||
-      (typeof seconds === 'string' && seconds.startsWith('-'))
-    ) {
+    if (seconds < 0n) {
       throw new RangeError('seconds value must not be negative');
     }
 
-    if (
-      int64.lt(nanoseconds, 0) ||
-      (typeof nanoseconds === 'string' && nanoseconds.startsWith('-'))
-    ) {
+    if (nanoseconds < 0n) {
       throw new RangeError('nanoseconds value must not be negative');
     }
 
-    this._nanoseconds = int64.from(seconds).multiply(1e9).add(nanoseconds);
-    this._handle = rclnodejs.createTimePoint(
-      this._nanoseconds.toString(),
-      clockType
-    );
+    const total = seconds * S_TO_NS + nanoseconds;
+    if (total >= 2n ** 63n) {
+      throw new RangeError(
+        'Total nanoseconds value is too large to store in C time point.'
+      );
+    }
+    this._nanoseconds = total;
+    this._handle = rclnodejs.createTimePoint(this._nanoseconds, clockType);
     this._clockType = clockType;
   }
 
@@ -80,22 +81,11 @@ class Time {
    * Get the nanosecond part of the time.
    * @name Time#get:nanoseconds
    * @function
-   * @return {number|string} - value in nanosecond, if the value is greater than Number.MAX_SAFE_INTEGER (2^53-1), will be presented in string of decimal format.
+   * @return {bigint} - value in nanosecond.
    */
 
   get nanoseconds() {
-    let str = rclnodejs.getNanoseconds(this._handle);
-    let nano;
-
-    if (str.startsWith('-')) {
-      nano = int64.negative(int64.from(str));
-    } else {
-      nano = int64.from(str);
-    }
-    if (Number.isFinite(nano.toNumber())) {
-      return nano.toNumber();
-    }
-    return nano.toString();
+    return rclnodejs.getNanoseconds(this._handle);
   }
 
   /**
@@ -106,9 +96,11 @@ class Time {
    */
 
   get secondsAndNanoseconds() {
-    const seconds = int64.from(this._nanoseconds).divide(1e9).toNumber();
-    const nanoseconds = int64.from(this._nanoseconds).mod(1e9).toNumber();
-    return { seconds, nanoseconds };
+    const nanoseconds = this._nanoseconds;
+    return {
+      seconds: nanoseconds / S_TO_NS,
+      nanoseconds: nanoseconds % S_TO_NS,
+    };
   }
 
   /**
@@ -119,8 +111,8 @@ class Time {
   add(other) {
     if (other instanceof Duration) {
       return new Time(
-        0,
-        int64.add(this._nanoseconds, other.nanoseconds).toString(),
+        0n,
+        this._nanoseconds + other.nanoseconds,
         this._clockType
       );
     }
@@ -137,14 +129,11 @@ class Time {
       if (other._clockType !== this._clockType) {
         throw new TypeError("Can't subtract times with different clock types");
       }
-      return new Duration(
-        0,
-        int64.subtract(this._nanoseconds, other._nanoseconds).toString()
-      );
+      return new Duration(0n, this._nanoseconds - other._nanoseconds);
     } else if (other instanceof Duration) {
       return new Time(
-        0,
-        int64.subtract(this._nanoseconds, other._nanoseconds).toString(),
+        0n,
+        this._nanoseconds - other._nanoseconds,
         this._clockType
       );
     }
@@ -161,7 +150,7 @@ class Time {
       if (other._clockType !== this._clockType) {
         throw new TypeError("Can't compare times with different clock types");
       }
-      return this._nanoseconds.eq(other.nanoseconds);
+      return this._nanoseconds == other.nanoseconds;
     }
     throw new TypeError('Invalid argument');
   }
@@ -176,7 +165,7 @@ class Time {
       if (other._clockType !== this._clockType) {
         throw new TypeError("Can't compare times with different clock types");
       }
-      return this._nanoseconds.ne(other.nanoseconds);
+      return this._nanoseconds !== other.nanoseconds;
     }
   }
 
@@ -190,7 +179,7 @@ class Time {
       if (other._clockType !== this._clockType) {
         throw new TypeError("Can't compare times with different clock types");
       }
-      return this._nanoseconds.lt(other.nanoseconds);
+      return this._nanoseconds < other.nanoseconds;
     }
     throw new TypeError('Invalid argument');
   }
@@ -205,7 +194,7 @@ class Time {
       if (other._clockType !== this._clockType) {
         throw new TypeError("Can't compare times with different clock types");
       }
-      return this._nanoseconds.lte(other.nanoseconds);
+      return this._nanoseconds <= other.nanoseconds;
     }
     throw new TypeError('Invalid argument');
   }
@@ -220,7 +209,7 @@ class Time {
       if (other._clockType !== this._clockType) {
         throw new TypeError("Can't compare times with different clock types");
       }
-      return this._nanoseconds.gt(other.nanoseconds);
+      return this._nanoseconds > other.nanoseconds;
     }
     throw new TypeError('Invalid argument');
   }
@@ -235,7 +224,7 @@ class Time {
       if (other._clockType !== this._clockType) {
         throw new TypeError("Can't compare times with different clock types");
       }
-      return this._nanoseconds.gte(other.nanoseconds);
+      return this._nanoseconds >= other.nanoseconds;
     }
     throw new TypeError('Invalid argument');
   }
@@ -261,7 +250,7 @@ class Time {
    * @return {Time} Return the created Time object.
    */
   static fromMsg(msg, clockType = ClockType.ROS_TIME) {
-    return new Time(msg.sec, msg.nanosec, clockType);
+    return new Time(BigInt(msg.sec), BigInt(msg.nanosec), clockType);
   }
 }
 

--- a/lib/time.js
+++ b/lib/time.js
@@ -150,7 +150,7 @@ class Time {
       if (other._clockType !== this._clockType) {
         throw new TypeError("Can't compare times with different clock types");
       }
-      return this._nanoseconds == other.nanoseconds;
+      return this._nanoseconds === other.nanoseconds;
     }
     throw new TypeError('Invalid argument');
   }

--- a/lib/time_source.js
+++ b/lib/time_source.js
@@ -37,7 +37,7 @@ class TimeSource {
     this._node = node;
     this._associatedClocks = [];
     this._clockSubscription = undefined;
-    this._lastTimeSet = new Time(0, 0, ClockType.ROS_TIME);
+    this._lastTimeSet = new Time(0n, 0n, ClockType.ROS_TIME);
     this._isRosTimeActive = false;
 
     if (this._node) {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "tree-kill": "^1.2.2",
     "typescript": "^5.7.2"
   },
-  "//": "Pin int64-napi to ^1.0.2",
   "dependencies": {
     "@rclnodejs/ref-array-di": "^1.2.2",
     "@rclnodejs/ref-napi": "^4.0.0",
@@ -76,7 +75,6 @@
     "dtslint": "^4.2.1",
     "fs-extra": "^11.2.0",
     "json-bigint": "^1.0.0",
-    "int64-napi": "^1.0.2",
     "is-close": "^1.3.3",
     "mkdirp": "^3.0.1",
     "mz": "^2.7.0",

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -434,12 +434,17 @@ NAN_METHOD(TimerGetTimeSinceLastCall) {
 }
 
 NAN_METHOD(CreateTimePoint) {
-  std::string str(*Nan::Utf8String(info[0]));
+  if (!info[0]->IsBigInt()) {
+    Nan::ThrowTypeError("Timer period must be a BigInt");
+    return;
+  }
+  v8::Local<v8::BigInt> bigInt = info[0].As<v8::BigInt>();
+  const int64_t total_nanoseconds = bigInt->Int64Value();
   uint32_t clock_type = Nan::To<uint32_t>(info[1]).FromJust();
   rcl_time_point_t* time_point =
       reinterpret_cast<rcl_time_point_t*>(malloc(sizeof(rcl_time_point_t)));
 
-  time_point->nanoseconds = std::stoll(str);
+  time_point->nanoseconds = total_nanoseconds;
   time_point->clock_type = static_cast<rcl_clock_type_t>(clock_type);
 
   auto js_obj =
@@ -452,16 +457,21 @@ NAN_METHOD(GetNanoseconds) {
       Nan::To<v8::Object>(info[0]).ToLocalChecked());
   rcl_time_point_t* time_point =
       reinterpret_cast<rcl_time_point_t*>(time_point_handle->ptr());
-  info.GetReturnValue().Set(
-      Nan::New<v8::String>(std::to_string(time_point->nanoseconds))
-          .ToLocalChecked());
+  v8::Local<v8::BigInt> bigInt =
+      v8::BigInt::New(v8::Isolate::GetCurrent(), time_point->nanoseconds);
+  info.GetReturnValue().Set(bigInt);
 }
 
 NAN_METHOD(CreateDuration) {
-  std::string str(*Nan::Utf8String(info[0]));
+  if (!info[0]->IsBigInt()) {
+    Nan::ThrowTypeError("Timer period must be a BigInt");
+    return;
+  }
+  v8::Local<v8::BigInt> bigInt = info[0].As<v8::BigInt>();
+  const int64_t total_nanoseconds = bigInt->Int64Value();
   rcl_duration_t* duration =
       reinterpret_cast<rcl_duration_t*>(malloc(sizeof(rcl_duration_t)));
-  duration->nanoseconds = std::stoll(str);
+  duration->nanoseconds = total_nanoseconds;
 
   auto js_obj =
       RclHandle::NewInstance(duration, nullptr, [](void* ptr) { free(ptr); });
@@ -473,10 +483,9 @@ NAN_METHOD(GetDurationNanoseconds) {
       Nan::To<v8::Object>(info[0]).ToLocalChecked());
   rcl_duration_t* duration =
       reinterpret_cast<rcl_duration_t*>(duration_handle->ptr());
-
-  info.GetReturnValue().Set(
-      Nan::New<v8::String>(std::to_string(duration->nanoseconds))
-          .ToLocalChecked());
+  v8::Local<v8::BigInt> bigInt =
+      v8::BigInt::New(v8::Isolate::GetCurrent(), duration->nanoseconds);
+  info.GetReturnValue().Set(bigInt);
 }
 
 NAN_METHOD(SetRosTimeOverrideIsEnabled) {
@@ -546,7 +555,6 @@ static void ReturnJSTimeObj(
     Nan::NAN_METHOD_ARGS_TYPE info, int64_t nanoseconds,
     rcl_clock_type_t clock_type = RCL_CLOCK_UNINITIALIZED) {
   auto obj = v8::Object::New(v8::Isolate::GetCurrent());
-
   const auto sec = static_cast<std::int32_t>(RCL_NS_TO_S(nanoseconds));
   const auto nanosec =
       static_cast<std::int32_t>(nanoseconds % (1000 * 1000 * 1000));
@@ -572,8 +580,9 @@ NAN_METHOD(ClockGetNow) {
   THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
                            rcl_clock_get_now(clock, &time_point.nanoseconds),
                            rcl_get_error_string().str);
-
-  ReturnJSTimeObj(info, time_point.nanoseconds, time_point.clock_type);
+  v8::Local<v8::BigInt> bigInt =
+      v8::BigInt::New(v8::Isolate::GetCurrent(), time_point.nanoseconds);
+  info.GetReturnValue().Set(bigInt);
 }
 
 NAN_METHOD(StaticClockGetNow) {

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -439,12 +439,12 @@ NAN_METHOD(CreateTimePoint) {
     return;
   }
   v8::Local<v8::BigInt> bigInt = info[0].As<v8::BigInt>();
-  const int64_t total_nanoseconds = bigInt->Int64Value();
+  const int64_t nanoseconds = bigInt->Int64Value();
   uint32_t clock_type = Nan::To<uint32_t>(info[1]).FromJust();
   rcl_time_point_t* time_point =
       reinterpret_cast<rcl_time_point_t*>(malloc(sizeof(rcl_time_point_t)));
 
-  time_point->nanoseconds = total_nanoseconds;
+  time_point->nanoseconds = nanoseconds;
   time_point->clock_type = static_cast<rcl_clock_type_t>(clock_type);
 
   auto js_obj =
@@ -468,10 +468,10 @@ NAN_METHOD(CreateDuration) {
     return;
   }
   v8::Local<v8::BigInt> bigInt = info[0].As<v8::BigInt>();
-  const int64_t total_nanoseconds = bigInt->Int64Value();
+  const int64_t nanoseconds = bigInt->Int64Value();
   rcl_duration_t* duration =
       reinterpret_cast<rcl_duration_t*>(malloc(sizeof(rcl_duration_t)));
-  duration->nanoseconds = total_nanoseconds;
+  duration->nanoseconds = nanoseconds;
 
   auto js_obj =
       RclHandle::NewInstance(duration, nullptr, [](void* ptr) { free(ptr); });
@@ -551,24 +551,6 @@ NAN_METHOD(CreateClock) {
       }));
 }
 
-static void ReturnJSTimeObj(
-    Nan::NAN_METHOD_ARGS_TYPE info, int64_t nanoseconds,
-    rcl_clock_type_t clock_type = RCL_CLOCK_UNINITIALIZED) {
-  auto obj = v8::Object::New(v8::Isolate::GetCurrent());
-  const auto sec = static_cast<std::int32_t>(RCL_NS_TO_S(nanoseconds));
-  const auto nanosec =
-      static_cast<std::int32_t>(nanoseconds % (1000 * 1000 * 1000));
-  const int32_t type = clock_type;
-
-  Nan::Set(obj, Nan::New("sec").ToLocalChecked(), Nan::New(sec));
-  Nan::Set(obj, Nan::New("nanosec").ToLocalChecked(), Nan::New(nanosec));
-  if (clock_type != RCL_CLOCK_UNINITIALIZED) {
-    Nan::Set(obj, Nan::New("type").ToLocalChecked(), Nan::New(type));
-  }
-
-  info.GetReturnValue().Set(obj);
-}
-
 NAN_METHOD(ClockGetNow) {
   rcl_clock_t* clock = reinterpret_cast<rcl_clock_t*>(
       RclHandle::Unwrap<RclHandle>(
@@ -583,62 +565,6 @@ NAN_METHOD(ClockGetNow) {
   v8::Local<v8::BigInt> bigInt =
       v8::BigInt::New(v8::Isolate::GetCurrent(), time_point.nanoseconds);
   info.GetReturnValue().Set(bigInt);
-}
-
-NAN_METHOD(StaticClockGetNow) {
-  int32_t type = Nan::To<int32_t>(info[0]).FromJust();
-
-  if (type < RCL_ROS_TIME && type > RCL_STEADY_TIME) {
-    info.GetReturnValue().Set(Nan::Undefined());
-    return;
-  }
-
-  rcl_clock_t ros_clock;
-  rcl_time_point_t rcl_time;
-  rcl_allocator_t allocator = rcl_get_default_allocator();
-
-  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
-                           rcl_clock_init(static_cast<rcl_clock_type_t>(type),
-                                          &ros_clock, &allocator),
-                           rcl_get_error_string().str);
-
-  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
-                           rcl_clock_get_now(&ros_clock, &rcl_time.nanoseconds),
-                           rcl_get_error_string().str);
-
-  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, rcl_clock_fini(&ros_clock),
-                           rcl_get_error_string().str);
-
-  ReturnJSTimeObj(info, rcl_time.nanoseconds, rcl_time.clock_type);
-}
-
-NAN_METHOD(TimeDiff) {
-  int64_t s_sec = Nan::To<int32_t>(info[0]).FromJust();
-  uint32_t s_nano = Nan::To<uint32_t>(info[1]).FromJust();
-  int32_t s_type = Nan::To<int32_t>(info[2]).FromJust();
-
-  int64_t f_sec = Nan::To<int32_t>(info[3]).FromJust();
-  uint32_t f_nano = Nan::To<uint32_t>(info[4]).FromJust();
-  int32_t f_type = Nan::To<int32_t>(info[5]).FromJust();
-
-  rcl_time_point_t start;
-  rcl_time_point_t finish;
-  rcl_duration_t delta;
-
-  start.nanoseconds = s_sec * 1000 * 1000 * 1000 + s_nano;
-  start.clock_type = static_cast<rcl_clock_type_t>(s_type);
-
-  finish.nanoseconds = f_sec * 1000 * 1000 * 1000 + f_nano;
-  finish.clock_type = static_cast<rcl_clock_type_t>(f_type);
-
-  auto ret = rcl_difference_times(&start, &finish, &delta);
-
-  if (ret == RCL_RET_OK) {
-    ReturnJSTimeObj(info, delta.nanoseconds);
-    return;
-  }
-
-  info.GetReturnValue().Set(Nan::Undefined());
 }
 
 NAN_METHOD(RclTake) {
@@ -2063,8 +1989,6 @@ std::vector<BindingMethod> binding_methods = {
     {"timerGetTimeUntilNextCall", TimerGetTimeUntilNextCall},
     {"createClock", CreateClock},
     {"clockGetNow", ClockGetNow},
-    {"staticClockGetNow", StaticClockGetNow},
-    {"timeDiff", TimeDiff},
     {"createTimePoint", CreateTimePoint},
     {"getNanoseconds", GetNanoseconds},
     {"createDuration", CreateDuration},

--- a/test/test-node-oo.js
+++ b/test/test-node-oo.js
@@ -372,7 +372,7 @@ describe('rcl node methods testing', function () {
     assert.ok(time);
     assert.strictEqual(node.getClock().clockType, time.clockType);
 
-    const seconds = time.secondsAndNanoseconds.seconds;
+    const seconds = Number(time.secondsAndNanoseconds.seconds);
     const dateSeconds = Date.now() / 1000;
     assert.ok(IsClose.isClose(seconds, dateSeconds, 1));
   });

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -373,7 +373,7 @@ describe('rcl node methods testing', function () {
     assert.ok(time);
     assert.strictEqual(node.getClock().clockType, time.clockType);
 
-    const seconds = time.secondsAndNanoseconds.seconds;
+    const seconds = Number(time.secondsAndNanoseconds.seconds);
     const dateSeconds = Date.now() / 1000;
     assert.ok(IsClose.isClose(seconds, dateSeconds, 1));
   });

--- a/test/test-time-source.js
+++ b/test/test-time-source.js
@@ -18,7 +18,6 @@ const assert = require('assert');
 const rclnodejs = require('../index.js');
 const { Clock, Parameter, ParameterType, ROSClock, TimeSource, Time } =
   rclnodejs;
-const int64 = require('int64-napi');
 
 describe('rclnodejs TimeSource testing', function () {
   this.timeout(60 * 1000);
@@ -73,13 +72,13 @@ describe('rclnodejs TimeSource testing', function () {
     let now = clock.now();
     let sysClock = new Clock(Clock.ClockType.SYSTEM_TIME);
     let sysNow = sysClock.now();
-    assert.ok(int64.subtract(sysNow.nanoseconds, now.nanoseconds) < 1e9);
+    assert.ok(sysNow.nanoseconds - now.nanoseconds < 1n ** 9n);
 
     publishClockMessage(node);
     assert.strictEqual(clock.isRosTimeActive, false);
     now = clock.now();
     sysNow = sysClock.now();
-    assert.ok(int64.subtract(sysNow.nanoseconds, now.nanoseconds) < 1e9);
+    assert.ok(sysNow.nanoseconds - now.nanoseconds < 1n ** 9n);
 
     assert.strictEqual(timeSource.isRosTimeActive, false);
     let clock2 = new ROSClock();
@@ -121,19 +120,19 @@ describe('rclnodejs TimeSource testing', function () {
 
     assert.ok(timeSource._clockSubscription);
     assert.strictEqual(
-      clock.now().eq(new Time(0, 0, Clock.ClockType.ROS_TIME)),
+      clock.now().eq(new Time(0n, 0n, Clock.ClockType.ROS_TIME)),
       true
     );
 
     publishClockMessage(node);
     setTimeout(() => {
-      assert.ok(clock.now().gt(new Time(0, 0, Clock.ClockType.ROS_TIME)));
-      assert.ok(clock.now().lte(new Time(5, 0, Clock.ClockType.ROS_TIME)));
+      assert.ok(clock.now().gt(new Time(0n, 0n, Clock.ClockType.ROS_TIME)));
+      assert.ok(clock.now().lte(new Time(5n, 0n, Clock.ClockType.ROS_TIME)));
 
       let clock2 = new ROSClock();
       timeSource.attachClock(clock2);
-      assert.ok(clock2.now().gt(new Time(0, 0, Clock.ClockType.ROS_TIME)));
-      assert.ok(clock2.now().lte(new Time(5, 0, Clock.ClockType.ROS_TIME)));
+      assert.ok(clock2.now().gt(new Time(0n, 0n, Clock.ClockType.ROS_TIME)));
+      assert.ok(clock2.now().lte(new Time(5n, 0n, Clock.ClockType.ROS_TIME)));
 
       timeSource.detachNode();
       let node2 = rclnodejs.createNode(

--- a/test/test-time-source.js
+++ b/test/test-time-source.js
@@ -72,13 +72,13 @@ describe('rclnodejs TimeSource testing', function () {
     let now = clock.now();
     let sysClock = new Clock(Clock.ClockType.SYSTEM_TIME);
     let sysNow = sysClock.now();
-    assert.ok(sysNow.nanoseconds - now.nanoseconds < 1n ** 9n);
+    assert.ok(sysNow.nanoseconds - now.nanoseconds < 10n ** 9n);
 
     publishClockMessage(node);
     assert.strictEqual(clock.isRosTimeActive, false);
     now = clock.now();
     sysNow = sysClock.now();
-    assert.ok(sysNow.nanoseconds - now.nanoseconds < 1n ** 9n);
+    assert.ok(sysNow.nanoseconds - now.nanoseconds < 10n ** 9n);
 
     assert.strictEqual(timeSource.isRosTimeActive, false);
     let clock2 = new ROSClock();

--- a/test/test-time.js
+++ b/test/test-time.js
@@ -31,74 +31,73 @@ describe('rclnodejs Time/Clock testing', function () {
   });
 
   it('Construct time object', function () {
-    let time = new Time(1, 64);
-    assert.strictEqual(time.nanoseconds, 1000000064);
+    let time = new Time(1n, 64n);
+    assert.strictEqual(time.nanoseconds, 1000000064n);
     assert.strictEqual(time.clockType, ClockType.SYSTEM_TIME);
 
-    time = new Time(0, Number.MAX_SAFE_INTEGER);
-    assert.strictEqual(time.nanoseconds, 9007199254740991);
+    time = new Time(0n, BigInt(Number.MAX_SAFE_INTEGER));
+    assert.strictEqual(time.nanoseconds, 9007199254740991n);
 
-    // The nanoseconds property will be presented in a string, if the value excesses 2^53-1
-    time = new Time(0, '9007199254740992');
-    assert.strictEqual(time.nanoseconds, '9007199254740992');
+    time = new Time(0n, 9007199254740992n);
+    assert.strictEqual(time.nanoseconds, 9007199254740992n);
 
-    time = new Time(0, '9223372036854775807');
-    assert.strictEqual(time.nanoseconds, '9223372036854775807');
+    time = new Time(0n, 9223372036854775807n);
+    assert.strictEqual(time.nanoseconds, 9223372036854775807n);
 
-    time = Time.fromMsg({ sec: 1, nanosec: 64 });
-    assert.strictEqual(time.nanoseconds, 1000000064);
+    time = Time.fromMsg({ sec: 1n, nanosec: 64n });
+    assert.strictEqual(time.nanoseconds, 1000000064n);
     assert.strictEqual(time.clockType, ClockType.ROS_TIME);
 
     assert.throws(() => {
-      new Time(1, 1, 'SYSTEM_TIME');
+      new Time(1n, 1n, 'SYSTEM_TIME');
     }, TypeError);
 
     assert.throws(() => {
-      new Time({ seconds: 0, nanoseconds: 0 });
+      new Time({ seconds: 0n, nanoseconds: 0n });
     }, TypeError);
 
     assert.throws(() => {
-      new Time(-1, 0);
+      new Time(-1n, 0n);
     }, RangeError);
 
     assert.throws(() => {
-      new Time(0, '-9007199254740992');
+      new Time(0n, -9007199254740992n);
     }, RangeError);
 
     assert.throws(() => {
-      new Time(0, -1);
+      new Time(0n, -1n);
     }, RangeError);
   });
 
   it('Construct duration object', function () {
     let duration = new Duration();
-    assert.strictEqual(duration.nanoseconds, 0);
+    assert.strictEqual(duration.nanoseconds, 0n);
 
-    duration = new Duration(1, 64);
-    assert.strictEqual(duration.nanoseconds, 1000000064);
+    duration = new Duration(1n, 64n);
+    assert.strictEqual(duration.nanoseconds, 1000000064n);
 
-    duration = new Duration(-1);
-    assert.strictEqual(duration.nanoseconds, -1000000000);
+    duration = new Duration(-1n);
+    assert.strictEqual(duration.nanoseconds, -1000000000n);
 
-    duration = new Duration(0, -1);
-    assert.strictEqual(duration.nanoseconds, -1);
+    duration = new Duration(0n, -1n);
+    assert.strictEqual(duration.nanoseconds, -1n);
 
-    duration = new Duration(0, Number.MAX_SAFE_INTEGER);
-    assert.strictEqual(duration.nanoseconds, 9007199254740991);
+    duration = new Duration(0n, BigInt(Number.MAX_SAFE_INTEGER));
+    assert.strictEqual(duration.nanoseconds, 9007199254740991n);
 
-    duration = new Duration(0, '9007199254740992');
-    assert.strictEqual(duration.nanoseconds, '9007199254740992');
+    duration = new Duration(0n, 9007199254740992n);
+    assert.strictEqual(duration.nanoseconds, 9007199254740992n);
 
-    duration = new Duration(0, '-9007199254740992');
-    assert.strictEqual(duration.nanoseconds, '-9007199254740992');
+    duration = new Duration(0n, -9007199254740992n);
+    assert.strictEqual(duration.nanoseconds, -9007199254740992n);
 
-    duration = new Duration(0, '9223372036854775807');
-    assert.strictEqual(duration.nanoseconds, '9223372036854775807');
+    duration = new Duration(0n, 9223372036854775807n);
+    assert.strictEqual(duration.nanoseconds, 9223372036854775807n);
   });
 
   it('Test time functions', function () {
-    let left = new Time(0, 1);
-    let right = new Time(0, 2);
+    let left = new Time(0n, 1n);
+    let right = new Time(0n, 2n);
 
     assert.strictEqual(left.eq(right), false);
     assert.strictEqual(left.ne(right), true);
@@ -107,8 +106,8 @@ describe('rclnodejs Time/Clock testing', function () {
     assert.strictEqual(left.gt(right), false);
     assert.strictEqual(left.gte(right), false);
 
-    left = new Time(0, 1, ClockType.SYSTEM_TIME);
-    right = new Time(0, 2, ClockType.STEADY_TIME);
+    left = new Time(0n, 1n, ClockType.SYSTEM_TIME);
+    right = new Time(0n, 2n, ClockType.STEADY_TIME);
 
     assert.throws(() => {
       left.eq(right);
@@ -134,21 +133,21 @@ describe('rclnodejs Time/Clock testing', function () {
       left.gte(right);
     }, TypeError);
 
-    let time = new Time(0, 1, ClockType.STEADY_TIME);
-    let duration = new Duration(0, 1);
+    let time = new Time(0n, 1n, ClockType.STEADY_TIME);
+    let duration = new Duration(0n, 1n);
     let result = time.add(duration);
     assert.ok(result instanceof Time);
-    assert.strictEqual(result.nanoseconds, 2);
+    assert.strictEqual(result.nanoseconds, 2n);
     assert.strictEqual(result.clockType, ClockType.STEADY_TIME);
 
     result = time.sub(duration);
     assert.ok(result instanceof Time);
-    assert.strictEqual(result.nanoseconds, 0);
+    assert.strictEqual(result.nanoseconds, 0n);
     assert.strictEqual(result.clockType, ClockType.STEADY_TIME);
 
     let diff = time.sub(result);
     assert.ok(diff instanceof Duration);
-    assert.strictEqual(diff.nanoseconds, 1);
+    assert.strictEqual(diff.nanoseconds, 1n);
     assert.throws(() => {
       time.add(result);
     }, TypeError);
@@ -159,8 +158,8 @@ describe('rclnodejs Time/Clock testing', function () {
   });
 
   it('Test duration functions', function () {
-    let left = new Duration(0, 1);
-    let right = new Duration(0, 2);
+    let left = new Duration(0n, 1n);
+    let right = new Duration(0n, 2n);
     assert.strictEqual(left.eq(right), false);
     assert.strictEqual(left.ne(right), true);
     assert.strictEqual(left.gt(right), false);
@@ -168,12 +167,12 @@ describe('rclnodejs Time/Clock testing', function () {
     assert.strictEqual(left.lt(right), true);
     assert.strictEqual(left.lte(right), true);
 
-    left = new Duration(0, 5e9);
-    right = new Duration(5, 0);
+    left = new Duration(0n, 5n * 10n ** 9n);
+    right = new Duration(5n, 0n);
     assert.ok(left.eq(right));
 
     assert.throws(() => {
-      left.eq(5e9);
+      left.eq(5n ** 9n);
     }, TypeError);
 
     let time = new Time();
@@ -198,10 +197,10 @@ describe('rclnodejs Time/Clock testing', function () {
   });
 
   it('Conversion to Time message', function () {
-    let time = new Time(100, 200);
+    let time = new Time(100n, 200n);
     let msg = time.toMsg();
 
-    assert.strictEqual(msg.sec, 100);
-    assert.strictEqual(msg.nanosec, 200);
+    assert.strictEqual(msg.sec, 100n);
+    assert.strictEqual(msg.nanosec, 200n);
   });
 });


### PR DESCRIPTION
Per current implementation, the `Time`/`Duration` in rclnodejs module may be initialized with two parts, which are `seconds` and `nanoseconds` using type of `number` or `string`, this is because the range limitation of integer that JavaScript can [represents](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). While, after [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) introduced, we can change it to type of `bigint` only, which aligns with other ROS2 clients, like `rclpy`.

This patch implements:

1. Leverage `BigInt` to initialize `Time`/`Duration` in nanoseconds from JavaScript side.
2. Change `Clock` and `TimeSource` accordingly.
3. Get the period from `v8::BigInt` object as `int64_t` and pass it to `rcl` from C++ side.
4. Update the related unit tests accordingly.
5. Remove dependency, `int64-napi`, which was used to pass `int64_t` from JavaScript to C++.

Fix: #1040
