### PR TITLE
Re-enable coveralls

### DIFF
--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -52,3 +52,20 @@ jobs:
         npm i
         npm run lint
         npm test
+
+    - name: Coveralls Parallel
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        flag-name: run-${{ matrix.node-version}}
+        parallel: true
+
+  finish:
+      needs: build
+      runs-on: ubuntu-latest
+      steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ build
 log
 .vscode
 .project
+.nyc_output/
+coverage/
 
 # test build artifacts
 /test/cpp/add_two_ints_client

--- a/.npmignore
+++ b/.npmignore
@@ -11,6 +11,7 @@ suppr.txt
 types/interfaces.d.ts
 generated/
 build/
+coverage/
 dist/
 electron_demo/
 log/
@@ -21,5 +22,6 @@ example/
 benchmark/
 tutorials/
 .github/
+.nyc_output/
 .vscode/
 .husky/

--- a/.nycrc.yml
+++ b/.nycrc.yml
@@ -1,0 +1,7 @@
+extension:
+  - .js
+include:
+  - lib/**/*
+report-dir: './coverage'
+reporter:
+  - lcov

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
     "install": "npm run rebuild",
     "postinstall": "npm run generate-messages",
     "docs": "cd docs && make",
-    "test": "node --expose-gc ./scripts/run_test.js && npx tsd",
+    "test": "nyc node --expose-gc ./scripts/run_test.js && npx tsd",
     "lint": "eslint && node ./scripts/cpplint.js",
     "format": "clang-format -i -style=file ./src/*.cpp ./src/*.hpp && prettier --write \"{lib,rosidl_gen,rostsd_gen,rosidl_parser,types,example,test,scripts,benchmark}/**/*.{js,md,ts}\" ./*.{js,md,ts}",
-    "prepare": "husky"
+    "prepare": "husky",
+    "coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "bin": {
     "generate-ros-messages": "./scripts/generate_messages.js"
@@ -49,6 +50,7 @@
     "@typescript-eslint/parser": "^8.18.0",
     "clang-format": "^1.8.0",
     "commander": "^13.1.0",
+    "coveralls": "^3.1.1",
     "deep-equal": "^2.2.3",
     "eslint": "^9.16.0",
     "eslint-config-prettier": "^10.0.2",
@@ -58,6 +60,7 @@
     "jsdoc": "^4.0.4",
     "lint-staged": "^15.2.10",
     "mocha": "^11.0.2",
+    "nyc": "^17.1.0",
     "rimraf": "^6.0.1",
     "sinon": "^19.0.2",
     "tree-kill": "^1.2.2",

--- a/test/test-signals.js
+++ b/test/test-signals.js
@@ -21,7 +21,7 @@ function forkOnlyRemoveRclnodejsHandlers() {
   const myHandler = () => {};
   process.on('SIGINT', myHandler);
   rclnodejs.removeSignalHandlers();
-  if (myHandler in process.listeners('SIGINT')) {
+  if (process.listeners('SIGINT').includes(myHandler)) {
     process.exitCode = 0;
   } else {
     process.exitCode = 1;
@@ -29,8 +29,13 @@ function forkOnlyRemoveRclnodejsHandlers() {
 }
 
 function forkRemoveSignalHandlers() {
+  const listenerCount = process.listenerCount('SIGINT');
   rclnodejs.removeSignalHandlers();
-  process.exitCode = process.listenerCount('SIGINT');
+  if (listenerCount - 1 === process.listenerCount('SIGINT')) {
+    process.exitCode = 0;
+  } else {
+    process.exitCode = 1;
+  }
 }
 
 function forkDoPublish(context) {
@@ -146,7 +151,7 @@ if (process.env['RCLNODEJS_TEST_FORK']) {
       );
       await new Promise((res) => {
         child.on('close', (exitCode) => {
-          assert.strictEqual(exitCode, 1);
+          assert.strictEqual(exitCode, 0);
           res();
         });
       });


### PR DESCRIPTION
This patch re-enables `coveralls` by leveraging:

- `nyc`: https://github.com/istanbuljs/nyc/blob/main/README.md#selecting-files-for-coverage
- `Coveralls Action`: https://github.com/marketplace/actions/coveralls-github-action

Fix: #1063