### PR TITLE
Add missing methods for graph

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -65,6 +65,7 @@
         '-lrcl_lifecycle',
         '-lrcutils',
         '-lrcl_yaml_param_parser',
+        '-lrcpputils',
         '-lrmw',
         '-lrosidl_runtime_c',
       ],

--- a/lib/node.js
+++ b/lib/node.js
@@ -1014,6 +1014,32 @@ class Node extends rclnodejs.ShadowNode {
   }
 
   /**
+   * Get a list of publishers on a given topic.
+   * @param {string} topic - the topic name to get the publishers for.
+   * @param {boolean} noDemangle - if `true`, `topic_name` needs to be a valid middleware topic name,
+   *       otherwise it should be a valid ROS topic name.
+   * @returns {Array} - list of publishers
+   */
+  getPublishersInfoByTopic(topic, noDemangle) {
+    return rclnodejs.getPublishersInfoByTopic(this.handle, topic, noDemangle);
+  }
+
+  /**
+   * Get a list of subscriptions on a given topic.
+   * @param {string} topic - the topic name to get the subscriptions for.
+   * @param {boolean} noDemangle - if `true`, `topic_name` needs to be a valid middleware topic name,
+   *       otherwise it should be a valid ROS topic name.
+   * @returns {Array} - list of subscriptions
+   */
+  getSubscriptionsInfoByTopic(topic, noDemangle) {
+    return rclnodejs.getSubscriptionsInfoByTopic(
+      this.handle,
+      topic,
+      noDemangle
+    );
+  }
+
+  /**
    * Get the list of nodes discovered by the provided node.
    * @return {Array<string>} - An array of the names.
    */

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -29,6 +29,7 @@ const dependencies = [
   'builtin_interfaces',
   'rcl_lifecycle',
   'lifecycle_msgs',
+  'rcpputils',
   'rosidl_runtime_c',
   'rosidl_dynamic_typesupport',
   'type_description_interfaces',

--- a/src/rcl_client_bindings.cpp
+++ b/src/rcl_client_bindings.cpp
@@ -112,12 +112,30 @@ Napi::Value GetClientServiceName(const Napi::CallbackInfo& info) {
   return Napi::String::New(env, service_name);
 }
 
+Napi::Value ServiceServerIsAvailable(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  RclHandle* client_handle = RclHandle::Unwrap(info[1].As<Napi::Object>());
+  rcl_client_t* client = reinterpret_cast<rcl_client_t*>(client_handle->ptr());
+
+  bool is_available;
+  THROW_ERROR_IF_NOT_EQUAL(
+      RCL_RET_OK, rcl_service_server_is_available(node, client, &is_available),
+      "Failed to get service state.");
+
+  return Napi::Boolean::New(env, is_available);
+}
+
 Napi::Object InitClientBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("createClient", Napi::Function::New(env, CreateClient));
   exports.Set("sendRequest", Napi::Function::New(env, SendRequest));
   exports.Set("rclTakeResponse", Napi::Function::New(env, RclTakeResponse));
   exports.Set("getClientServiceName",
               Napi::Function::New(env, GetClientServiceName));
+  exports.Set("serviceServerIsAvailable",
+              Napi::Function::New(env, ServiceServerIsAvailable));
   return exports;
 }
 

--- a/src/rcl_graph_bindings.cpp
+++ b/src/rcl_graph_bindings.cpp
@@ -19,6 +19,7 @@
 #include <rcl/rcl.h>
 
 #include <rcpputils/scope_exit.hpp>
+// NOLINTNEXTLINE
 #include <string>
 
 #include "macros.h"

--- a/src/rcl_graph_bindings.cpp
+++ b/src/rcl_graph_bindings.cpp
@@ -211,6 +211,8 @@ Napi::Value GetInfoByTopic(Napi::Env env, rcl_node_t* node,
     rcl_ret_t fini_ret =
         rcl_topic_endpoint_info_array_fini(&info_array, &allocator);
     if (RCL_RET_OK != fini_ret) {
+      Napi::Error::New(env, rcl_get_error_string().str)
+          .ThrowAsJavaScriptException();
       rcl_reset_error();
     }
   });

--- a/src/rcl_graph_bindings.cpp
+++ b/src/rcl_graph_bindings.cpp
@@ -18,6 +18,7 @@
 #include <rcl/graph.h>
 #include <rcl/rcl.h>
 
+#include <rcpputils/scope_exit.hpp>
 #include <string>
 
 #include "macros.h"
