### PR TITLE
Remove dependency array.prototype.flat

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@rclnodejs/ref-array-di": "^1.2.2",
     "@rclnodejs/ref-napi": "^4.0.0",
     "@rclnodejs/ref-struct-di": "^1.1.1",
-    "array.prototype.flat": "^1.3.2",
     "bindings": "^1.5.0",
     "compare-versions": "^6.1.1",
     "debug": "^4.4.0",

--- a/rosidl_gen/packages.js
+++ b/rosidl_gen/packages.js
@@ -20,7 +20,6 @@ const readline = require('readline');
 const path = require('path');
 const walk = require('walk');
 const os = require('os');
-const flat = require('array.prototype.flat');
 const pkgFilters = require('../rosidl_gen/filter.js');
 
 const fsp = fs.promises;
@@ -193,8 +192,7 @@ async function findAmentPackagesInDirectory(dir) {
     pkgs.map((pkg) => getPackageDefinitionsFiles(pkg, dir))
   );
 
-  // Support flat() method for nodejs < 11.
-  const rosFiles = Array.prototype.flat ? files.flat() : flat(files);
+  const rosFiles = files.flat();
   const pkgMap = new Map();
   await Promise.all(
     rosFiles.map((filePath) => addInterfaceInfos(filePath, dir, pkgMap))


### PR DESCRIPTION
This patch removes dependency, `array.prototype.flat`, needed for nodejs prior to version 11.

Fix: #1048
