### PR TITLE
[ROSIDL] Add toPlainObject() method for array messages

### DIFF
--- a/rosidl_gen/generator.json
+++ b/rosidl_gen/generator.json
@@ -1,6 +1,6 @@
 {
   "name": "rosidl-generator",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Generate JavaScript object from ROS IDL(.msg) files",
   "main": "index.js",
   "authors": [

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -824,6 +824,10 @@ class {{=arrayWrapper}} {
   get classType() {
     return {{=arrayWrapper}};
   }
+
+  toPlainObject(enableTypedArray) {
+    return translator.toPlainObject(this, enableTypedArray);
+  }
 }
 
 {{? it.spec.constants != undefined && it.spec.constants.length}}

--- a/test/test-array-data.js
+++ b/test/test-array-data.js
@@ -19,10 +19,7 @@ const deepEqual = require('deep-equal');
 const rclnodejs = require('../index.js');
 const translator = require('../rosidl_gen/message_translator.js');
 const arrayGen = require('./array_generator.js');
-
-function isTypedArray(v) {
-  return ArrayBuffer.isView(v) && !(v instanceof DataView);
-}
+const { isTypedArray } = require('./utils.js');
 
 describe('rclnodejs message communication', function () {
   this.timeout(60 * 1000);

--- a/test/test-message-properties-validation.js
+++ b/test/test-message-properties-validation.js
@@ -175,13 +175,12 @@ describe('Rclnodejs message properities validation', function () {
         // Assign the property with a plain object.
         left[i] = testData.value[i];
         if (typeof left[i].toPlainObject === 'function') {
-          assert.ok(deepEqual(testData.value[i], left[i].toPlainObject()));
-        } else if (left[i].classType && left[i].classType.isROSArray) {
-          left[i].data.forEach((value, index) => {
-            assert.ok(
-              deepEqual(testData.value[i][index], value.toPlainObject())
-            );
-          });
+          assert.ok(
+            deepEqual(
+              testData.value[i],
+              left[i].toPlainObject(/*enableTypedArray=*/ true)
+            )
+          );
         } else {
           assert.ok(deepEqual(testData.value[i], left[i]));
         }

--- a/test/test-message-translator-complex.js
+++ b/test/test-message-translator-complex.js
@@ -14,13 +14,8 @@
 
 'use strict';
 
-const assert = require('assert');
 const rclnodejs = require('../index.js');
 const deepEqual = require('deep-equal');
-
-function isTypedArray(v) {
-  return ArrayBuffer.isView(v) && !(v instanceof DataView);
-}
 
 describe('Rclnodejs message translation: complex types', function () {
   this.timeout(60 * 1000);

--- a/test/test-message-translator-primitive.js
+++ b/test/test-message-translator-primitive.js
@@ -17,10 +17,7 @@
 const rclnodejs = require('../index.js');
 const deepEqual = require('deep-equal');
 const arrayGen = require('./array_generator.js');
-
-function isTypedArray(v) {
-  return ArrayBuffer.isView(v) && !(v instanceof DataView);
-}
+const { isTypedArray } = require('./utils.js');
 
 /* eslint-disable camelcase */
 /* eslint-disable indent */

--- a/test/utils.js
+++ b/test/utils.js
@@ -85,10 +85,15 @@ function createDelay(millis) {
   return new Promise((resolve) => setTimeout(resolve, millis));
 }
 
+function isTypedArray(v) {
+  return ArrayBuffer.isView(v) && !(v instanceof DataView);
+}
+
 module.exports = {
   assertMember: assertMember,
   assertThrowsError: assertThrowsError,
   createDelay: createDelay,
   getAvailablePath: getAvailablePath,
   launchPythonProcess: launchPythonProcess,
+  isTypedArray: isTypedArray,
 };


### PR DESCRIPTION
This patch adds support for converting array messages to plain objects by introducing a helper function to detect typed arrays and updating relevant tests.

Fix: #1046