@@ -25,6 +26,11 @@
 #include "rcl_utilities.h"
 
 namespace rclnodejs {
+
+typedef rcl_ret_t (*rcl_get_info_by_topic_func_t)(
+    const rcl_node_t* node, rcutils_allocator_t* allocator,
+    const char* topic_name, bool no_mangle,
+    rcl_topic_endpoint_info_array_t* info_array);
 
 Napi::Value GetPublisherNamesAndTypesByNode(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
@@ -193,59 +199,59 @@ Napi::Value GetServiceNamesAndTypes(const Napi::CallbackInfo& info) {
   return result_list;
 }
 
-Napi::Value GetNodeNames(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
+Napi::Value GetInfoByTopic(Napi::Env env, rcl_node_t* node,
+                           const char* topic_name, bool no_mangle,
+                           const char* type,
+                           rcl_get_info_by_topic_func_t rcl_get_info_by_topic) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcl_topic_endpoint_info_array_t info_array =
+      rcl_get_zero_initialized_topic_endpoint_info_array();
 
-  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
-  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
-  rcutils_string_array_t node_names =
-      rcutils_get_zero_initialized_string_array();
-  rcutils_string_array_t node_namespaces =
-      rcutils_get_zero_initialized_string_array();
-  rcl_allocator_t allocator = rcl_get_default_allocator();
+  RCPPUTILS_SCOPE_EXIT({
+    rcl_ret_t fini_ret =
+        rcl_topic_endpoint_info_array_fini(&info_array, &allocator);
+    if (RCL_RET_OK != fini_ret) {
+      rcl_reset_error();
+    }
+  });
 
-  THROW_ERROR_IF_NOT_EQUAL(
-      RCL_RET_OK,
-      rcl_get_node_names(node, allocator, &node_names, &node_namespaces),
-      "Failed to get_node_names.");
-
-  Napi::Array result_list = Napi::Array::New(env, node_names.size);
-
-  for (size_t i = 0; i < node_names.size; ++i) {
-    Napi::Object item = Napi::Object::New(env);
-
-    item.Set("name", Napi::String::New(env, node_names.data[i]));
-    item.Set("namespace", Napi::String::New(env, node_namespaces.data[i]));
-
-    result_list.Set(i, item);
+  rcl_ret_t ret = rcl_get_info_by_topic(node, &allocator, topic_name, no_mangle,
+                                        &info_array);
+  if (RCL_RET_OK != ret) {
+    if (RCL_RET_UNSUPPORTED == ret) {
+      Napi::Error::New(
+          env, std::string("Failed to get information by topic for ") + type +
+                   ": function not supported by RMW_IMPLEMENTATION")
+          .ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+    Napi::Error::New(
+        env, std::string("Failed to get information by topic for ") + type)
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
-  rcutils_ret_t fini_names_ret = rcutils_string_array_fini(&node_names);
-  rcutils_ret_t fini_namespaces_ret =
-      rcutils_string_array_fini(&node_namespaces);
-
-  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, fini_names_ret,
-                           "Failed to destroy node_names");
-  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, fini_namespaces_ret,
-                           "Failed to destroy node_namespaces");
-
-  return result_list;
+  return ConvertToJSTopicEndpointInfoList(env, &info_array);
 }
 
-Napi::Value ServiceServerIsAvailable(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-
+Napi::Value GetPublishersInfoByTopic(const Napi::CallbackInfo& info) {
   RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
   rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
-  RclHandle* client_handle = RclHandle::Unwrap(info[1].As<Napi::Object>());
-  rcl_client_t* client = reinterpret_cast<rcl_client_t*>(client_handle->ptr());
+  std::string topic_name = info[1].As<Napi::String>().Utf8Value();
+  bool no_mangle = info[2].As<Napi::Boolean>();
 
-  bool is_available;
-  THROW_ERROR_IF_NOT_EQUAL(
-      RCL_RET_OK, rcl_service_server_is_available(node, client, &is_available),
-      "Failed to get service state.");
+  return GetInfoByTopic(info.Env(), node, topic_name.c_str(), no_mangle,
+                        "publishers", rcl_get_publishers_info_by_topic);
+}
 
-  return Napi::Boolean::New(env, is_available);
+Napi::Value GetSubscriptionsInfoByTopic(const Napi::CallbackInfo& info) {
+  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  std::string topic_name = info[1].As<Napi::String>().Utf8Value();
+  bool no_mangle = info[2].As<Napi::Boolean>();
+
+  return GetInfoByTopic(info.Env(), node, topic_name.c_str(), no_mangle,
+                        "subscriptions", rcl_get_subscriptions_info_by_topic);
 }
 
 Napi::Object InitGraphBindings(Napi::Env env, Napi::Object exports) {
@@ -261,9 +267,10 @@ Napi::Object InitGraphBindings(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, GetTopicNamesAndTypes));
   exports.Set("getServiceNamesAndTypes",
               Napi::Function::New(env, GetServiceNamesAndTypes));
-  exports.Set("getNodeNames", Napi::Function::New(env, GetNodeNames));
-  exports.Set("serviceServerIsAvailable",
-              Napi::Function::New(env, ServiceServerIsAvailable));
+  exports.Set("getPublishersInfoByTopic",
+              Napi::Function::New(env, GetPublishersInfoByTopic));
+  exports.Set("getSubscriptionsInfoByTopic",
+              Napi::Function::New(env, GetSubscriptionsInfoByTopic));
   return exports;
 }
 

--- a/src/rcl_node_bindings.cpp
+++ b/src/rcl_node_bindings.cpp
@@ -378,6 +378,45 @@ Napi::Value CountServices(const Napi::CallbackInfo& info) {
   return Napi::Number::New(env, count);
 }
 
+Napi::Value GetNodeNames(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  rcutils_string_array_t node_names =
+      rcutils_get_zero_initialized_string_array();
+  rcutils_string_array_t node_namespaces =
+      rcutils_get_zero_initialized_string_array();
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+
+  THROW_ERROR_IF_NOT_EQUAL(
+      RCL_RET_OK,
+      rcl_get_node_names(node, allocator, &node_names, &node_namespaces),
+      "Failed to get_node_names.");
+
+  Napi::Array result_list = Napi::Array::New(env, node_names.size);
+
+  for (size_t i = 0; i < node_names.size; ++i) {
+    Napi::Object item = Napi::Object::New(env);
+
+    item.Set("name", Napi::String::New(env, node_names.data[i]));
+    item.Set("namespace", Napi::String::New(env, node_namespaces.data[i]));
+
+    result_list.Set(i, item);
+  }
+
+  rcutils_ret_t fini_names_ret = rcutils_string_array_fini(&node_names);
+  rcutils_ret_t fini_namespaces_ret =
+      rcutils_string_array_fini(&node_namespaces);
+
+  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, fini_names_ret,
+                           "Failed to destroy node_names");
+  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, fini_namespaces_ret,
+                           "Failed to destroy node_namespaces");
+
+  return result_list;
+}
+
 Napi::Object InitNodeBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("getParameterOverrides",
               Napi::Function::New(env, GetParameterOverrides));
@@ -395,6 +434,7 @@ Napi::Object InitNodeBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("countSubscribers", Napi::Function::New(env, CountSubscribers));
   exports.Set("countClients", Napi::Function::New(env, CountClients));
   exports.Set("countServices", Napi::Function::New(env, CountServices));
+  exports.Set("getNodeNames", Napi::Function::New(env, GetNodeNames));
   return exports;
 }
 

