### PR TITLE
Remove unused dependencies from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,10 +58,12 @@
     "jsdoc": "^4.0.4",
     "lint-staged": "^15.2.10",
     "mocha": "^11.0.2",
+    "rimraf": "^6.0.1",
     "sinon": "^19.0.2",
     "tree-kill": "^1.2.2",
     "tsd": "^0.31.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "uuid": "^11.0.3"
   },
   "dependencies": {
     "@rclnodejs/ref-array-di": "^1.2.2",
@@ -74,12 +76,8 @@
     "fs-extra": "^11.2.0",
     "is-close": "^1.3.3",
     "json-bigint": "^1.0.0",
-    "mkdirp": "^3.0.1",
-    "mz": "^2.7.0",
     "nan": "^2.22.0",
     "prettier": "^3.4.2",
-    "rimraf": "^6.0.1",
-    "uuid": "^11.0.3",
     "walk": "^2.3.15"
   },
   "husky": {


### PR DESCRIPTION
This patch removes `mkdirp` and `mz` from `dependencies` in `package.json` as they are not used in the project. Meanwhile, `rimraf` and `uuid` are moved into `devDependencies` in  `package.json`  as they are for testing only.

Fix: #1054
