### PR TITLE
Disable methods not supported by humble

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1096,7 +1096,7 @@ class Node extends rclnodejs.ShadowNode {
   countClients(serviceName) {
     if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
       console.warn('countClients is not supported by this version of ROS 2');
-      return;
+      return null;
     }
     return rclnodejs.countClients(this.handle, serviceName);
   }
@@ -1109,7 +1109,7 @@ class Node extends rclnodejs.ShadowNode {
   countServices(serviceName) {
     if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
       console.warn('countServices is not supported by this version of ROS 2');
-      return;
+      return null;
     }
     return rclnodejs.countServices(this.handle, serviceName);
   }

--- a/lib/node.js
+++ b/lib/node.js
@@ -21,6 +21,7 @@ const Client = require('./client.js');
 const Clock = require('./clock.js');
 const Context = require('./context.js');
 const debug = require('debug')('rclnodejs:node');
+const DistroUtils = require('./distro.js');
 const GuardCondition = require('./guard_condition.js');
 const loader = require('./interface_loader.js');
 const Logging = require('./logging.js');
@@ -1093,6 +1094,10 @@ class Node extends rclnodejs.ShadowNode {
    * @returns {Number}
    */
   countClients(serviceName) {
+    if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
+      console.warn('countClients is not supported by this version of ROS 2');
+      return;
+    }
     return rclnodejs.countClients(this.handle, serviceName);
   }
 
@@ -1102,6 +1107,10 @@ class Node extends rclnodejs.ShadowNode {
    * @returns {Number}
    */
   countServices(serviceName) {
+    if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
+      console.warn('countServices is not supported by this version of ROS 2');
+      return;
+    }
     return rclnodejs.countServices(this.handle, serviceName);
   }
 

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const rclnodejs = require('bindings')('rclnodejs');
+const DistroUtils = require('./distro.js');
 
 /**
  * @class - Class representing a Timer in ROS
@@ -109,6 +110,12 @@ class Timer {
    * @return {object} - The timer information.
    */
   callTimerWithInfo() {
+    if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
+      console.warn(
+        'callTimerWithInfo is not supported by this version of ROS 2'
+      );
+      return;
+    }
     return rclnodejs.callTimerWithInfo(this._handle);
   }
 }

--- a/src/rcl_node_bindings.cpp
+++ b/src/rcl_node_bindings.cpp
@@ -348,6 +348,7 @@ Napi::Value CountSubscribers(const Napi::CallbackInfo& info) {
   return Napi::Number::New(env, static_cast<int32_t>(count));
 }
 
+#if ROS_VERSION > 2205  // 2205 == Humble
 Napi::Value CountClients(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
 
@@ -377,6 +378,7 @@ Napi::Value CountServices(const Napi::CallbackInfo& info) {
 
   return Napi::Number::New(env, count);
 }
+#endif
 
 Napi::Value GetNodeNames(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
@@ -432,8 +434,10 @@ Napi::Object InitNodeBindings(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, ActionGetNamesAndTypes));
   exports.Set("countPublishers", Napi::Function::New(env, CountPublishers));
   exports.Set("countSubscribers", Napi::Function::New(env, CountSubscribers));
+#if ROS_VERSION > 2205  // 2205 == Humble
   exports.Set("countClients", Napi::Function::New(env, CountClients));
   exports.Set("countServices", Napi::Function::New(env, CountServices));
+#endif
   exports.Set("getNodeNames", Napi::Function::New(env, GetNodeNames));
   return exports;
 }

--- a/src/rcl_timer_bindings.cpp
+++ b/src/rcl_timer_bindings.cpp
@@ -195,6 +195,7 @@ Napi::Value GetTimerPeriod(const Napi::CallbackInfo& info) {
   return Napi::BigInt::New(env, period_nsec);
 }
 
+#if ROS_VERSION > 2205  // 2205 == Humble
 Napi::Value CallTimerWithInfo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   RclHandle* timer_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
@@ -212,6 +213,7 @@ Napi::Value CallTimerWithInfo(const Napi::CallbackInfo& info) {
                  Napi::BigInt::New(env, call_info.actual_call_time));
   return timer_info;
 }
