### PR TITLE
Add missing functions for timer

### DIFF
--- a/lib/timer.js
+++ b/lib/timer.js
@@ -86,6 +86,31 @@ class Timer {
   timeUntilNextCall() {
     return rclnodejs.timerGetTimeUntilNextCall(this._handle);
   }
+
+  /**
+   * Change the timer period.
+   * @param {bigint} period - The new period in nanoseconds.
+   * @return {undefined}
+   */
+  changeTimerPeriod(period) {
+    rclnodejs.changeTimerPeriod(this._handle, period);
+  }
+
+  /**
+   * Get the timer period.
+   * @return {bigint} - The period in nanoseconds.
+   */
+  get timerPeriod() {
+    return rclnodejs.getTimerPeriod(this._handle);
+  }
+
+  /**
+   * Call a timer and starts counting again, retrieves actual and expected call time.
+   * @return {object} - The timer information.
+   */
+  callTimerWithInfo() {
+    return rclnodejs.callTimerWithInfo(this._handle);
+  }
 }
 
 module.exports = Timer;

--- a/src/rcl_timer_bindings.cpp
+++ b/src/rcl_timer_bindings.cpp
@@ -159,6 +159,60 @@ Napi::Value TimerGetTimeSinceLastCall(const Napi::CallbackInfo& info) {
   return Napi::BigInt::New(env, elapsed_time);
 }
 
+Napi::Value ChangeTimerPeriod(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* timer_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_timer_t* timer = reinterpret_cast<rcl_timer_t*>(timer_handle->ptr());
+
+  if (!info[1].IsBigInt()) {
+    Napi::TypeError::New(env, "Timer period must be a BigInt")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  bool lossless;
+  int64_t period_nsec = info[1].As<Napi::BigInt>().Int64Value(&lossless);
+  int64_t old_period;
+  THROW_ERROR_IF_NOT_EQUAL(
+      RCL_RET_OK, rcl_timer_exchange_period(timer, period_nsec, &old_period),
+      rcl_get_error_string().str);
+
+  return env.Undefined();
+}
+
+Napi::Value GetTimerPeriod(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* timer_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_timer_t* timer = reinterpret_cast<rcl_timer_t*>(timer_handle->ptr());
+  int64_t period_nsec = 0;
+
+  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
+                           rcl_timer_get_period(timer, &period_nsec),
+                           rcl_get_error_string().str);
+
+  return Napi::BigInt::New(env, period_nsec);
+}
+
+Napi::Value CallTimerWithInfo(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  RclHandle* timer_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_timer_t* timer = reinterpret_cast<rcl_timer_t*>(timer_handle->ptr());
+  rcl_timer_call_info_t call_info;
+
+  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
+                           rcl_timer_call_with_info(timer, &call_info),
+                           rcl_get_error_string().str);
+
+  Napi::Object timer_info = Napi::Object::New(env);
+  timer_info.Set("expectetCallTime",
+                 Napi::BigInt::New(env, call_info.expected_call_time));
+  timer_info.Set("actualCallTime",
+                 Napi::BigInt::New(env, call_info.actual_call_time));
+  return timer_info;
+}
+
 Napi::Object InitTimerBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("createTimer", Napi::Function::New(env, CreateTimer));
   exports.Set("isTimerReady", Napi::Function::New(env, IsTimerReady));
@@ -170,6 +224,9 @@ Napi::Object InitTimerBindings(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, TimerGetTimeSinceLastCall));
   exports.Set("timerGetTimeUntilNextCall",
               Napi::Function::New(env, TimerGetTimeUntilNextCall));
+  exports.Set("changeTimerPeriod", Napi::Function::New(env, ChangeTimerPeriod));
+  exports.Set("getTimerPeriod", Napi::Function::New(env, GetTimerPeriod));
+  exports.Set("callTimerWithInfo", Napi::Function::New(env, CallTimerWithInfo));
   return exports;
 }
 

--- a/src/rcl_timer_bindings.cpp
+++ b/src/rcl_timer_bindings.cpp
@@ -206,7 +206,7 @@ Napi::Value CallTimerWithInfo(const Napi::CallbackInfo& info) {
                            rcl_get_error_string().str);
 
   Napi::Object timer_info = Napi::Object::New(env);
-  timer_info.Set("expectetCallTime",
+  timer_info.Set("expectedCallTime",
                  Napi::BigInt::New(env, call_info.expected_call_time));
   timer_info.Set("actualCallTime",
                  Napi::BigInt::New(env, call_info.actual_call_time));

--- a/test/test-timer.js
+++ b/test/test-timer.js
@@ -137,5 +137,29 @@ describe('rclnodejs Timer class testing', function () {
       });
       rclnodejs.spin(node);
     });
+
+    it('timer.timerPeriod', function (done) {
+      const timer = node.createTimer(BigInt('100000000'), () => {});
+      assert.deepStrictEqual(timer.timerPeriod, BigInt('100000000'));
+      timer.cancel();
+      done();
+    });
+
+    it('timer.changeTimerPeriod', function (done) {
+      const timer = node.createTimer(BigInt('100000000'), () => {});
+      timer.changeTimerPeriod(BigInt('200000000'));
+      assert.deepStrictEqual(timer.timerPeriod, BigInt('200000000'));
+      timer.cancel();
+      done();
+    });
+
+    it('timer.callTimerWithInfo', function (done) {
+      const timer = node.createTimer(BigInt('100000000'), () => {});
+      const info = timer.callTimerWithInfo();
+      assert.deepStrictEqual(typeof info.expectetCallTime, 'bigint');
+      assert.deepStrictEqual(typeof info.actualCallTime, 'bigint');
+      timer.cancel();
+      done();
+    });
   });
 });

--- a/test/test-timer.js
+++ b/test/test-timer.js
@@ -156,7 +156,7 @@ describe('rclnodejs Timer class testing', function () {
     it('timer.callTimerWithInfo', function (done) {
       const timer = node.createTimer(BigInt('100000000'), () => {});
       const info = timer.callTimerWithInfo();
-      assert.deepStrictEqual(typeof info.expectetCallTime, 'bigint');
+      assert.deepStrictEqual(typeof info.expectedCallTime, 'bigint');
       assert.deepStrictEqual(typeof info.actualCallTime, 'bigint');
       timer.cancel();
       done();


### PR DESCRIPTION
This PR adds missing timer functionalities and their corresponding unit tests. The key changes include:
- New unit tests for timer operations in test/test-timer.js.
- New timer binding functions in src/rcl_timer_bindings.cpp to support period retrieval, timer period change, and timer call information.
- New Timer class methods and getter in lib/timer.js to expose the newly added timer functionalities.

Fix: #1109