### PR TITLE
Only enable C++20 when nodejs >= 23

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,6 +12,7 @@
     'runtime%': 'node',
     'ros_lib_dir': "<!(node -p \"require('./scripts/config.js').getROSLibPath()\")",
     'ros_include_root': "<!(node -p \"require('./scripts/config.js').getROSIncludeRootPath()\")",
+    'node_major_version': '<!(node -p \"process.versions.node.split(\'.\')[0]\")',
   },
   'targets': [
     {
@@ -62,8 +63,21 @@
             'defines': [
               'OS_LINUX'
             ],
-            'cflags_cc': [
-              '-std=c++20'
+            'conditions': [
+              [
+                'node_major_version >= 23', {
+                  'cflags': [
+                    '-std=c++20'
+                  ]
+                }
+              ],
+              [
+                'node_major_version < 23', {
+                  'cflags_cc': [
+                    '-std=c++17'
+                  ]
+                }
+              ]
             ]
           }
         ],
@@ -72,8 +86,21 @@
             'defines': [
               'OS_WINDOWS'
             ],
-            'cflags_cc': [
-              '-std=c++20'
+            'conditions': [
+              [
+                'node_major_version >= 23', {
+                  'cflags': [
+                    '-std=c++20'
+                  ]
+                }
+              ],
+              [
+                'node_major_version < 23', {
+                  'cflags_cc': [
+                    '-std=c++17'
+                  ]
+                }
+              ]
             ],
             'include_dirs': [
               './src/third_party/dlfcn-win32/',

--- a/binding.gyp
+++ b/binding.gyp
@@ -66,7 +66,7 @@
             'conditions': [
               [
                 'node_major_version >= 23', {
-                  'cflags': [
+                  'cflags_cc': [
                     '-std=c++20'
                   ]
                 }
@@ -89,7 +89,7 @@
             'conditions': [
               [
                 'node_major_version >= 23', {
-                  'cflags': [
+                  'cflags_cc': [
                     '-std=c++20'
                   ]
                 }


### PR DESCRIPTION
This patch implements to enable C++20 only when nodejs >= 23, which improve the compatibility with g++ lower versions, because C++20 only needed for nodejs >= 23.

Fix: #1089