+#endif
 
 Napi::Object InitTimerBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("createTimer", Napi::Function::New(env, CreateTimer));
@@ -226,7 +228,9 @@ Napi::Object InitTimerBindings(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, TimerGetTimeUntilNextCall));
   exports.Set("changeTimerPeriod", Napi::Function::New(env, ChangeTimerPeriod));
   exports.Set("getTimerPeriod", Napi::Function::New(env, GetTimerPeriod));
+#if ROS_VERSION > 2205  // 2205 == Humble
   exports.Set("callTimerWithInfo", Napi::Function::New(env, CallTimerWithInfo));
+#endif
   return exports;
 }
 

--- a/src/rcl_utilities.cpp
+++ b/src/rcl_utilities.cpp
@@ -78,6 +78,7 @@ Napi::Value ConvertRMWTimeToDuration(Napi::Env env,
   return obj;
 }
 
+#if ROS_VERSION > 2205  // 2205 == Humble
 Napi::Value ConvertToHashObject(Napi::Env env,
                                 const rosidl_type_hash_t* type_hash) {
   Napi::Object obj = Napi::Object::New(env);
@@ -87,6 +88,7 @@ Napi::Value ConvertToHashObject(Napi::Env env,
                        ROSIDL_TYPE_HASH_SIZE));
   return obj;
 }
+#endif
 
 Napi::Value ConvertToJSTopicEndpoint(
     Napi::Env env, const rmw_topic_endpoint_info_t* topic_endpoint_info) {
@@ -103,8 +105,10 @@ Napi::Value ConvertToJSTopicEndpoint(
                Napi::String::New(env, topic_endpoint_info->node_namespace));
   endpoint.Set("topic_type",
                Napi::String::New(env, topic_endpoint_info->topic_type));
+#if ROS_VERSION > 2205  // 2205 == Humble
   endpoint.Set("topic_type_hash",
                ConvertToHashObject(env, &topic_endpoint_info->topic_type_hash));
+#endif
   endpoint.Set("endpoint_type",
                Napi::Number::New(
                    env, static_cast<int>(topic_endpoint_info->endpoint_type)));

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -18,6 +18,7 @@ const IsClose = require('is-close');
 const assert = require('assert');
 const rclnodejs = require('../index.js');
 const assertUtils = require('./utils.js');
+const DistroUtils = require('../lib/distro.js');
 const { NodeOptions } = require('../index.js');
 const assertThrowsError = assertUtils.assertThrowsError;
 const Context = require('../lib/context.js');
@@ -422,6 +423,10 @@ describe('rcl node methods testing', function () {
   });
 
   it('node.countClients', function () {
+    if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
+      this.skip();
+      return;
+    }
     const node = rclnodejs.createNode('publisher_node');
     const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
     node.createClient(AddTwoInts, 'add_two_ints');
@@ -432,6 +437,10 @@ describe('rcl node methods testing', function () {
   });
 
   it('node.countServices', function () {
+    if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
+      this.skip();
+      return;
+    }
     const node = rclnodejs.createNode('publisher_node');
     const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
     node.createService(AddTwoInts, 'add_two_ints', (req) => {});

--- a/test/test-timer.js
+++ b/test/test-timer.js
@@ -16,6 +16,7 @@
 
 const assert = require('assert');
 const rclnodejs = require('../index.js');
+const DistroUtils = require('../lib/distro.js');
 
 const TIMER_INTERVAL = BigInt('100000000');
 describe('rclnodejs Timer class testing', function () {
@@ -154,6 +155,10 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.callTimerWithInfo', function (done) {
+      if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
+        this.skip();
+        return;
+      }
       const timer = node.createTimer(BigInt('100000000'), () => {});
       const info = timer.callTimerWithInfo();
       assert.deepStrictEqual(typeof info.expectedCallTime, 'bigint');


### PR DESCRIPTION
This PR disables methods that are not supported by ROS 2 Humble by conditionally skipping tests and excluding bindings and functionality when running on that distribution.  
- Tests for timer and node methods now skip execution on Humble.  
- C++ and JavaScript bindings for timer and node methods are conditionally compiled/invoked based on the ROS version.

Fix: #1118 