### PR TITLE
Add some missing methods from rcl

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -219,6 +219,14 @@ class Context {
     }
     return defaultContext;
   }
+
+  /**
+   * Get the domain ID of this context.
+   * @returns {Number} domain ID of this context
+   */
+  get domainId() {
+    return rclnodejs.getDomainId(this.handle);
+  }
 }
 
 Context._instances = [];

--- a/lib/node.js
+++ b/lib/node.js
@@ -1062,7 +1062,7 @@ class Node extends rclnodejs.ShadowNode {
   }
 
   /**
-   * Get the number of client on a given service name.
+   * Get the number of clients on a given service name.
    * @param {string} serviceName - the service name
    * @returns {Number}
    */
@@ -1071,7 +1071,7 @@ class Node extends rclnodejs.ShadowNode {
   }
 
   /**
-   * Get the number of client on a given service name.
+   * Get the number of services on a given service name.
    * @param {string} serviceName - the service name
    * @returns {Number}
    */

--- a/lib/node.js
+++ b/lib/node.js
@@ -1062,6 +1062,24 @@ class Node extends rclnodejs.ShadowNode {
   }
 
   /**
+   * Get the number of client on a given service name.
+   * @param {string} serviceName - the service name
+   * @returns {Number}
+   */
+  countClients(serviceName) {
+    return rclnodejs.countClients(this.handle, serviceName);
+  }
+
+  /**
+   * Get the number of client on a given service name.
+   * @param {string} serviceName - the service name
+   * @returns {Number}
+   */
+  countServices(serviceName) {
+    return rclnodejs.countServices(this.handle, serviceName);
+  }
+
+  /**
    * Get the list of parameter-overrides found on the commandline and
    * in the NodeOptions.parameter_overrides property.
    *

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -74,7 +74,7 @@ class Publisher extends Entity {
   }
 
   /**
-   * Get the number of subscription to this publisher.
+   * Get the number of subscriptions to this publisher.
    * @returns {number} The number of subscription
    */
   get subscriptionCount() {

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -75,7 +75,7 @@ class Publisher extends Entity {
 
   /**
    * Get the number of subscriptions to this publisher.
-   * @returns {number} The number of subscription
+   * @returns {number} The number of subscriptions
    */
   get subscriptionCount() {
     return rclnodejs.getSubscriptionCount(this._handle);

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -72,6 +72,14 @@ class Publisher extends Entity {
     );
     return new Publisher(handle, typeClass, topic, options);
   }
+
+  /**
+   * Get the number of subscription to this publisher.
+   * @returns {number} The number of subscription
+   */
+  get subscriptionCount() {
+    return rclnodejs.getSubscriptionCount(this._handle);
+  }
 }
 
 module.exports = Publisher;

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -116,6 +116,14 @@ class Subscription extends Entity {
       ? rclnodejs.clearContentFilter(this.handle)
       : true;
   }
+
+  /**
+   * Get the number of publishers to this subscription.
+   * @returns {number} The number of publishers
+   */
+  get publisherCount() {
+    return rclnodejs.getPublisherCount(this._handle);
+  }
 }
 
 module.exports = Subscription;

--- a/src/rcl_context_bindings.cpp
+++ b/src/rcl_context_bindings.cpp
@@ -127,11 +127,29 @@ Napi::Value IsContextValid(const Napi::CallbackInfo& info) {
   return Napi::Boolean::New(env, is_valid);
 }
 
+Napi::Value GetDomainId(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* context_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_context_t* context =
+      reinterpret_cast<rcl_context_t*>(context_handle->ptr());
+  size_t domain_id;
+  rcl_ret_t ret = rcl_context_get_domain_id(context, &domain_id);
+  if (RCL_RET_OK != ret) {
+    Napi::Error::New(env, rcl_get_error_string().str)
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  return Napi::Number::New(env, domain_id);
+}
+
 Napi::Object InitContextBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("init", Napi::Function::New(env, Init));
   exports.Set("shutdown", Napi::Function::New(env, Shutdown));
   exports.Set("createContext", Napi::Function::New(env, CreateContext));
   exports.Set("isContextValid", Napi::Function::New(env, IsContextValid));
+  exports.Set("getDomainId", Napi::Function::New(env, GetDomainId));
   return exports;
 }
 

