### PR TITLE
Move configure client introspection to binding of client

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -147,15 +147,14 @@ class Client extends Entity {
     }
 
     let type = this.typeClass.type();
-    rclnodejs.configureServiceIntrospection(
+    rclnodejs.configureClientIntrospection(
       this.handle,
       this._nodeHandle,
       clock.handle,
       type.interfaceName,
       type.pkgName,
       qos,
-      introspectionState,
-      false
+      introspectionState
     );
   }
 }

--- a/lib/service.js
+++ b/lib/service.js
@@ -138,8 +138,7 @@ class Service extends Entity {
       type.interfaceName,
       type.pkgName,
       qos,
-      introspectionState,
-      true
+      introspectionState
     );
   }
 

--- a/src/rcl_client_bindings.cpp
+++ b/src/rcl_client_bindings.cpp
@@ -128,6 +128,43 @@ Napi::Value ServiceServerIsAvailable(const Napi::CallbackInfo& info) {
   return Napi::Boolean::New(env, is_available);
 }
 
+#if ROS_VERSION > 2205  // 2205 == Humble
+Napi::Value ConfigureClientIntrospection(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* client_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_client_t* client = reinterpret_cast<rcl_client_t*>(client_handle->ptr());
+  RclHandle* node_handle = RclHandle::Unwrap(info[1].As<Napi::Object>());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  rcl_clock_t* clock = reinterpret_cast<rcl_clock_t*>(
+      RclHandle::Unwrap(info[2].As<Napi::Object>())->ptr());
+
+  std::string interface_name = info[3].As<Napi::String>().Utf8Value();
+  std::string package_name = info[4].As<Napi::String>().Utf8Value();
+  const rosidl_service_type_support_t* ts =
+      GetServiceTypeSupport(package_name, interface_name);
+
+  if (ts) {
+    rcl_publisher_options_t publisher_ops = rcl_publisher_get_default_options();
+    auto qos_profile = GetQoSProfile(info[5]);
+    if (qos_profile) {
+      publisher_ops.qos = *qos_profile;
+    }
+    rcl_service_introspection_state_t state =
+        static_cast<rcl_service_introspection_state_t>(
+            info[6].As<Napi::Number>().Uint32Value());
+
+    THROW_ERROR_IF_NOT_EQUAL(rcl_client_configure_service_introspection(
+                                 client, node, clock, ts, publisher_ops, state),
+                             RCL_RET_OK, rcl_get_error_string().str);
+  } else {
+    Napi::Error::New(env, GetErrorMessageAndClear())
+        .ThrowAsJavaScriptException();
+  }
+  return env.Undefined();
+}
+#endif
+
 Napi::Object InitClientBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("createClient", Napi::Function::New(env, CreateClient));
   exports.Set("sendRequest", Napi::Function::New(env, SendRequest));
@@ -136,6 +173,10 @@ Napi::Object InitClientBindings(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, GetClientServiceName));
   exports.Set("serviceServerIsAvailable",
               Napi::Function::New(env, ServiceServerIsAvailable));
+#if ROS_VERSION > 2205  // 2205 == Humble
+  exports.Set("configureClientIntrospection",
+              Napi::Function::New(env, ConfigureClientIntrospection));
+#endif
   return exports;
 }
 

--- a/src/rcl_service_bindings.cpp
+++ b/src/rcl_service_bindings.cpp
@@ -120,6 +120,9 @@ Napi::Value GetServiceServiceName(const Napi::CallbackInfo& info) {
 Napi::Value ConfigureServiceIntrospection(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
 
+  RclHandle* service_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_service_t* service =
+      reinterpret_cast<rcl_service_t*>(service_handle->ptr());
   RclHandle* node_handle = RclHandle::Unwrap(info[1].As<Napi::Object>());
   rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
 
@@ -137,39 +140,18 @@ Napi::Value ConfigureServiceIntrospection(const Napi::CallbackInfo& info) {
     if (qos_profile) {
       publisher_ops.qos = *qos_profile;
     }
-
     rcl_service_introspection_state_t state =
         static_cast<rcl_service_introspection_state_t>(
             info[6].As<Napi::Number>().Uint32Value());
 
-    bool configureForService = info[7].As<Napi::Boolean>();
-
-    if (configureForService) {
-      RclHandle* service_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
-      rcl_service_t* service =
-          reinterpret_cast<rcl_service_t*>(service_handle->ptr());
-
-      THROW_ERROR_IF_NOT_EQUAL(
-          rcl_service_configure_service_introspection(service, node, clock, ts,
-                                                      publisher_ops, state),
-          RCL_RET_OK, rcl_get_error_string().str);
-
-    } else {
-      RclHandle* client_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
-      rcl_client_t* client =
-          reinterpret_cast<rcl_client_t*>(client_handle->ptr());
-
-      THROW_ERROR_IF_NOT_EQUAL(
-          rcl_client_configure_service_introspection(client, node, clock, ts,
-                                                     publisher_ops, state),
-          RCL_RET_OK, rcl_get_error_string().str);
-    }
-
+    THROW_ERROR_IF_NOT_EQUAL(
+        rcl_service_configure_service_introspection(service, node, clock, ts,
+                                                    publisher_ops, state),
+        RCL_RET_OK, rcl_get_error_string().str);
   } else {
     Napi::Error::New(env, GetErrorMessageAndClear())
         .ThrowAsJavaScriptException();
   }
-
   return env.Undefined();
 }
 #endif


### PR DESCRIPTION
This PR refactors the introspection configuration by shifting the client-specific introspection logic into its dedicated binding while cleaning up the service bindings.  
- In src/rcl_service_bindings.cpp, the conditional branch for client introspection is removed and the service introspection configuration is streamlined.  
- In src/rcl_client_bindings.cpp, a new function ConfigureClientIntrospection is introduced and exported for client use.  
- In lib/service.js and lib/client.js, calls are updated to use the appropriate introspection functions and argument signatures.

Fix: #1117