### PR TITLE
Don't run test for rolling on Windows temporarily

### DIFF
--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -1,4 +1,3 @@
-
 name:  rclnodejs - Windows Build & Test
 
 on:
@@ -61,4 +60,4 @@ jobs:
       run: |
         call "c:\dev\${{ needs.identify-ros-distro.outputs.distro }}\ros2-windows\setup.bat"
         cmd /c "if ${{ needs.identify-ros-distro.outputs.distro }}==foxy (set RMW_IMPLEMENTATION=rmw_cyclonedds_cpp&&npm test)"
-        cmd /c "if NOT ${{ needs.identify-ros-distro.outputs.distro }}==foxy (npm test)"
+        cmd /c "if NOT ${{ needs.identify-ros-distro.outputs.distro }}==foxy if NOT ${{ needs.identify-ros-distro.outputs.distro }}==rolling (npm test)"


### PR DESCRIPTION
The latest ROS2 rolling is migrating to `pixi` to install dependencies on Windows platform, which causes the failure of running unit tests, we are going to disable it temporarily.

See details:

- https://docs.ros.org/en/rolling/Installation/Windows-Install-Binary.html
- https://github.com/RobotWebTools/rclnodejs/pull/1101

Fix: #1102