--- a/src/rcl_graph_bindings.cpp
+++ b/src/rcl_graph_bindings.cpp
@@ -232,36 +232,6 @@ Napi::Value GetNodeNames(const Napi::CallbackInfo& info) {
   return result_list;
 }
 
-Napi::Value CountPublishers(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-
-  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
-  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
-  std::string topic_name = info[1].As<Napi::String>().Utf8Value();
-
-  size_t count = 0;
-  THROW_ERROR_IF_NOT_EQUAL(
-      RCL_RET_OK, rcl_count_publishers(node, topic_name.c_str(), &count),
-      "Failed to count publishers.");
-
-  return Napi::Number::New(env, static_cast<int32_t>(count));
-}
-
-Napi::Value CountSubscribers(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-
-  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
-  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
-  std::string topic_name = info[1].As<Napi::String>().Utf8Value();
-
-  size_t count = 0;
-  THROW_ERROR_IF_NOT_EQUAL(
-      RCL_RET_OK, rcl_count_subscribers(node, topic_name.c_str(), &count),
-      "Failed to count subscribers.");
-
-  return Napi::Number::New(env, static_cast<int32_t>(count));
-}
-
 Napi::Value ServiceServerIsAvailable(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
 
@@ -292,8 +262,6 @@ Napi::Object InitGraphBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("getServiceNamesAndTypes",
               Napi::Function::New(env, GetServiceNamesAndTypes));
   exports.Set("getNodeNames", Napi::Function::New(env, GetNodeNames));
-  exports.Set("countPublishers", Napi::Function::New(env, CountPublishers));
-  exports.Set("countSubscribers", Napi::Function::New(env, CountSubscribers));
   exports.Set("serviceServerIsAvailable",
               Napi::Function::New(env, ServiceServerIsAvailable));
   return exports;

--- a/src/rcl_node_bindings.cpp
+++ b/src/rcl_node_bindings.cpp
@@ -318,6 +318,66 @@ Napi::Value ActionGetNamesAndTypes(const Napi::CallbackInfo& info) {
   return result_list;
 }
 
+Napi::Value CountPublishers(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  std::string topic_name = info[1].As<Napi::String>().Utf8Value();
+
+  size_t count = 0;
+  THROW_ERROR_IF_NOT_EQUAL(
+      RCL_RET_OK, rcl_count_publishers(node, topic_name.c_str(), &count),
+      "Failed to count publishers.");
+
+  return Napi::Number::New(env, static_cast<int32_t>(count));
+}
+
+Napi::Value CountSubscribers(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  std::string topic_name = info[1].As<Napi::String>().Utf8Value();
+
+  size_t count = 0;
+  THROW_ERROR_IF_NOT_EQUAL(
+      RCL_RET_OK, rcl_count_subscribers(node, topic_name.c_str(), &count),
+      "Failed to count subscribers.");
+
+  return Napi::Number::New(env, static_cast<int32_t>(count));
+}
+
+Napi::Value CountClients(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(
+      RclHandle::Unwrap(info[0].As<Napi::Object>())->ptr());
+  std::string service_name = info[1].As<Napi::String>().Utf8Value();
+
+  size_t count = 0;
+  THROW_ERROR_IF_NOT_EQUAL(
+      rcl_count_clients(node, service_name.c_str(), &count), RCL_RET_OK,
+      rcl_get_error_string().str);
+
+  return Napi::Number::New(env, count);
+}
+
+Napi::Value CountServices(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(
+      RclHandle::Unwrap(info[0].As<Napi::Object>())->ptr());
+  std::string service_name = info[1].As<Napi::String>().Utf8Value();
+
+  size_t count = 0;
+  THROW_ERROR_IF_NOT_EQUAL(
+      rcl_count_services(node, service_name.c_str(), &count), RCL_RET_OK,
+      rcl_get_error_string().str);
+
+  return Napi::Number::New(env, count);
+}
+
 Napi::Object InitNodeBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("getParameterOverrides",
               Napi::Function::New(env, GetParameterOverrides));
@@ -331,6 +391,10 @@ Napi::Object InitNodeBindings(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, ActionGetServerNamesAndTypesByNode));
   exports.Set("actionGetNamesAndTypes",
               Napi::Function::New(env, ActionGetNamesAndTypes));