--- a/src/rcl_utilities.cpp
+++ b/src/rcl_utilities.cpp
@@ -16,6 +16,7 @@
 
 #include <rcl/rcl.h>
 #include <rcl_action/rcl_action.h>
+#include <rmw/topic_endpoint_info.h>
 #include <uv.h>
 
 #include <memory>
@@ -67,6 +68,68 @@ std::unique_ptr<rmw_qos_profile_t> GetQosProfileFromObject(
       avoid_ros_namespace_conventions.As<Napi::Boolean>();
 
   return qos_profile;
+}
+
+Napi::Value ConvertRMWTimeToDuration(Napi::Env env,
+                                     const rmw_time_t* duration) {
+  Napi::Object obj = Napi::Object::New(env);
+  obj.Set("seconds", Napi::BigInt::New(env, duration->sec));
+  obj.Set("nanoseconds", Napi::Number::New(env, duration->nsec));
+  return obj;
+}
+
+Napi::Value ConvertToHashObject(Napi::Env env,
+                                const rosidl_type_hash_t* type_hash) {
+  Napi::Object obj = Napi::Object::New(env);
+  obj.Set("version", Napi::Number::New(env, type_hash->version));
+  obj.Set("value", Napi::Buffer<char>::Copy(
+                       env, reinterpret_cast<const char*>(type_hash->value),
+                       ROSIDL_TYPE_HASH_SIZE));
+  return obj;
+}
+
+Napi::Value ConvertToQoS(Napi::Env env, const rmw_qos_profile_t* qos_profile) {
+  Napi::Object qos = Napi::Object::New(env);
+  qos.Set("depth", Napi::Number::New(env, qos_profile->depth));
+  qos.Set("history", Napi::Number::New(env, qos_profile->history));
+  qos.Set("reliability", Napi::Number::New(env, qos_profile->reliability));
+  qos.Set("durability", Napi::Number::New(env, qos_profile->durability));
+  qos.Set("lifespan", ConvertRMWTimeToDuration(env, &qos_profile->lifespan));
+  qos.Set("deadline", ConvertRMWTimeToDuration(env, &qos_profile->deadline));
+  qos.Set("liveliness", Napi::Number::New(env, qos_profile->liveliness));
+  qos.Set(
+      "liveliness_lease_duration",
+      ConvertRMWTimeToDuration(env, &qos_profile->liveliness_lease_duration));
+  qos.Set(
+      "avoid_ros_namespace_conventions",
+      Napi::Boolean::New(env, qos_profile->avoid_ros_namespace_conventions));
+  return qos;
+}
+
+Napi::Value ConvertToJSTopicEndpoint(
+    Napi::Env env, const rmw_topic_endpoint_info_t* topic_endpoint_info) {
+  Napi::Array endpoint_gid = Napi::Array::New(env, RMW_GID_STORAGE_SIZE);
+  for (size_t i = 0; i < RMW_GID_STORAGE_SIZE; i++) {
+    endpoint_gid.Set(
+        i, Napi::Number::New(env, topic_endpoint_info->endpoint_gid[i]));
+  }
+
+  Napi::Object endpoint = Napi::Object::New(env);
+  endpoint.Set("node_name",
+               Napi::String::New(env, topic_endpoint_info->node_name));
+  endpoint.Set("node_namespace",
+               Napi::String::New(env, topic_endpoint_info->node_namespace));
+  endpoint.Set("topic_type",
+               Napi::String::New(env, topic_endpoint_info->topic_type));
+  endpoint.Set("topic_type_hash",
+               ConvertToHashObject(env, &topic_endpoint_info->topic_type_hash));
+  endpoint.Set("endpoint_type",
+               Napi::Number::New(
+                   env, static_cast<int>(topic_endpoint_info->endpoint_type)));
+  endpoint.Set("endpoint_gid", endpoint_gid);
+  endpoint.Set("qos_profile",
+               ConvertToQoS(env, &topic_endpoint_info->qos_profile));
+  return endpoint;
 }
 
 uv_lib_t g_lib;
