### PR TITLE
Cleanup code

### DIFF
--- a/lib/lifecycle_publisher.js
+++ b/lib/lifecycle_publisher.js
@@ -37,7 +37,7 @@ class LifecyclePublisher extends Publisher {
    * Publish a message only when activated; otherwise do nothing (nop);
    *
    * @param {object|Buffer} message - The message to be sent, could be kind of JavaScript message generated from .msg
-   *                                                          or be a Buffer for a raw message.
+   *                                  or be a Buffer for a raw message.
    * @returns {undefined}
    */
   publish(message) {

--- a/lib/node.js
+++ b/lib/node.js
@@ -1496,7 +1496,7 @@ class Node extends rclnodejs.ShadowNode {
       );
     }
 
-    // publish ParameterEvent
+    // Publish ParameterEvent.
     this._parameterEventPublisher.publish(parameterEvent);
 
     return {

--- a/lib/parameter.js
+++ b/lib/parameter.js
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 // Copyright (c) 2020 Wayne Parrott. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,8 +19,9 @@
 
 'use strict';
 
+/* eslint-disable camelcase */
+
 const IsClose = require('is-close');
-const rclnodejs = require('bindings')('rclnodejs');
 
 /**
  * The plus/minus tolerance for determining number equivalence.

--- a/lib/parameter_service.js
+++ b/lib/parameter_service.js
@@ -27,6 +27,7 @@ const { Parameter, PARAMETER_SEPARATOR } = require('./parameter.js');
  *  rcl_interfaces/srv/GetParameters
  *  rcl_interfaces/srv/SetParameters
  *  rcl_interfaces/srv/SetParametersAtomically
+ *  rcl_interfaces/srv/GetParameterTypes
  *
  * Call start() to begin receiving client request.
  * All service requests are forwarded to the node this service works for.

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -38,7 +38,7 @@ class Publisher extends Entity {
   /**
    * Publish a message
    * @param {object|Buffer} message - The message to be sent, could be kind of JavaScript message generated from .msg
-   *                                                          or be a Buffer for a raw message.
+   *                                  or be a Buffer for a raw message.
    * @return {undefined}
    */
   publish(message) {

--- a/lib/rate.js
+++ b/lib/rate.js
@@ -1,4 +1,3 @@
-//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/lib/rmw.js
+++ b/lib/rmw.js
@@ -1,3 +1,15 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 
 const DistroUtils = require('./distro');

--- a/rosidl_gen/filter.js
+++ b/rosidl_gen/filter.js
@@ -1,3 +1,17 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
 const os = require('os');

--- a/rosidl_gen/message_translator.js
+++ b/rosidl_gen/message_translator.js
@@ -16,8 +16,6 @@
 
 /* eslint-disable max-depth */
 
-const debug = require('debug')('rclnodejs:message_translator');
-
 function isTypedArray(value) {
   return ArrayBuffer.isView(value) && !(value instanceof DataView);
 }
@@ -39,7 +37,6 @@ function copyMsgObject(msg, obj) {
           // It's an array
           if (typeof obj[i][0] === 'object') {
             // It's an array of objects: converting to ROS message objects
-
             // 1. Extract the element-type first
             // 2. Build the array by translate every elements
             let msgArray = [];
@@ -66,8 +63,7 @@ function copyMsgObject(msg, obj) {
 function verifyMessage(message, obj) {
   if (message.constructor.isROSArray) {
     // It's a ROS message array
-    //  Note: there won't be any JavaScript array in message
-
+    // Note: there won't be any JavaScript array in message.
     if (!Array.isArray(obj)) {
       return false;
     }
@@ -131,7 +127,7 @@ function toPlainObject(message, enableTypedArray = true) {
 
   if (message.constructor.isROSArray) {
     // It's a ROS message array
-    //  Note: there won't be any JavaScript array in message
+    // Note: there won't be any JavaScript array in message.
     let array = [];
     message.data.forEach((e) => {
       array.push(toPlainObject(e, enableTypedArray)); // Translate every elements

--- a/rostsd_gen/index.js
+++ b/rostsd_gen/index.js
@@ -1,6 +1,3 @@
-/* eslint-disable max-depth */
-/* eslint-disable no-sync */
-/* eslint-disable camelcase */
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -25,6 +22,10 @@ declare module "rclnodejs" {
 	}
 }
 */
+
+/* eslint-disable max-depth */
+/* eslint-disable no-sync */
+/* eslint-disable camelcase */
 
 'use strict';
 

--- a/scripts/generate_messages.js
+++ b/scripts/generate_messages.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-/* eslint-disable camelcase */
 // Copyright (c) 2018 Intel Corporation. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/* eslint-disable camelcase */
 'use strict';
 
 const generator = require('../rosidl_gen/index.js');

--- a/scripts/ros_distro.js
+++ b/scripts/ros_distro.js
@@ -1,3 +1,15 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 
 const DistroUtils = require('../lib/distro');

--- a/scripts/run_test.js
+++ b/scripts/run_test.js
@@ -19,8 +19,6 @@ const Mocha = require('mocha');
 const os = require('os');
 const path = require('path');
 
-let rootDir = path.dirname(__dirname);
-
 fs.remove(path.join(path.dirname(__dirname), 'generated'), (err) => {
   if (!err) {
     let mocha = new Mocha();

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -710,7 +710,6 @@ NAN_METHOD(HasContentFilter) {
   info.GetReturnValue().Set(Nan::False());
   return;
 #else
-
   RclHandle* subscription_handle = RclHandle::Unwrap<RclHandle>(
       Nan::To<v8::Object>(info[0]).ToLocalChecked());
   rcl_subscription_t* subscription =

--- a/test/array_generator.js
+++ b/test/array_generator.js
@@ -41,20 +41,6 @@ function noRound(v) {
   return v;
 }
 
-// const arrayGen = require('./array_generator.js');
-// const arrayLength = 100 * 1024;
-// arrayGen.generateValues(Float32Array, arrayLength, 100000000, arrayGen.negative, arrayGen.noRound);
-// arrayGen.generateValues(Float32Array, arrayLength, 10000, arrayGen.negative, arrayGen.noRound);
-// arrayGen.generateValues(Float64Array, arrayLength, Number.MAX_VALUE, arrayGen.negative, arrayGen.noRound);
-// arrayGen.generateValues(Float64Array, arrayLength, 10000, arrayGen.negative, arrayGen.noRound);
-// arrayGen.generateValues(Int8Array,    arrayLength, 128, arrayGen.negative, Math.floor);
-// arrayGen.generateValues(Int16Array,   arrayLength, 32768, arrayGen.negative, Math.floor);
-// arrayGen.generateValues(Int32Array,   arrayLength, 2147483648, arrayGen.negative, Math.floor);
-// arrayGen.generateValues(Uint8Array,   arrayLength, 256, arrayGen.positive, Math.floor);
-// arrayGen.generateValues(Uint16Array,  arrayLength, 65536, arrayGen.positive, Math.floor);
-// arrayGen.generateValues(Uint32Array,  arrayLength, 4294967296, arrayGen.positive, Math.floor);
-// arrayGen.generateValues(Array, arrayLength, 256, arrayGen.positive, Math.floor);
-
 module.exports = {
   generateValues: generateValues,
   positive: positive,

--- a/test/blocklist.json
+++ b/test/blocklist.json
@@ -1,6 +1,5 @@
 {
   "Linux": [
-    "test-raw-pub-sub.js",
     "test-multi-nodes.js",
     "test-msg-type-py-node.js",
     "test-msg-type-cpp-node.js",
@@ -15,7 +14,6 @@
     "test-subscription-content-filter.js"
   ],
   "Windows_NT": [
-    "test-raw-pub-sub.js", 
     "test-multi-nodes.js", 
     "test-msg-type-py-node.js", 
     "test-msg-type-cpp-node.js", 

--- a/test/blocklist.json
+++ b/test/blocklist.json
@@ -14,6 +14,7 @@
     "test-subscription-content-filter.js"
   ],
   "Windows_NT": [
+    "test-raw-pub-sub.js",
     "test-multi-nodes.js", 
     "test-msg-type-py-node.js", 
     "test-msg-type-cpp-node.js", 

--- a/test/test-compound-msg-type-check.js
+++ b/test/test-compound-msg-type-check.js
@@ -16,7 +16,6 @@
 
 const assert = require('assert');
 const rclnodejs = require('../index.js');
-const assertThrowsError = require('./utils.js').assertThrowsError;
 
 describe('Compound types', function () {
   this.timeout(60 * 1000);

--- a/test/test-distro.js
+++ b/test/test-distro.js
@@ -1,7 +1,18 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 
 const assert = require('assert');
-const childProcess = require('child_process');
 const rclnodejs = require('../index.js');
 
 const DistroUtils = rclnodejs.DistroUtils;

--- a/test/test-extra-destroy-methods.js
+++ b/test/test-extra-destroy-methods.js
@@ -31,7 +31,6 @@ describe('Node extra destroy methods testing', function () {
   it('destroyPublisher()', function () {
     var node = rclnodejs.createNode('node1');
     const RclString = 'std_msgs/msg/String';
-    // const RclString = rclnodejs.require('std_msgs/msg/String');
     var publisher = node.createPublisher(RclString, 'chatter');
     assert.deepStrictEqual(node._publishers.length, 2);
 
@@ -51,7 +50,6 @@ describe('Node extra destroy methods testing', function () {
   it('destroySubscription()', function () {
     var node = rclnodejs.createNode('node2');
     const RclString = 'std_msgs/msg/String';
-    // const RclString = rclnodejs.require('std_msgs/msg/String');
     var subscription = node.createSubscription(RclString, 'chatter', () => {});
     assert.deepStrictEqual(node._subscriptions.length, 1);
 
@@ -71,7 +69,6 @@ describe('Node extra destroy methods testing', function () {
   it('destroyClient()', function () {
     var node = rclnodejs.createNode('node3');
     const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
-    // const AddTwoInts = rclnodejs.require('example_interfaces/srv/AddTwoInts');
     var client = node.createClient(AddTwoInts, 'add_two_ints');
     assert.deepStrictEqual(node._clients.length, 1);
 
@@ -91,7 +88,6 @@ describe('Node extra destroy methods testing', function () {
   it('destroyService()', function () {
     var node = rclnodejs.createNode('node4');
     const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
-    // const AddTwoInts = rclnodejs.require('example_interfaces/srv/AddTwoInts');
     var service = node.createService(AddTwoInts, 'add_two_ints', () => {});
     assert.deepStrictEqual(node._services.length, 7);
 

--- a/test/test-lifecycle-publisher.js
+++ b/test/test-lifecycle-publisher.js
@@ -21,9 +21,6 @@ const assertThrowsError = assertUtils.assertThrowsError;
 
 const NODE_NAME = 'lifecycle_node';
 
-// let StateInterface = rclnodejs.createMessage('lifecycle_msgs/msg/State').constructor;
-// let TransitionInterface = rclnodejs.createMessage('lifecycle_msgs/msg/Transition').constructor;
-
 describe('LifecyclePublisher test suite', function () {
   let node;
   this.timeout(60 * 1000);

--- a/test/test-lifecycle.js
+++ b/test/test-lifecycle.js
@@ -1,4 +1,3 @@
-//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -18,7 +17,6 @@ const assert = require('assert');
 const rclnodejs = require('../index.js');
 const childProcess = require('child_process');
 const assertUtils = require('./utils.js');
-const assertThrowsError = assertUtils.assertThrowsError;
 
 const NODE_NAME = 'lifecycle_node';
 
@@ -332,7 +330,6 @@ describe('LifecycleNode test suite', function () {
     if (version < GALACTIC_VERSION) return;
 
     let rosDistro = process.env.ROS_DISTRO;
-    let firstChar = rosDistro.charAt(0);
     let testNode = new rclnodejs.lifecycle.LifecycleNode(
       'TEST_NODE',
       undefined,

--- a/test/test-message-type.js
+++ b/test/test-message-type.js
@@ -18,22 +18,6 @@ const assert = require('assert');
 const childProcess = require('child_process');
 const rclnodejs = require('../index.js');
 
-// function checkType(m, rclType, jsType, value, callback) {
-//                   // rclnodejs, 'Bool', 'boolean', '"true"', callback
-//   if ((typeof rclType !== 'string') || (typeof value !== 'string')) {
-//     throw TypeError('Invalid type of parameters!');
-//   }
-
-//   var node = m.createNode(rclType + '_subscription');
-//   var msgType = m.require('std_msgs').msg[rclType];
-//   var publisher = childProcess.fork(`${__dirname}/publisher_msg.js`, [rclType, value]);
-//   var subscription = node.createSubscription(msgType, rclType + '_type_channel', (msg) => {
-//     publisher.send('quit');
-//     callback(msg, jsType, value);
-//   });
-//   m.spin(node);
-// }
-
 describe('Rclnodejs message type testing', function () {
   this.timeout(60 * 1000);
 
@@ -125,19 +109,6 @@ describe('Rclnodejs message type testing', function () {
       );
       rclnodejs.spin(node);
     });
-
-    // it('InitString', function(done) {
-    //   var node = rclnodejs.createNode('init_string_subscription');
-    //   var msgString = 'std_msgs/msg/String';
-    //   var publisher = childProcess.fork(`${__dirname}/publisher_msg.js`, ['InitString', '"RCL String"']);
-    //   var subscription = node.createSubscription(msgString, 'InitString_channel', (msg) => {
-    //     publisher.send('quit');
-    //     assert.deepStrictEqual(typeof msg.data, 'string');
-    //     assert.deepStrictEqual(msg.data, 'RCL String');
-    //     done();
-    //   });
-    //   rclnodejs.spin(node);
-    // });
 
     it('Int8', function (done) {
       var node = rclnodejs.createNode('int8_subscription');
@@ -354,26 +325,22 @@ describe('Rclnodejs message type testing', function () {
         (msg) => {
           publisher.kill('SIGINT');
           assert.ok('r' in msg);
-          // assert.deepStrictEqual(typeof msg.r, 'number');
+          assert.deepStrictEqual(typeof msg.r, 'number');
           assert.deepStrictEqual(msg.r, 127);
           assert.ok('g' in msg);
-          // assert.deepStrictEqual(typeof msg.g, 'number');
+          assert.deepStrictEqual(typeof msg.g, 'number');
           assert.deepStrictEqual(msg.g, 255);
           assert.ok('b' in msg);
-          // assert.deepStrictEqual(typeof msg.b, 'number');
+          assert.deepStrictEqual(typeof msg.b, 'number');
           assert.deepStrictEqual(msg.b, 255);
           assert.ok('a' in msg);
-          // assert.deepStrictEqual(typeof msg.a, 'number');
+          assert.deepStrictEqual(typeof msg.a, 'number');
           assert.ok(Math.abs(msg.a - 0.5) < 0.000001);
           done();
         }
       );
       rclnodejs.spin(node);
     });
-
-    // it('Array', function(done) {
-
-    // });
 
     it('Object with Header', function (done) {
       var node = rclnodejs.createNode('header_subscription');

--- a/test/test-node-options.js
+++ b/test/test-node-options.js
@@ -14,8 +14,6 @@
 'use strict';
 
 const assert = require('assert');
-const IsClose = require('is-close');
-
 const rclnodejs = require('../index.js');
 const assertUtils = require('./utils.js');
 const assertThrowsError = assertUtils.assertThrowsError;

--- a/test/test-parameter-service.js
+++ b/test/test-parameter-service.js
@@ -28,10 +28,6 @@ const {
   PARAMETER_SEPARATOR,
 } = require('../lib/parameter.js');
 
-const PARAM_REL_TOL = 1e-6;
-
-const Node = rclnodejs.Node;
-
 const PARAMETER_EVENT_MSG_TYPE = 'rcl_interfaces/msg/ParameterEvent';
 const PARAMETER_EVENT_TOPIC = 'parameter_events';
 

--- a/test/test-primitive-msg-type-check.js
+++ b/test/test-primitive-msg-type-check.js
@@ -30,7 +30,6 @@ describe('Rclnodejs message type data testing', function () {
   });
 
   it('Bool data checking', function () {
-    var node = rclnodejs.createNode('bool');
     var msgBool = rclnodejs.require('std_msgs').msg.Bool;
     var msg = new msgBool();
 
@@ -54,7 +53,6 @@ describe('Rclnodejs message type data testing', function () {
   });
 
   it('Char data checking', function () {
-    var node = rclnodejs.createNode('char');
     var msgChar = rclnodejs.require('std_msgs').msg.Char;
     var msg = new msgChar();
 
@@ -81,7 +79,6 @@ describe('Rclnodejs message type data testing', function () {
   });
 
   it('Byte data checking', function () {
-    var node = rclnodejs.createNode('byte');
     var msgByte = rclnodejs.require('std_msgs').msg.Byte;
     var msg = new msgByte();
 
@@ -108,7 +105,6 @@ describe('Rclnodejs message type data testing', function () {
   });
 
   it('String data checking', function () {
-    var node = rclnodejs.createNode('string');
     var msgString = rclnodejs.require('std_msgs').msg.String;
     var msg = new msgString();
 
@@ -135,7 +131,6 @@ describe('Rclnodejs message type data testing', function () {
   });
 
   it('Int8 data checking', function () {
-    var node = rclnodejs.createNode('int8');
     var msgInt8 = rclnodejs.require('std_msgs').msg.Int8;
     var msg = new msgInt8();
 
@@ -162,7 +157,6 @@ describe('Rclnodejs message type data testing', function () {
   });
 
   it('UInt8 data checking', function () {
-    var node = rclnodejs.createNode('uint8');
     var msgUInt8 = rclnodejs.require('std_msgs').msg.UInt8;
     var msg = new msgUInt8();
 
@@ -189,7 +183,6 @@ describe('Rclnodejs message type data testing', function () {
   });
 
   it('Int16 data checking', function () {
-    var node = rclnodejs.createNode('int16');
     var msgInt16 = rclnodejs.require('std_msgs').msg.Int16;
     var msg = new msgInt16();
 
@@ -216,7 +209,6 @@ describe('Rclnodejs message type data testing', function () {
   });
 
   it('UInt16 data checking', function () {
-    var node = rclnodejs.createNode('uint16');
     var msgUInt16 = rclnodejs.require('std_msgs').msg.UInt16;
     var msg = new msgUInt16();
 
@@ -243,7 +235,6 @@ describe('Rclnodejs message type data testing', function () {
   });
 
   it('Int32 data checking', function () {
-    var node = rclnodejs.createNode('int32');
     var msgInt32 = rclnodejs.require('std_msgs').msg.Int32;
     var msg = new msgInt32();
 
@@ -270,7 +261,6 @@ describe('Rclnodejs message type data testing', function () {
   });
 
   it('UInt32 data checking', function () {
-    var node = rclnodejs.createNode('uint32');
     var msgUInt32 = rclnodejs.require('std_msgs').msg.UInt32;
     var msg = new msgUInt32();
 
@@ -297,7 +287,6 @@ describe('Rclnodejs message type data testing', function () {
   });
 
   it('Int64 data checking', function () {
-    var node = rclnodejs.createNode('int64');
     var msgInt64 = rclnodejs.require('std_msgs').msg.Int64;
     var msg = new msgInt64();
 
@@ -307,7 +296,6 @@ describe('Rclnodejs message type data testing', function () {
   });
 
   it('UInt64 data checking', function () {
-    var node = rclnodejs.createNode('uint64');
     var msgUInt64 = rclnodejs.require('std_msgs').msg.UInt64;
     var msg = new msgUInt64();
 
@@ -317,7 +305,6 @@ describe('Rclnodejs message type data testing', function () {
   });
 
   it('Float32 data checking', function () {
-    var node = rclnodejs.createNode('float32');
     var msgFloat32 = rclnodejs.require('std_msgs').msg.Float32;
     var msg = new msgFloat32();
 
@@ -327,7 +314,6 @@ describe('Rclnodejs message type data testing', function () {
   });
 
   it('Float64 data checking', function () {
-    var node = rclnodejs.createNode('float64');
     var msgFloat64 = rclnodejs.require('std_msgs').msg.Float64;
     var msg = new msgFloat64();
 

--- a/test/test-publisher.js
+++ b/test/test-publisher.js
@@ -14,9 +14,7 @@
 
 'use strict';
 
-const assert = require('assert');
 const rclnodejs = require('../index.js');
-const { message } = rclnodejs;
 
 describe('rclnodejs publisher test suite', function () {
   this.timeout(60 * 1000);

--- a/test/test-rate.js
+++ b/test/test-rate.js
@@ -14,11 +14,8 @@
 'use strict';
 
 const assert = require('assert');
-
-const isClose = require('is-close');
 const rclnodejs = require('../index.js');
 const assertUtils = require('./utils.js');
-const assertThrowsError = assertUtils.assertThrowsError;
 const { performance } = require('perf_hooks');
 
 describe('rclnodejs rate test suite', function () {
@@ -110,6 +107,5 @@ describe('rclnodejs rate test suite', function () {
       arr.reduce((prev, cur) => {
         return prev + cur;
       }, 0) / dataSize;
-    // console.log('data avg: ', avg);
   });
 });

--- a/test/test-raw-pub-sub.js
+++ b/test/test-raw-pub-sub.js
@@ -14,7 +14,6 @@
 
 'use strict';
 
-const childProcess = require('child_process');
 const assert = require('assert');
 const rclnodejs = require('../index.js');
 const DistroUtils = rclnodejs.DistroUtils;
@@ -49,12 +48,6 @@ describe('rclnodejs publisher test suite', function () {
         clearInterval(timer);
 
         let buffer = topic;
-        const distroId = DistroUtils.getDistroId();
-
-        if (distroId >= DistroUtils.DistroId.GALACTIC) {
-          // The received Buffer is null-terminated.
-          buffer = Buffer.concat([buffer, Buffer.from([0x00])]);
-        }
         assert.deepStrictEqual(
           Buffer.compare(msg, buffer),
           0,

--- a/test/test-service-introspection.js
+++ b/test/test-service-introspection.js
@@ -28,8 +28,6 @@ const QOS = rclnodejs.QoS.profileSystemDefault;
 
 const DELAY = 1000; // ms
 
-//  ros2 topic echo /add_two_ints/_service_event
-
 function isServiceIntrospectionSupported() {
   return DistroUtils.getDistroId() > DistroUtils.getDistroId('humble');
 }

--- a/test/test-signals.js
+++ b/test/test-signals.js
@@ -1,3 +1,15 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 
 const assert = require('assert');

--- a/test/utils.js
+++ b/test/utils.js
@@ -29,8 +29,6 @@ function assertThrowsError(operation, errors, errMsg, message) {
   assert.throws(
     operation,
     function (err) {
-      var containedMsg = new RegExp(errMsg);
-
       if (errors instanceof Array) {
         var foundError = false;
         errors.forEach((e) => {


### PR DESCRIPTION
This patch removes obsolete comments and standardizes header and inline comment placements. The changes primarily involve reordering or removing ESLint disable comments, license header additions or removals, and the deletion of commented out legacy code.

Meanwhile, this patch re-enables `test-raw-pub-sub.js` on Linux platform.

Fix: #1052