+  exports.Set("countPublishers", Napi::Function::New(env, CountPublishers));
+  exports.Set("countSubscribers", Napi::Function::New(env, CountSubscribers));
+  exports.Set("countClients", Napi::Function::New(env, CountClients));
+  exports.Set("countServices", Napi::Function::New(env, CountServices));
   return exports;
 }
 

--- a/src/rcl_publisher_bindings.cpp
+++ b/src/rcl_publisher_bindings.cpp
@@ -114,11 +114,27 @@ Napi::Value PublishRawMessage(const Napi::CallbackInfo& info) {
   return env.Undefined();
 }
 
+Napi::Value GetSubscriptionCount(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  rcl_publisher_t* publisher = reinterpret_cast<rcl_publisher_t*>(
+      RclHandle::Unwrap(info[0].As<Napi::Object>())->ptr());
+
+  size_t count = 0;
+  THROW_ERROR_IF_NOT_EQUAL(
+      rcl_publisher_get_subscription_count(publisher, &count), RCL_RET_OK,
+      rcl_get_error_string().str);
+
+  return Napi::Number::New(env, count);
+}
+
 Napi::Object InitPublisherBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("createPublisher", Napi::Function::New(env, CreatePublisher));
   exports.Set("publish", Napi::Function::New(env, Publish));
   exports.Set("getPublisherTopic", Napi::Function::New(env, GetPublisherTopic));
   exports.Set("publishRawMessage", Napi::Function::New(env, PublishRawMessage));
+  exports.Set("getSubscriptionCount",
+              Napi::Function::New(env, GetSubscriptionCount));
   return exports;
 }
 

--- a/src/rcl_subscription_bindings.cpp
+++ b/src/rcl_subscription_bindings.cpp
@@ -303,6 +303,20 @@ Napi::Value ClearContentFilter(const Napi::CallbackInfo& info) {
 #endif
 }
 
+Napi::Value GetPublisherCount(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  rcl_subscription_t* subscription = reinterpret_cast<rcl_subscription_t*>(
+      RclHandle::Unwrap(info[0].As<Napi::Object>())->ptr());
+
+  size_t count = 0;
+  THROW_ERROR_IF_NOT_EQUAL(
+      rcl_subscription_get_publisher_count(subscription, &count), RCL_RET_OK,
+      rcl_get_error_string().str);
+
+  return Napi::Number::New(env, count);
+}
+
 Napi::Object InitSubscriptionBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("rclTake", Napi::Function::New(env, RclTake));
   exports.Set("createSubscription",
@@ -314,6 +328,7 @@ Napi::Object InitSubscriptionBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("setContentFilter", Napi::Function::New(env, SetContentFilter));
   exports.Set("clearContentFilter",
               Napi::Function::New(env, ClearContentFilter));
+  exports.Set("getPublisherCount", Napi::Function::New(env, GetPublisherCount));
   return exports;
 }
 

--- a/test/test-context.js
+++ b/test/test-context.js
@@ -80,4 +80,10 @@ describe('context test suite', function () {
     context.shutdown();
     assert.strictEqual(context.nodes.length, 0);
   });
+
+  it('context number id', async function () {
+    let context = new rclnodejs.Context();
+    await rclnodejs.init(context);
+    assert.strictEqual(typeof context.domainId, 'number');
+  });
 });

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -420,6 +420,23 @@ describe('rcl node methods testing', function () {
     await assertUtils.createDelay(500);
     assert.strictEqual(node.countSubscribers('chatter'), 2);
   });