@@ -181,6 +244,16 @@ void ExtractNamesAndTypes(rcl_names_and_types_t names_and_types,
     item.Set("types", type_list);
     result_list->Set(i, item);
   }
+}
+
+Napi::Array ConvertToJSTopicEndpointInfoList(
+    Napi::Env env, const rmw_topic_endpoint_info_array_t* info_array) {
+  Napi::Array list = Napi::Array::New(env, info_array->size);
+  for (size_t i = 0; i < info_array->size; ++i) {
+    rmw_topic_endpoint_info_t topic_endpoint_info = info_array->info_array[i];
+    list.Set(i, ConvertToJSTopicEndpoint(env, &topic_endpoint_info));
+  }
+  return list;
 }
 
 }  // namespace rclnodejs

--- a/src/rcl_utilities.h
+++ b/src/rcl_utilities.h
@@ -48,6 +48,9 @@ std::unique_ptr<rmw_qos_profile_t> GetQoSProfile(Napi::Value qos);
 void ExtractNamesAndTypes(rcl_names_and_types_t names_and_types,
                           Napi::Array* result_list);
 
+Napi::Array ConvertToJSTopicEndpointInfoList(
+    Napi::Env env, const rmw_topic_endpoint_info_array_t* info_array);
+
 }  // namespace rclnodejs
 
 #endif  // SRC_RCL_UTILITIES_H_

