### PR TITLE
feat: add descriptor namespaces

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,6 @@
 # rclnodejs contributors (sorted alphabetically)
 
-- **[Alaa El Jawad](https://github.com/ejalaa12), [Ian McElroy](https://github.com/imcelroy)**
+- **[Alaa El Jawad](https://github.com/ejalaa12)**
 
   - Fix compatibility with ROS2 parameters array types
   - Unit tests for all parameter types
@@ -19,6 +19,13 @@
 - **[Hanyia](https://github.com/hanyia)**
 
   - Benchmark test script
+
+- **[Ian McElroy](https://github.com/imcelroy)**
+
+  - Add descriptor namespace for all interfaces, rostsd_gen improvements
+  - Fix compatibility with ROS2 parameters array types
+  - Unit tests for all parameter types
+  - Handle concurrent ROS2 client calls, with unit tests
 
 - **[Kenny Yuan](https://github.com/kenny-y)**
 

--- a/rostsd_gen/index.js
+++ b/rostsd_gen/index.js
@@ -405,7 +405,7 @@ function saveActionAsTSD(
   fd,
   descriptorInterfaceType = false
 ) {
-  if (!descriptorInterfaceNamespace) {
+  if (!descriptorInterfaceType) {
     const actionName = rosActionInterface.type().interfaceName;
 
     const interfaceTemplate = [

--- a/rostsd_gen/index.js
+++ b/rostsd_gen/index.js
@@ -133,7 +133,7 @@ function savePkgInfoAsTSD(pkgInfos, fd) {
 
       // generate descriptor msg/srv/action interfaces
       fs.writeSync(fd, `      namespace ${descriptorInterfaceNamespace} {\n`);
-      const descriptorInterfaceType = true;
+      const willGenerateDescriptorInterface = true;
       generateRosMsgInterfaces(
         pkgInfo,
         subfolder,
@@ -141,7 +141,7 @@ function savePkgInfoAsTSD(pkgInfos, fd) {
         servicesMap,
         actionsMap,
         fd,
-        descriptorInterfaceType
+        willGenerateDescriptorInterface
       );
       // close namespace descriptor declare
       fs.writeSync(fd, '      }\n');
@@ -230,12 +230,12 @@ function generateRosMsgInterfaces(
   servicesMap,
   actionsMap,
   fd,
-  descriptorInterfaceType = false
+  willGenerateDescriptorInterface = false
 ) {
-  const descriptorNamespaceName = descriptorInterfaceType
+  const descriptorNamespaceName = willGenerateDescriptorInterface
     ? `${descriptorInterfaceNamespace}/`
     : '';
-  const descriptorNamespacePath = descriptorInterfaceType
+  const descriptorNamespacePath = willGenerateDescriptorInterface
     ? `${descriptorInterfaceNamespace}.`
     : '';
   for (const rosInterface of pkgInfo.subfolders.get(subfolder)) {
@@ -244,10 +244,16 @@ function generateRosMsgInterfaces(
     const fullInterfacePath = `${type.pkgName}.${type.subFolder}.${descriptorNamespacePath}${type.interfaceName}`;
     const fullInterfaceConstructor = fullInterfacePath + 'Constructor';
 
+    const indentStartLevel = willGenerateDescriptorInterface ? 4 : 3;
     if (isMsgInterface(rosInterface)) {
       // create message interface
-      saveMsgAsTSD(rosInterface, fd, descriptorInterfaceType);
-      saveMsgConstructorAsTSD(rosInterface, fd, descriptorInterfaceType);
+      saveMsgAsTSD(
+        rosInterface,
+        fd,
+        indentStartLevel,
+        willGenerateDescriptorInterface
+      );
+      saveMsgConstructorAsTSD(rosInterface, fd, indentStartLevel);
       messagesMap[fullInterfaceName] = fullInterfacePath;
     } else if (isSrvInterface(rosInterface)) {
       if (!isValidService(rosInterface, pkgInfo.subfolders.get(subfolder))) {
@@ -259,7 +265,7 @@ function generateRosMsgInterfaces(
       }
 
       // create service interface
-      saveSrvAsTSD(rosInterface, fd, descriptorInterfaceType);
+      saveSrvAsTSD(rosInterface, fd, indentStartLevel);
       if (!isInternalActionSrvInterface(rosInterface)) {
         servicesMap[fullInterfaceName] = fullInterfaceConstructor;
       }
@@ -273,33 +279,39 @@ function generateRosMsgInterfaces(
       }
 
       // create action interface
-      saveActionAsTSD(rosInterface, fd, descriptorInterfaceType);
+      saveActionAsTSD(rosInterface, fd, indentStartLevel);
       actionsMap[fullInterfaceName] = fullInterfaceConstructor;
     }
   }
 }
 
-function saveMsgAsTSD(rosMsgInterface, fd, descriptorInterfaceType = false) {
-  const indentlevel = descriptorInterfaceType ? 8 : 6;
+function saveMsgAsTSD(
+  rosMsgInterface,
+  fd,
+  indentLevel = 3,
+  willGenerateDescriptorInterface = false
+) {
+  const outerIndentSpacing = getIndentSpacing(indentLevel);
   const tmpl = indentString(
     `export interface ${rosMsgInterface.type().interfaceName} {\n`,
-    indentlevel
+    outerIndentSpacing
   );
   fs.writeSync(fd, tmpl);
   const useSamePkg =
     isInternalActionMsgInterface(rosMsgInterface) ||
     isInternalServiceEventMsgInterface(rosMsgInterface);
-  const indentLevel = descriptorInterfaceType ? 10 : 8;
+  const innerIndentLevel = indentLevel + 1;
+  const innerIndentSpacing = getIndentSpacing(innerIndentLevel);
   saveMsgFieldsAsTSD(
     rosMsgInterface,
     fd,
-    indentLevel,
+    innerIndentSpacing,
     ';',
     '',
     useSamePkg,
-    descriptorInterfaceType
+    willGenerateDescriptorInterface
   );
-  const tmplEnd = indentString('}\n', indentlevel);
+  const tmplEnd = indentString('}\n', outerIndentSpacing);
   fs.writeSync(fd, tmplEnd);
 }
 
@@ -314,7 +326,7 @@ function saveMsgAsTSD(rosMsgInterface, fd, descriptorInterfaceType = false) {
  * @param {string} typePrefix The prefix to put before the type name for
  * non-primitive types
  * @param {boolean} useSamePackageSubFolder Indicates if the sub folder name should be taken from the message
- * @param {boolean} descriptorInterfaceType Indicates if descriptor interface is being generated
+ * @param {boolean} willGenerateDescriptorInterface Indicates if descriptor interface is being generated
  * when the field type comes from the same package. This is needed for action interfaces. Defaults to false.
  * @returns {undefined}
  */
@@ -325,7 +337,7 @@ function saveMsgFieldsAsTSD(
   lineEnd = ',',
   typePrefix = '',
   useSamePackageSubFolder = false,
-  descriptorInterfaceType = false
+  willGenerateDescriptorInterface = false
 ) {
   let type = rosMsgInterface.type();
   let fields = rosMsgInterface.ROSMessageDef.fields;
@@ -335,7 +347,11 @@ function saveMsgFieldsAsTSD(
       useSamePackageSubFolder && field.type.pkgName === type.pkgName
         ? type.subFolder
         : 'msg';
-    let fieldType = fieldType2JSName(field, subFolder, descriptorInterfaceType);
+    let fieldType = fieldType2JSName(
+      field,
+      subFolder,
+      willGenerateDescriptorInterface
+    );
     let tp = field.type.isPrimitiveType ? '' : typePrefix;
     if (typePrefix === 'rclnodejs.') {
       fieldType = 'any';
@@ -346,11 +362,11 @@ function saveMsgFieldsAsTSD(
     if (field.type.isArray) {
       arrayString = '[]';
 
-      if (field.type.isFixedSizeArray && descriptorInterfaceType) {
+      if (field.type.isFixedSizeArray && willGenerateDescriptorInterface) {
         arrayString = `[${field.type.arraySize}]`;
       }
 
-      if (fieldType === 'number' && !descriptorInterfaceType) {
+      if (fieldType === 'number' && !willGenerateDescriptorInterface) {
         // for number[] include alternate typed-array types, e.g., number[] | uint8[]
         let jsTypedArrayName = fieldTypeArray2JSTypedArrayName(field.type.type);
 
@@ -359,7 +375,7 @@ function saveMsgFieldsAsTSD(
         }
       }
     }
-    const fieldString = descriptorInterfaceType
+    const fieldString = willGenerateDescriptorInterface
       ? `${field.name}: '${tp}${fieldType}${arrayString}'`
       : `${field.name}: ${tp}${fieldType}${arrayString}`;
     const tmpl = indentString(fieldString, indent);
@@ -370,11 +386,7 @@ function saveMsgFieldsAsTSD(
   }
 }
 
-function saveMsgConstructorAsTSD(
-  rosMsgInterface,
-  fd,
-  descriptorInterfaceType = false
-) {
+function saveMsgConstructorAsTSD(rosMsgInterface, fd, indentLevel = 3) {
   const type = rosMsgInterface.type();
   const msgName = type.interfaceName;
   let interfaceTmpl = [`export interface ${msgName}Constructor {`];
@@ -386,11 +398,11 @@ function saveMsgConstructorAsTSD(
   interfaceTmpl.push(`  new(other?: ${msgName}): ${msgName};`);
   interfaceTmpl.push('}');
   interfaceTmpl.push('');
-  const indentLevel = descriptorInterfaceType ? 8 : 6;
-  fs.writeSync(fd, indentLines(interfaceTmpl, indentLevel).join('\n'));
+  const indentSpacing = getIndentSpacing(indentLevel);
+  fs.writeSync(fd, indentLines(interfaceTmpl, indentSpacing).join('\n'));
 }
 
-function saveSrvAsTSD(rosSrvInterface, fd, descriptorInterfaceType = false) {
+function saveSrvAsTSD(rosSrvInterface, fd, indentLevel = 3) {
   const serviceName = rosSrvInterface.type().interfaceName;
 
   const interfaceTemplate = [
@@ -400,15 +412,11 @@ function saveSrvAsTSD(rosSrvInterface, fd, descriptorInterfaceType = false) {
     '}',
     '',
   ];
-  const indentLevel = descriptorInterfaceType ? 8 : 6;
-  fs.writeSync(fd, indentLines(interfaceTemplate, indentLevel).join('\n'));
+  const indentSpacing = getIndentSpacing(indentLevel);
+  fs.writeSync(fd, indentLines(interfaceTemplate, indentSpacing).join('\n'));
 }
 
-function saveActionAsTSD(
-  rosActionInterface,
-  fd,
-  descriptorInterfaceType = false
-) {
+function saveActionAsTSD(rosActionInterface, fd, indentLevel = 3) {
   const actionName = rosActionInterface.type().interfaceName;
 
   const interfaceTemplate = [
@@ -419,8 +427,19 @@ function saveActionAsTSD(
     '}',
     '',
   ];
-  const indentLevel = descriptorInterfaceType ? 8 : 6;
-  fs.writeSync(fd, indentLines(interfaceTemplate, indentLevel).join('\n'));
+  const indentSpacing = getIndentSpacing(indentLevel);
+  fs.writeSync(fd, indentLines(interfaceTemplate, indentSpacing).join('\n'));
+}
+
+/**
+ * Get number of indent spaces for given level
+ *
+ * @param {*} indentLevel Indention level
+ * @param {*} spacesPerLevel Number of spaces per level
+ * @returns Total number of space
+ */
+function getIndentSpacing(indentLevel, spacesPerLevel = 2) {
+  return indentLevel * spacesPerLevel;
 }
 
 function isMsgInterface(rosInterface) {
@@ -526,9 +545,9 @@ function isValidAction(rosActionInterface, infos) {
 function fieldType2JSName(
   fieldInfo,
   subFolder = 'msg',
-  descriptorInterfaceType = false
+  willGenerateDescriptorInterface = false
 ) {
-  if (descriptorInterfaceType) {
+  if (willGenerateDescriptorInterface) {
     return fieldInfo.type.isPrimitiveType
       ? `${fieldInfo.type.type}`
       : `${fieldInfo.type.pkgName}/${subFolder}/${fieldInfo.type.type}`;

--- a/rostsd_gen/index.js
+++ b/rostsd_gen/index.js
@@ -31,6 +31,8 @@ const fs = require('fs');
 const loader = require('../lib/interface_loader.js');
 const pkgFilters = require('../rosidl_gen/filter.js');
 
+const descriptorInterfaceNamespace = 'descriptor';
+
 async function generateAll() {
   // load pkg and interface info (msgs and srvs)
   const generatedPath = path.join(__dirname, '../generated/');
@@ -119,47 +121,30 @@ function savePkgInfoAsTSD(pkgInfos, fd) {
     for (const subfolder of pkgInfo.subfolders.keys()) {
       fs.writeSync(fd, `    namespace ${subfolder} {\n`);
 
-      for (const rosInterface of pkgInfo.subfolders.get(subfolder)) {
-        const type = rosInterface.type();
-        const fullInterfaceName = `${type.pkgName}/${type.subFolder}/${type.interfaceName}`;
-        const fullInterfacePath = `${type.pkgName}.${type.subFolder}.${type.interfaceName}`;
-        const fullInterfaceConstructor = fullInterfacePath + 'Constructor';
+      // generate real msg/srv/action interfaces
+      generateRosMsgInterfaces(
+        pkgInfo,
+        subfolder,
+        messagesMap,
+        servicesMap,
+        actionsMap,
+        fd
+      );
 
-        if (isMsgInterface(rosInterface)) {
-          // create message interface
-          saveMsgAsTSD(rosInterface, fd);
-          saveMsgConstructorAsTSD(rosInterface, fd);
-          messagesMap[fullInterfaceName] = fullInterfacePath;
-        } else if (isSrvInterface(rosInterface)) {
-          if (
-            !isValidService(rosInterface, pkgInfo.subfolders.get(subfolder))
-          ) {
-            let type = rosInterface.type();
-            console.log(
-              `Incomplete service: ${type.pkgName}.${type.subFolder}.${type.interfaceName}.`
-            );
-            continue;
-          }
-
-          // create service interface
-          saveSrvAsTSD(rosInterface, fd);
-          if (!isInternalActionSrvInterface(rosInterface)) {
-            servicesMap[fullInterfaceName] = fullInterfaceConstructor;
-          }
-        } else if (isActionInterface(rosInterface)) {
-          if (!isValidAction(rosInterface, pkgInfo.subfolders.get(subfolder))) {
-            let type = rosInterface.type();
-            console.log(
-              `Incomplete action: ${type.pkgName}.${type.subFolder}.${type.interfaceName}.`
-            );
-            continue;
-          }
-
-          // create action interface
-          saveActionAsTSD(rosInterface, fd);
-          actionsMap[fullInterfaceName] = fullInterfaceConstructor;
-        }
-      }
+      // generate descriptor msg/srv/action interfaces
+      fs.writeSync(fd, `      namespace ${descriptorInterfaceNamespace} {\n`);
+      const descriptorInterfaceType = true;
+      generateRosMsgInterfaces(
+        pkgInfo,
+        subfolder,
+        messagesMap,
+        servicesMap,
+        actionsMap,
+        fd,
+        descriptorInterfaceType
+      );
+      // close namespace descriptor declare
+      fs.writeSync(fd, '      }\n');
 
       // close namespace declare
       fs.writeSync(fd, '    }\n');
@@ -238,16 +223,78 @@ function savePkgInfoAsTSD(pkgInfos, fd) {
   fs.writeSync(fd, '}\n');
 }
 
-function saveMsgAsTSD(rosMsgInterface, fd) {
-  fs.writeSync(
-    fd,
-    `      export interface ${rosMsgInterface.type().interfaceName} {\n`
+function generateRosMsgInterfaces(
+  pkgInfo,
+  subfolder,
+  messagesMap,
+  servicesMap,
+  actionsMap,
+  fd,
+  descriptorInterfaceType = false
+) {
+  for (const rosInterface of pkgInfo.subfolders.get(subfolder)) {
+    const type = rosInterface.type();
+    const fullInterfaceName = `${type.pkgName}/${type.subFolder}/${type.interfaceName}`;
+    const fullInterfacePath = `${type.pkgName}.${type.subFolder}.${type.interfaceName}`;
+    const fullInterfaceConstructor = fullInterfacePath + 'Constructor';
+
+    if (isMsgInterface(rosInterface)) {
+      // create message interface
+      saveMsgAsTSD(rosInterface, fd, descriptorInterfaceType);
+      saveMsgConstructorAsTSD(rosInterface, fd, descriptorInterfaceType);
+      messagesMap[fullInterfaceName] = fullInterfacePath;
+    } else if (isSrvInterface(rosInterface)) {
+      if (!isValidService(rosInterface, pkgInfo.subfolders.get(subfolder))) {
+        let type = rosInterface.type();
+        console.log(
+          `Incomplete service: ${type.pkgName}.${type.subFolder}.${type.interfaceName}.`
+        );
+        continue;
+      }
+
+      // create service interface
+      saveSrvAsTSD(rosInterface, fd, descriptorInterfaceType);
+      if (!isInternalActionSrvInterface(rosInterface)) {
+        servicesMap[fullInterfaceName] = fullInterfaceConstructor;
+      }
+    } else if (isActionInterface(rosInterface)) {
+      if (!isValidAction(rosInterface, pkgInfo.subfolders.get(subfolder))) {
+        let type = rosInterface.type();
+        console.log(
+          `Incomplete action: ${type.pkgName}.${type.subFolder}.${type.interfaceName}.`
+        );
+        continue;
+      }
+
+      // create action interface
+      saveActionAsTSD(rosInterface, fd, descriptorInterfaceType);
+      actionsMap[fullInterfaceName] = fullInterfaceConstructor;
+    }
+  }
+}
+
+function saveMsgAsTSD(rosMsgInterface, fd, descriptorInterfaceType = false) {
+  const indentlevel = descriptorInterfaceType ? 8 : 6;
+  const tmpl = indentString(
+    `export interface ${rosMsgInterface.type().interfaceName} {\n`,
+    indentlevel
   );
+  fs.writeSync(fd, tmpl);
   const useSamePkg =
     isInternalActionMsgInterface(rosMsgInterface) ||
     isInternalServiceEventMsgInterface(rosMsgInterface);
-  saveMsgFieldsAsTSD(rosMsgInterface, fd, 8, ';', '', useSamePkg);
-  fs.writeSync(fd, '      }\n');
+  const indentLevel = descriptorInterfaceType ? 10 : 8;
+  saveMsgFieldsAsTSD(
+    rosMsgInterface,
+    fd,
+    indentLevel,
+    ';',
+    '',
+    useSamePkg,
+    descriptorInterfaceType
+  );
+  const tmplEnd = indentString('}\n', indentlevel);
+  fs.writeSync(fd, tmplEnd);
 }
 
 /**
@@ -261,6 +308,7 @@ function saveMsgAsTSD(rosMsgInterface, fd) {
  * @param {string} typePrefix The prefix to put before the type name for
  * non-primitive types
  * @param {boolean} useSamePackageSubFolder Indicates if the sub folder name should be taken from the message
+ * @param {boolean} descriptorInterfaceType Indicates if descriptor interface is being generated
  * when the field type comes from the same package. This is needed for action interfaces. Defaults to false.
  * @returns {undefined}
  */
@@ -270,7 +318,8 @@ function saveMsgFieldsAsTSD(
   indent = 0,
   lineEnd = ',',
   typePrefix = '',
-  useSamePackageSubFolder = false
+  useSamePackageSubFolder = false,
+  descriptorInterfaceType = false
 ) {
   let type = rosMsgInterface.type();
   let fields = rosMsgInterface.ROSMessageDef.fields;
@@ -280,75 +329,96 @@ function saveMsgFieldsAsTSD(
       useSamePackageSubFolder && field.type.pkgName === type.pkgName
         ? type.subFolder
         : 'msg';
-    let fieldType = fieldType2JSName(field, subFolder);
+    let fieldType = fieldType2JSName(field, subFolder, descriptorInterfaceType);
     let tp = field.type.isPrimitiveType ? '' : typePrefix;
     if (typePrefix === 'rclnodejs.') {
       fieldType = 'any';
       tp = '';
     }
 
-    const tmpl = indentString(`${field.name}: ${tp}${fieldType}`, indent);
-    fs.writeSync(fd, tmpl);
+    let arrayString = '';
     if (field.type.isArray) {
-      fs.writeSync(fd, '[]');
+      arrayString = '[]';
 
-      if (fieldType === 'number') {
+      if (field.type.isFixedSizeArray && descriptorInterfaceType) {
+        arrayString = `[${field.type.arraySize}]`;
+      }
+
+      if (fieldType === 'number' && !descriptorInterfaceType) {
         // for number[] include alternate typed-array types, e.g., number[] | uint8[]
         let jsTypedArrayName = fieldTypeArray2JSTypedArrayName(field.type.type);
 
         if (jsTypedArrayName) {
-          fs.writeSync(fd, ` | ${jsTypedArrayName}`);
+          arrayString += ` | ${jsTypedArrayName}`;
         }
       }
     }
+    const fieldString = descriptorInterfaceType
+      ? `${field.name}: '${tp}${fieldType}${arrayString}'`
+      : `${field.name}: ${tp}${fieldType}${arrayString}`;
+    const tmpl = indentString(fieldString, indent);
+    fs.writeSync(fd, tmpl);
 
     fs.writeSync(fd, lineEnd);
     fs.writeSync(fd, '\n');
   }
 }
 
-function saveMsgConstructorAsTSD(rosMsgInterface, fd) {
+function saveMsgConstructorAsTSD(
+  rosMsgInterface,
+  fd,
+  descriptorInterfaceType = false
+) {
   const type = rosMsgInterface.type();
   const msgName = type.interfaceName;
+  if (!descriptorInterfaceType) {
+    fs.writeSync(fd, `      export interface ${msgName}Constructor {\n`);
 
-  fs.writeSync(fd, `      export interface ${msgName}Constructor {\n`);
+    for (const constant of rosMsgInterface.ROSMessageDef.constants) {
+      const constantType = primitiveType2JSName(constant.type);
+      fs.writeSync(fd, `        readonly ${constant.name}: ${constantType};\n`);
+    }
 
-  for (const constant of rosMsgInterface.ROSMessageDef.constants) {
-    const constantType = primitiveType2JSName(constant.type);
-    fs.writeSync(fd, `        readonly ${constant.name}: ${constantType};\n`);
+    fs.writeSync(fd, `        new(other?: ${msgName}): ${msgName};\n`);
+    fs.writeSync(fd, '      }\n');
   }
-
-  fs.writeSync(fd, `        new(other?: ${msgName}): ${msgName};\n`);
-  fs.writeSync(fd, '      }\n');
 }
 
-function saveSrvAsTSD(rosSrvInterface, fd) {
-  const serviceName = rosSrvInterface.type().interfaceName;
+function saveSrvAsTSD(rosSrvInterface, fd, descriptorInterfaceType = false) {
+  if (!descriptorInterfaceType) {
+    const serviceName = rosSrvInterface.type().interfaceName;
 
-  const interfaceTemplate = [
-    `export interface ${serviceName}Constructor extends ROSService {`,
-    `  readonly Request: ${serviceName}_RequestConstructor;`,
-    `  readonly Response: ${serviceName}_ResponseConstructor;`,
-    '}',
-    '',
-  ];
-
-  fs.writeSync(fd, indentLines(interfaceTemplate, 6).join('\n'));
+    const interfaceTemplate = [
+      `export interface ${serviceName}Constructor extends ROSService {`,
+      `  readonly Request: ${serviceName}_RequestConstructor;`,
+      `  readonly Response: ${serviceName}_ResponseConstructor;`,
+      '}',
+      '',
+    ];
+    const indentLevel = 6;
+    fs.writeSync(fd, indentLines(interfaceTemplate, indentLevel).join('\n'));
+  }
 }
 
-function saveActionAsTSD(rosActionInterface, fd) {
-  const actionName = rosActionInterface.type().interfaceName;
+function saveActionAsTSD(
+  rosActionInterface,
+  fd,
+  descriptorInterfaceType = false
+) {
+  if (!descriptorInterfaceNamespace) {
+    const actionName = rosActionInterface.type().interfaceName;
 
-  const interfaceTemplate = [
-    `export interface ${actionName}Constructor {`,
-    `  readonly Goal: ${actionName}_GoalConstructor;`,
-    `  readonly Result: ${actionName}_ResultConstructor;`,
-    `  readonly Feedback: ${actionName}_FeedbackConstructor;`,
-    '}',
-    '',
-  ];
-
-  fs.writeSync(fd, indentLines(interfaceTemplate, 6).join('\n'));
+    const interfaceTemplate = [
+      `export interface ${actionName}Constructor {`,
+      `  readonly Goal: ${actionName}_GoalConstructor;`,
+      `  readonly Result: ${actionName}_ResultConstructor;`,
+      `  readonly Feedback: ${actionName}_FeedbackConstructor;`,
+      '}',
+      '',
+    ];
+    const indentLevel = 6;
+    fs.writeSync(fd, indentLines(interfaceTemplate, indentLevel).join('\n'));
+  }
 }
 
 function isMsgInterface(rosInterface) {
@@ -451,7 +521,16 @@ function isValidAction(rosActionInterface, infos) {
   return matches === SUCCESS_MATCH_COUNT;
 }
 
-function fieldType2JSName(fieldInfo, subFolder = 'msg') {
+function fieldType2JSName(
+  fieldInfo,
+  subFolder = 'msg',
+  descriptorInterfaceType = false
+) {
+  if (descriptorInterfaceType) {
+    return fieldInfo.type.isPrimitiveType
+      ? `${fieldInfo.type.type}`
+      : `${fieldInfo.type.pkgName}/${subFolder}/${fieldInfo.type.type}`;
+  }
   return fieldInfo.type.isPrimitiveType
     ? primitiveType2JSName(fieldInfo.type.type)
     : `${fieldInfo.type.pkgName}.${subFolder}.${fieldInfo.type.type}`;

--- a/rostsd_gen/index.js
+++ b/rostsd_gen/index.js
@@ -232,10 +232,16 @@ function generateRosMsgInterfaces(
   fd,
   descriptorInterfaceType = false
 ) {
+  const descriptorNamespaceName = descriptorInterfaceType
+    ? `${descriptorInterfaceNamespace}/`
+    : '';
+  const descriptorNamespacePath = descriptorInterfaceType
+    ? `${descriptorInterfaceNamespace}.`
+    : '';
   for (const rosInterface of pkgInfo.subfolders.get(subfolder)) {
     const type = rosInterface.type();
-    const fullInterfaceName = `${type.pkgName}/${type.subFolder}/${type.interfaceName}`;
-    const fullInterfacePath = `${type.pkgName}.${type.subFolder}.${type.interfaceName}`;
+    const fullInterfaceName = `${type.pkgName}/${type.subFolder}/${descriptorNamespaceName}${type.interfaceName}`;
+    const fullInterfacePath = `${type.pkgName}.${type.subFolder}.${descriptorNamespacePath}${type.interfaceName}`;
     const fullInterfaceConstructor = fullInterfacePath + 'Constructor';
 
     if (isMsgInterface(rosInterface)) {
@@ -371,33 +377,31 @@ function saveMsgConstructorAsTSD(
 ) {
   const type = rosMsgInterface.type();
   const msgName = type.interfaceName;
-  if (!descriptorInterfaceType) {
-    fs.writeSync(fd, `      export interface ${msgName}Constructor {\n`);
+  let interfaceTmpl = [`export interface ${msgName}Constructor {`];
 
-    for (const constant of rosMsgInterface.ROSMessageDef.constants) {
-      const constantType = primitiveType2JSName(constant.type);
-      fs.writeSync(fd, `        readonly ${constant.name}: ${constantType};\n`);
-    }
-
-    fs.writeSync(fd, `        new(other?: ${msgName}): ${msgName};\n`);
-    fs.writeSync(fd, '      }\n');
+  for (const constant of rosMsgInterface.ROSMessageDef.constants) {
+    const constantType = primitiveType2JSName(constant.type);
+    interfaceTmpl.push(`  readonly ${constant.name}: ${constantType};`);
   }
+  interfaceTmpl.push(`  new(other?: ${msgName}): ${msgName};`);
+  interfaceTmpl.push('}');
+  interfaceTmpl.push('');
+  const indentLevel = descriptorInterfaceType ? 8 : 6;
+  fs.writeSync(fd, indentLines(interfaceTmpl, indentLevel).join('\n'));
 }
 
 function saveSrvAsTSD(rosSrvInterface, fd, descriptorInterfaceType = false) {
-  if (!descriptorInterfaceType) {
-    const serviceName = rosSrvInterface.type().interfaceName;
+  const serviceName = rosSrvInterface.type().interfaceName;
 
-    const interfaceTemplate = [
-      `export interface ${serviceName}Constructor extends ROSService {`,
-      `  readonly Request: ${serviceName}_RequestConstructor;`,
-      `  readonly Response: ${serviceName}_ResponseConstructor;`,
-      '}',
-      '',
-    ];
-    const indentLevel = 6;
-    fs.writeSync(fd, indentLines(interfaceTemplate, indentLevel).join('\n'));
-  }
+  const interfaceTemplate = [
+    `export interface ${serviceName}Constructor extends ROSService {`,
+    `  readonly Request: ${serviceName}_RequestConstructor;`,
+    `  readonly Response: ${serviceName}_ResponseConstructor;`,
+    '}',
+    '',
+  ];
+  const indentLevel = descriptorInterfaceType ? 8 : 6;
+  fs.writeSync(fd, indentLines(interfaceTemplate, indentLevel).join('\n'));
 }
 
 function saveActionAsTSD(
@@ -405,20 +409,18 @@ function saveActionAsTSD(
   fd,
   descriptorInterfaceType = false
 ) {
-  if (!descriptorInterfaceType) {
-    const actionName = rosActionInterface.type().interfaceName;
+  const actionName = rosActionInterface.type().interfaceName;
 
-    const interfaceTemplate = [
-      `export interface ${actionName}Constructor {`,
-      `  readonly Goal: ${actionName}_GoalConstructor;`,
-      `  readonly Result: ${actionName}_ResultConstructor;`,
-      `  readonly Feedback: ${actionName}_FeedbackConstructor;`,
-      '}',
-      '',
-    ];
-    const indentLevel = 6;
-    fs.writeSync(fd, indentLines(interfaceTemplate, indentLevel).join('\n'));
-  }
+  const interfaceTemplate = [
+    `export interface ${actionName}Constructor {`,
+    `  readonly Goal: ${actionName}_GoalConstructor;`,
+    `  readonly Result: ${actionName}_ResultConstructor;`,
+    `  readonly Feedback: ${actionName}_FeedbackConstructor;`,
+    '}',
+    '',
+  ];
+  const indentLevel = descriptorInterfaceType ? 8 : 6;
+  fs.writeSync(fd, indentLines(interfaceTemplate, indentLevel).join('\n'));
 }
 
 function isMsgInterface(rosInterface) {

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -390,3 +390,48 @@ param.value.integer_value = BigInt(123);
 expectType<bigint>(param.value.integer_value);
 param.value.byte_array_value = [1, 2, 3];
 expectType<number[]>(param.value.byte_array_value);
+
+// ---- Descriptors -----
+// Note: All fields are of type string exactly equal to the type of interface.
+// built-in msg
+const duration = rclnodejs.createMessageObject(
+  'builtin_interfaces/msg/descriptor/Duration'
+);
+expectType<rclnodejs.builtin_interfaces.msg.descriptor.Duration>(duration);
+expectType<'int32'>(duration.sec);
+expectType<'uint32'>(duration.nanosec);
+// msg containing complex types
+const poseStampedDescriptor = rclnodejs.createMessageObject(
+  'geometry_msgs/msg/descriptor/PoseStamped'
+);
+expectType<rclnodejs.geometry_msgs.msg.descriptor.PoseStamped>(
+  poseStampedDescriptor
+);
+expectType<'std_msgs/msg/Header'>(poseStampedDescriptor.header);
+expectType<'geometry_msgs/msg/Pose'>(poseStampedDescriptor.pose);
+// action interface
+const navigateToPoseFeedbackDescriptor = rclnodejs.createMessageObject(
+  'nav2_msgs/action/descriptor/NavigateToPose_Feedback'
+);
+expectType<rclnodejs.nav2_msgs.action.descriptor.NavigateToPose_Feedback>(
+  navigateToPoseFeedbackDescriptor
+);
+expectType<'geometry_msgs/msg/PoseStamped'>(
+  navigateToPoseFeedbackDescriptor.current_pose
+);
+expectType<'float32'>(navigateToPoseFeedbackDescriptor.distance_remaining);
+expectType<'builtin_interfaces/msg/Duration'>(
+  navigateToPoseFeedbackDescriptor.estimated_time_remaining
+);
+expectType<'builtin_interfaces/msg/Duration'>(
+  navigateToPoseFeedbackDescriptor.navigation_time
+);
+expectType<'int16'>(navigateToPoseFeedbackDescriptor.number_of_recoveries);
+// srv interface
+const cancelGoalRequestDescriptor = rclnodejs.createMessageObject(
+  'action_msgs/srv/descriptor/CancelGoal_Request'
+);
+expectType<rclnodejs.action_msgs.srv.descriptor.CancelGoal_Request>(
+  cancelGoalRequestDescriptor
+);
+expectType<'action_msgs/msg/GoalInfo'>(cancelGoalRequestDescriptor.goal_info);

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../types/index.d.ts' />
 
-import { expectType } from 'tsd';
+import { expectType, expectAssignable } from 'tsd';
 import * as rclnodejs from 'rclnodejs';
 
 const NODE_NAME = 'test_node';
@@ -398,8 +398,8 @@ const duration = rclnodejs.createMessageObject(
   'builtin_interfaces/msg/descriptor/Duration'
 );
 expectType<rclnodejs.builtin_interfaces.msg.descriptor.Duration>(duration);
-expectType<'int32'>(duration.sec);
-expectType<'uint32'>(duration.nanosec);
+expectAssignable<'int32'>(duration.sec);
+expectAssignable<'uint32'>(duration.nanosec);
 // msg containing complex types
 const poseStampedDescriptor = rclnodejs.createMessageObject(
   'geometry_msgs/msg/descriptor/PoseStamped'
@@ -407,8 +407,8 @@ const poseStampedDescriptor = rclnodejs.createMessageObject(
 expectType<rclnodejs.geometry_msgs.msg.descriptor.PoseStamped>(
   poseStampedDescriptor
 );
-expectType<'std_msgs/msg/Header'>(poseStampedDescriptor.header);
-expectType<'geometry_msgs/msg/Pose'>(poseStampedDescriptor.pose);
+expectAssignable<'std_msgs/msg/Header'>(poseStampedDescriptor.header);
+expectAssignable<'geometry_msgs/msg/Pose'>(poseStampedDescriptor.pose);
 // action interface
 const navigateToPoseFeedbackDescriptor = rclnodejs.createMessageObject(
   'nav2_msgs/action/descriptor/NavigateToPose_Feedback'
@@ -416,17 +416,21 @@ const navigateToPoseFeedbackDescriptor = rclnodejs.createMessageObject(
 expectType<rclnodejs.nav2_msgs.action.descriptor.NavigateToPose_Feedback>(
   navigateToPoseFeedbackDescriptor
 );
-expectType<'geometry_msgs/msg/PoseStamped'>(
+expectAssignable<'geometry_msgs/msg/PoseStamped'>(
   navigateToPoseFeedbackDescriptor.current_pose
 );
-expectType<'float32'>(navigateToPoseFeedbackDescriptor.distance_remaining);
-expectType<'builtin_interfaces/msg/Duration'>(
+expectAssignable<'float32'>(
+  navigateToPoseFeedbackDescriptor.distance_remaining
+);
+expectAssignable<'builtin_interfaces/msg/Duration'>(
   navigateToPoseFeedbackDescriptor.estimated_time_remaining
 );
-expectType<'builtin_interfaces/msg/Duration'>(
+expectAssignable<'builtin_interfaces/msg/Duration'>(
   navigateToPoseFeedbackDescriptor.navigation_time
 );
-expectType<'int16'>(navigateToPoseFeedbackDescriptor.number_of_recoveries);
+expectAssignable<'int16'>(
+  navigateToPoseFeedbackDescriptor.number_of_recoveries
+);
 // srv interface
 const cancelGoalRequestDescriptor = rclnodejs.createMessageObject(
   'action_msgs/srv/descriptor/CancelGoal_Request'
@@ -434,4 +438,6 @@ const cancelGoalRequestDescriptor = rclnodejs.createMessageObject(
 expectType<rclnodejs.action_msgs.srv.descriptor.CancelGoal_Request>(
   cancelGoalRequestDescriptor
 );
-expectType<'action_msgs/msg/GoalInfo'>(cancelGoalRequestDescriptor.goal_info);
+expectAssignable<'action_msgs/msg/GoalInfo'>(
+  cancelGoalRequestDescriptor.goal_info
+);

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -410,27 +410,13 @@ expectType<rclnodejs.geometry_msgs.msg.descriptor.PoseStamped>(
 expectAssignable<'std_msgs/msg/Header'>(poseStampedDescriptor.header);
 expectAssignable<'geometry_msgs/msg/Pose'>(poseStampedDescriptor.pose);
 // action interface
-const navigateToPoseFeedbackDescriptor = rclnodejs.createMessageObject(
-  'nav2_msgs/action/descriptor/NavigateToPose_Feedback'
+const fibonacciFeedback = rclnodejs.createMessageObject(
+  'example_interfaces/action/descriptor/Fibonacci_Feedback'
 );
-expectType<rclnodejs.nav2_msgs.action.descriptor.NavigateToPose_Feedback>(
-  navigateToPoseFeedbackDescriptor
+expectType<rclnodejs.example_interfaces.action.descriptor.Fibonacci_Feedback>(
+  fibonacciFeedback
 );
-expectAssignable<'geometry_msgs/msg/PoseStamped'>(
-  navigateToPoseFeedbackDescriptor.current_pose
-);
-expectAssignable<'float32'>(
-  navigateToPoseFeedbackDescriptor.distance_remaining
-);
-expectAssignable<'builtin_interfaces/msg/Duration'>(
-  navigateToPoseFeedbackDescriptor.estimated_time_remaining
-);
-expectAssignable<'builtin_interfaces/msg/Duration'>(
-  navigateToPoseFeedbackDescriptor.navigation_time
-);
-expectAssignable<'int16'>(
-  navigateToPoseFeedbackDescriptor.number_of_recoveries
-);
+expectAssignable<'int32[]'>(fibonacciFeedback.sequence);
 // srv interface
 const cancelGoalRequestDescriptor = rclnodejs.createMessageObject(
   'action_msgs/srv/descriptor/CancelGoal_Request'


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
This will add a new namespace called `descriptor` for each ROS package interface generated by `generate-ros-messages`. The new namespace is found inside the msg|srv|action namespace for each package. For example:

```typescript
namespace builtin_interfaces {
    namespace msg {
      export interface Duration {
        sec: number;
        nanosec: number;
      }
      export interface DurationConstructor {
        new(other?: Duration): Duration;
      }
      export interface Time {
        sec: number;
        nanosec: number;
      }
      export interface TimeConstructor {
        new(other?: Time): Time;
      }
      namespace descriptor {
        export interface Duration {
          sec: 'int32';
          nanosec: 'uint32';
        }
        export interface Time {
          sec: 'int32';
          nanosec: 'uint32';
        }
      }
    }
  }
``` 
The descriptor interfaces always have the format `{field: "<interface_type>"}`. For example:

```typescript
  namespace geometry_msgs {
    namespace msg {
      namespace descriptor {
        export interface PointStamped {
          header: 'std_msgs/msg/Header';
          point: 'geometry_msgs/msg/Point';
        }
      }
    } 
  }  
```
<!-- Link relevant GitHub issues -->
Here is the discussion: [discussions/1091](https://github.com/RobotWebTools/rclnodejs/discussions/1091)