+
+  it('node.countClients', function () {
+    const node = rclnodejs.createNode('publisher_node');
+    const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
+    node.createClient(AddTwoInts, 'add_two_ints');
+    assert.strictEqual(node.countClients('/add_two_ints'), 1);
+
+    node.createClient(AddTwoInts, 'add_two_ints');
+    assert.strictEqual(node.countClients('/add_two_ints'), 2);
+  });
+
+  it('node.countServices', function () {
+    const node = rclnodejs.createNode('publisher_node');
+    const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
+    node.createService(AddTwoInts, 'add_two_ints', (req) => {});
+    assert.strictEqual(node.countServices('/add_two_ints'), 1);
+  });
 });
 
 describe('topic & serviceName getter/setter', function () {

--- a/test/test-publisher.js
+++ b/test/test-publisher.js
@@ -44,7 +44,7 @@ describe('rclnodejs publisher test suite', function () {
     rclnodejs.spin(node);
   });
 
-  it('Test count of subscription', function () {
+  it('Test count of subscriptions', function () {
     const node = rclnodejs.createNode('publisher_node');
     const String = 'std_msgs/msg/String';
     const publisher = node.createPublisher(String, 'topic');

--- a/test/test-subscription.js
+++ b/test/test-subscription.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Copyright (c) 2025, The Robot Web Tools Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 const assert = require('assert');
 const rclnodejs = require('../index.js');
 
-describe('rclnodejs publisher test suite', function () {
+describe('rclnodejs subscription test suite', function () {
   this.timeout(60 * 1000);
 
   beforeEach(function () {
@@ -28,27 +28,11 @@ describe('rclnodejs publisher test suite', function () {
     rclnodejs.shutdown();
   });
 
-  it('Try creating a publisher', function () {
-    const node = rclnodejs.createNode('publisher_node');
-    const String = 'std_msgs/msg/String';
-    const publisher = node.createPublisher(String, 'topic');
-    rclnodejs.spin(node);
-  });
-
-  it('Try publish a message', function () {
-    const node = rclnodejs.createNode('publisher_node');
-    const String = 'std_msgs/msg/String';
-    const publisher = node.createPublisher(String, 'topic');
-    const msg = 'Hello ROS 2.0 Publisher!';
-    publisher.publish(msg);
-    rclnodejs.spin(node);
-  });
-
   it('Test count of subscription', function () {
     const node = rclnodejs.createNode('publisher_node');
     const String = 'std_msgs/msg/String';
-    const publisher = node.createPublisher(String, 'topic');
-    node.createSubscription(String, 'topic', (msg) => {});
-    assert.strictEqual(publisher.subscriptionCount, 1);
+    node.createPublisher(String, 'topic');
+    const subscription = node.createSubscription(String, 'topic', (msg) => {});
+    assert.strictEqual(subscription.publisherCount, 1);
   });
 });


### PR DESCRIPTION
This PR adds missing methods to count publishers, subscriptions, clients, and services in rclnodejs, along with corresponding tests and binding implementations.  
- New tests have been implemented to verify the newly added methods.  
- Binding functions in C++ for subscriptions, publishers, nodes, and contexts have been extended.

| File                                | Description                                          |
| ----------------------------------- | ---------------------------------------------------- |
| test/test-subscription.js           | Added test to verify publisher count on a subscription. |
| test/test-publisher.js              | Added test to verify subscription count on a publisher. |
| test/test-node.js                   | Added tests for counting clients and services on a node.  |
| test/test-context.js                | Added test to verify the context's domain ID.        |
| src/rcl_subscription_bindings.cpp   | Added GetPublisherCount binding.                     |
| src/rcl_publisher_bindings.cpp      | Added GetSubscriptionCount binding.                  |
| src/rcl_node_bindings.cpp           | Added countPublishers, countSubscribers, countClients, and countServices bindings. |
| src/rcl_graph_bindings.cpp          | Removed redundant count functions.                   |
| src/rcl_context_bindings.cpp        | Added GetDomainId binding.                           |
| lib/subscription.js                 | Added publisherCount getter.                         |
| lib/publisher.js                    | Added subscriptionCount getter.                      |
| lib/node.js                        | Added countClients and countServices methods.        |
| lib/context.js                      | Added domainId getter.                               |

Fix: #1107
