### PR TITLE
Exclude .nycrc.yml from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,7 @@
 .coveralls.yml
 .clang-format
+.gitattributes
+.nycrc.yml
 .istanbul.yml
 .gitignore
 .prettierrc.yml


### PR DESCRIPTION
This patch excludes the following files from npm package:
- `.nycrc.yml`
- `.gitattributes`

Fix: #1068
