### PR TITLE
Support rcl_get_client_names_and_types_by_node

### DIFF
--- a/example/ros-graph-example.js
+++ b/example/ros-graph-example.js
@@ -46,6 +46,11 @@ rclnodejs
       }
     );
 
+    let clientNode = new rclnodejs.Node('client_node', 'ns2');
+    clientNode.createClient(
+      'example_interfaces/srv/AddTwoInts',
+      'add_two_ints'
+    );
     let node = rclnodejs.createNode('ros_graph_display_node', ns);
     let nodeNamesAndNameSpaces = node.getNodeNamesAndNamespaces();
 
@@ -114,6 +119,15 @@ rclnodejs
             ),
           };
         }),
+        undefined,
+        '  '
+      )
+    );
+
+    console.log('CLIENTS BY NODE');
+    console.log(
+      JSON.stringify(
+        node.getClientNamesAndTypesByNode('client_node', '/ns2'),
         undefined,
         '  '
       )

--- a/lib/node.js
+++ b/lib/node.js
@@ -969,13 +969,27 @@ class Node extends rclnodejs.ShadowNode {
   }
 
   /**
-   * Get the list of service topics discovered by the provided node for the remote node name.
+   * Get service names and types for which a remote node has servers.
    * @param {string} nodeName - The name of the node.
    * @param {string} namespace - The name of the namespace.
    * @return {Array<{name: string, types: Array<string>}>} - An array of the names and types.
    */
   getServiceNamesAndTypesByNode(nodeName, namespace) {
     return rclnodejs.getServiceNamesAndTypesByNode(
+      this.handle,
+      nodeName,
+      namespace
+    );
+  }
+
+  /**
+   * Get service names and types for which a remote node has clients.
+   * @param {string} nodeName - The name of the node.
+   * @param {string} namespace - The name of the namespace.
+   * @return {Array<{name: string, types: Array<string>}>} - An array of the names and types.
+   */
+  getClientNamesAndTypesByNode(nodeName, namespace) {
+    return rclnodejs.getClientNamesAndTypesByNode(
       this.handle,
       nodeName,
       namespace

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -1738,15 +1738,45 @@ NAN_METHOD(GetServiceNamesAndTypesByNode) {
       rcl_get_service_names_and_types_by_node(
           node, &allocator, node_name.c_str(), node_namespace.c_str(),
           &service_names_and_types),
-      "Failed to get_publisher_names_and_types.");
+      "Failed to get_service_names_and_types.");
 
   v8::Local<v8::Array> result_list =
       Nan::New<v8::Array>(service_names_and_types.names.size);
   ExtractNamesAndTypes(service_names_and_types, &result_list);
 
+  THROW_ERROR_IF_NOT_EQUAL(
+      RCL_RET_OK, rcl_names_and_types_fini(&service_names_and_types),
+      "Failed to destroy rcl_get_zero_initialized_names_and_types");
+
+  info.GetReturnValue().Set(result_list);
+}
+
+NAN_METHOD(GetClientNamesAndTypesByNode) {
+  v8::Local<v8::Context> currentContent = Nan::GetCurrentContext();
+  RclHandle* node_handle = RclHandle::Unwrap<RclHandle>(
+      Nan::To<v8::Object>(info[0]).ToLocalChecked());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  std::string node_name =
+      *Nan::Utf8String(info[1]->ToString(currentContent).ToLocalChecked());
+  std::string node_namespace =
+      *Nan::Utf8String(info[2]->ToString(currentContent).ToLocalChecked());
+
+  rcl_names_and_types_t client_names_and_types =
+      rcl_get_zero_initialized_names_and_types();
+  rcl_allocator_t allocator = rcl_get_default_allocator();
   THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
-                           rcl_names_and_types_fini(&service_names_and_types),
-                           "Failed to destroy topic_names_and_types");
+                           rcl_get_client_names_and_types_by_node(
+                               node, &allocator, node_name.c_str(),
+                               node_namespace.c_str(), &client_names_and_types),
+                           "Failed to get_client_names_and_types.");
+
+  v8::Local<v8::Array> result_list =
+      Nan::New<v8::Array>(client_names_and_types.names.size);
+  ExtractNamesAndTypes(client_names_and_types, &result_list);
+
+  THROW_ERROR_IF_NOT_EQUAL(
+      RCL_RET_OK, rcl_names_and_types_fini(&client_names_and_types),
+      "Failed to destroy rcl_get_zero_initialized_names_and_types");
 
   info.GetReturnValue().Set(result_list);
 }
@@ -2033,6 +2063,7 @@ std::vector<BindingMethod> binding_methods = {
     {"getPublisherNamesAndTypesByNode", GetPublisherNamesAndTypesByNode},
     {"getSubscriptionNamesAndTypesByNode", GetSubscriptionNamesAndTypesByNode},
     {"getServiceNamesAndTypesByNode", GetServiceNamesAndTypesByNode},
+    {"getClientNamesAndTypesByNode", GetClientNamesAndTypesByNode},
     {"getTopicNamesAndTypes", GetTopicNamesAndTypes},
     {"getServiceNamesAndTypes", GetServiceNamesAndTypes},
     {"getNodeNames", GetNodeNames},

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -57,6 +57,9 @@ expectType<rclnodejs.NamesAndTypesQueryResult[]>(
   node.getServiceNamesAndTypesByNode(NODE_NAME)
 );
 expectType<rclnodejs.NamesAndTypesQueryResult[]>(
+  node.getClientNamesAndTypesByNode(NODE_NAME)
+);
+expectType<rclnodejs.NamesAndTypesQueryResult[]>(
   node.getSubscriptionNamesAndTypesByNode(NODE_NAME)
 );
 expectType<rclnodejs.NamesAndTypesQueryResult[]>(node.getTopicNamesAndTypes());

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -686,6 +686,22 @@ declare module 'rclnodejs' {
     ): Array<NamesAndTypesQueryResult>;
 
     /**
+     * Get a remote node's client topics.
+     *
+     * @param remoteNodeName - Name of the remote node.
+     * @param namespace - Name of the remote namespace.
+     * @returns An array of the names and types.
+     *        [
+     *          { name: '/rosout', types: [ 'rcl_interfaces/msg/Log' ] },
+     *          ...
+     *        ]
+     */
+    getClientNamesAndTypesByNode(
+      remoteNodeName: string,
+      namespace?: string
+    ): Array<NamesAndTypesQueryResult>;
+
+    /**
      * Get this node's topics and corresponding types.
      *
      * @param noDemangle - If true. topic names and types returned will not be demangled, default: false.


### PR DESCRIPTION
This patch implements to expose `rcl_get_client_names_and_types_by_node` provided by `rcl` library, including:

1. Expose `rcl_get_client_names_and_types_by_node` by binding to JavaScript method `GetClientNamesAndTypesByNode`.
2. Add the type definition for `GetClientNamesAndTypesByNode` into `rclnodejs.d.ts`.
3. Add unit test for type into `test/types/index.test-d.ts`.
4. Add example into `example/ros-graph-example.js`.

Fix: #1096