--- a/test/test-graph.js
+++ b/test/test-graph.js
@@ -1,0 +1,50 @@
+// Copyright (c) 2025, The Robot Web Tools Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const rclnodejs = require('../index.js');
+
+describe('rclnodejs graph test suite', function () {
+  this.timeout(60 * 1000);
+
+  beforeEach(function () {
+    return rclnodejs.init();
+  });
+
+  afterEach(function () {
+    rclnodejs.shutdown();
+  });
+
+  it('Get publishers info by topic', function () {
+    const node = rclnodejs.createNode('publisher_node');
+    const String = 'std_msgs/msg/String';
+    node.createPublisher(String, 'topic');
+    const publishers = node.getPublishersInfoByTopic('/topic', false);
+    assert.strictEqual(publishers.length, 1);
+    assert.strictEqual(publishers[0].node_name, 'publisher_node');
+    assert.strictEqual(publishers[0].topic_type, String);
+  });
+
+  it('Get subscriptions info by topic', function () {
+    const node = rclnodejs.createNode('subscription_node');
+    const String = 'std_msgs/msg/String';
+    node.createSubscription(String, 'topic', (msg) => {});
+    const subscriptions = node.getSubscriptionsInfoByTopic('/topic', false);
+    assert.strictEqual(subscriptions.length, 1);
+    assert.strictEqual(subscriptions[0].node_name, 'subscription_node');
+    assert.strictEqual(subscriptions[0].topic_type, String);
+  });
+});

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -65,6 +65,8 @@ expectType<rclnodejs.NamesAndTypesQueryResult[]>(
 expectType<rclnodejs.NamesAndTypesQueryResult[]>(node.getTopicNamesAndTypes());
 expectType<string[]>(node.getNodeNames());
 expectType<rclnodejs.NodeNamesQueryResult[]>(node.getNodeNamesAndNamespaces());
+expectType<Array<object>>(node.getPublishersInfoByTopic('topic', false));
+expectType<Array<object>>(node.getSubscriptionsInfoByTopic('topic', false));
 expectType<number>(node.countPublishers(TOPIC));
 expectType<number>(node.countSubscribers(TOPIC));
 expectType<rclnodejs.Options<string | rclnodejs.QoS>>(

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -719,13 +719,30 @@ declare module 'rclnodejs' {
     /**
      * Get this node's service names and corresponding types.
      *
-     * @returns An array of the names and types.
+     * @returns list of publishers of the names and types.
      *        [
      *          { name: '/start_motor', types: [ 'rplidar_ros/srv/Control' ] },
      *          { name: '/stop_motor',  types: [ 'rplidar_ros/srv/Control' ] }
      *        ]
      */
     getServiceNamesAndTypes(): Array<NamesAndTypesQueryResult>;
+
+    /**
+     * Get a list of publishers on a given topic.
+     *
+     * @returns list of publishers.
+     */
+    getPublishersInfoByTopic(topic: string, noDemangle: boolean): Array<object>;
+
+    /**
+     * Get a list of subscriptions on a given topic.
+     *
+     * @returns list of subscriptions.
+     */
+    getSubscriptionsInfoByTopic(
+      topic: string,
+      noDemangle: boolean
+    ): Array<object>;
 
     /**
      * Get the list of nodes discovered by the provided node.

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -719,7 +719,7 @@ declare module 'rclnodejs' {
     /**
      * Get this node's service names and corresponding types.
      *
-     * @returns list of publishers of the names and types.
+     * @returns An array of the names and types.
      *        [
      *          { name: '/start_motor', types: [ 'rplidar_ros/srv/Control' ] },
      *          { name: '/stop_motor',  types: [ 'rplidar_ros/srv/Control' ] }
@@ -728,16 +728,22 @@ declare module 'rclnodejs' {
     getServiceNamesAndTypes(): Array<NamesAndTypesQueryResult>;
 
     /**
-     * Get a list of publishers on a given topic.
+     * Get an array of publishers on a given topic.
      *
-     * @returns list of publishers.
+     * @param topic - The name of the topic.
+     * @param noDemangle - if `true`, `topic_name` needs to be a valid middleware topic name,
+     *       otherwise it should be a valid ROS topic name.
+     * @returns An array of publishers.
      */
     getPublishersInfoByTopic(topic: string, noDemangle: boolean): Array<object>;
 
     /**
-     * Get a list of subscriptions on a given topic.
+     * Get an array of subscriptions on a given topic.
      *
-     * @returns list of subscriptions.
+     * @param topic - The name of the topic.
+     * @param noDemangle - if `true`, `topic_name` needs to be a valid middleware topic name,
+     *     otherwise it should be a valid ROS topic name.
+     * @returns An array of subscriptions.
      */
     getSubscriptionsInfoByTopic(
       topic: string,


### PR DESCRIPTION
This PR adds new graph-related methods to expose publisher and subscription information by topic. 

- Introduces native bindings and corresponding JavaScript wrappers for retrieving publishers and subscriptions info.  
- Adds test coverage in both TypeScript and JavaScript test files to verify the new functionality.  
- Updates build configuration and dependency lists to support the added functionality.

Fix: #1111