### PR TITLE
Add GetNumEntities() for action client

### DIFF
--- a/lib/action/client.js
+++ b/lib/action/client.js
@@ -371,6 +371,14 @@ class ActionClient extends Entity {
 
     this._node._destroyEntity(this, this._node._actionClients);
   }
+
+  /**
+   * Get the number of wait set entities that make up an action entity.
+   * @return {object} - The number of subscriptions, guard_conditions, timers, and clients and services.
+   */
+  getNumEntities() {
+    return rclnodejs.getNumEntities(this.handle);
+  }
 }
 
 module.exports = ActionClient;

--- a/lib/action/client.js
+++ b/lib/action/client.js
@@ -374,7 +374,12 @@ class ActionClient extends Entity {
 
   /**
    * Get the number of wait set entities that make up an action entity.
-   * @return {object} - The number of subscriptions, guard_conditions, timers, and clients and services.
+   * @return {object} - An object containing the number of various entities.
+   * @property {number} subscriptionsNumber - The number of subscriptions.
+   * @property {number} guardConditionsNumber - The number of guard conditions.
+   * @property {number} timersNumber - The number of timers.
+   * @property {number} clientsNumber - The number of clients.
+   * @property {number} servicesNumber - The number of services.
    */
   getNumEntities() {
     return rclnodejs.getNumEntities(this.handle);

--- a/src/rcl_action_client_bindings.cpp
+++ b/src/rcl_action_client_bindings.cpp
@@ -211,7 +211,7 @@ Napi::Value GetNumEntities(const Napi::CallbackInfo& info) {
     std::string error_text{
         "Failed to get number of entities for 'rcl_action_client_t'"};
     Napi::Error::New(env, error_text).ThrowAsJavaScriptException();
-    throw;
+    return env.Undefined();
   }
   Napi::Object entities = Napi::Object::New(env);
   entities.Set("subscriptionsNumber",
@@ -248,8 +248,6 @@ Napi::Object InitActionClientBindings(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, ActionServerIsAvailable));
   exports.Set("actionSendGoalRequest",
               Napi::Function::New(env, ActionSendGoalRequest));
-  exports.Set("actionTakeCancelRequest",
-              Napi::Function::New(env, ActionTakeCancelRequest));
   exports.Set("actionSendResultRequest",
               Napi::Function::New(env, ActionSendResultRequest));
   exports.Set("actionTakeFeedback",

--- a/src/rcl_action_client_bindings.cpp
+++ b/src/rcl_action_client_bindings.cpp
@@ -126,28 +126,6 @@ Napi::Value ActionSendGoalRequest(const Napi::CallbackInfo& info) {
   return Napi::Number::New(env, static_cast<int32_t>(sequence_number));
 }
 
-Napi::Value ActionTakeCancelRequest(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-
-  RclHandle* action_server_handle =
-      RclHandle::Unwrap(info[0].As<Napi::Object>());
-  rcl_action_server_t* action_server =
-      reinterpret_cast<rcl_action_server_t*>(action_server_handle->ptr());
-  rmw_request_id_t* header =
-      reinterpret_cast<rmw_request_id_t*>(malloc(sizeof(rmw_request_id_t)));
-
-  void* taken_request = info[1].As<Napi::Buffer<char>>().Data();
-  rcl_ret_t ret =
-      rcl_action_take_cancel_request(action_server, header, taken_request);
-  if (ret != RCL_RET_ACTION_SERVER_TAKE_FAILED) {
-    auto js_obj = RclHandle::NewInstance(env, header, nullptr,
-                                         [](void* ptr) { free(ptr); });
-    return js_obj;
-  }
-
-  return env.Undefined();
-}
-
 Napi::Value ActionSendResultRequest(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
 
@@ -211,6 +189,58 @@ Napi::Value ActionTakeStatus(const Napi::CallbackInfo& info) {
   return env.Undefined();
 }
 
+Napi::Value GetNumEntities(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  RclHandle* action_client_handle =
+      RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_action_client_t* action_client =
+      reinterpret_cast<rcl_action_client_t*>(action_client_handle->ptr());
+
+  size_t num_subscriptions = 0u;
+  size_t num_guard_conditions = 0u;
+  size_t num_timers = 0u;
+  size_t num_clients = 0u;
+  size_t num_services = 0u;
+
+  rcl_ret_t ret;
+  ret = rcl_action_client_wait_set_get_num_entities(
+      action_client, &num_subscriptions, &num_guard_conditions, &num_timers,
+      &num_clients, &num_services);
+  if (RCL_RET_OK != ret) {
+    rcl_reset_error();
+    std::string error_text{
+        "Failed to get number of entities for 'rcl_action_client_t'"};
+    Napi::Error::New(env, error_text).ThrowAsJavaScriptException();
+    throw;
+  }
+  Napi::Object entities = Napi::Object::New(env);
+  entities.Set("subscriptionsNumber",
+               Napi::Number::New(env, num_subscriptions));
+  entities.Set("guardConditionsNumber",
+               Napi::Number::New(env, num_guard_conditions));
+  entities.Set("timersNumber", Napi::Number::New(env, num_timers));
+  entities.Set("clientsNumber", Napi::Number::New(env, num_clients));
+  entities.Set("servicesNumber", Napi::Number::New(env, num_services));
+  return entities;
+}
+
+Napi::Value ActionSendCancelRequest(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* action_client_handle =
+      RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_action_client_t* action_client =
+      reinterpret_cast<rcl_action_client_t*>(action_client_handle->ptr());
+  void* buffer = info[1].As<Napi::Buffer<char>>().Data();
+
+  int64_t sequence_number;
+  THROW_ERROR_IF_NOT_EQUAL(
+      rcl_action_send_cancel_request(action_client, buffer, &sequence_number),
+      RCL_RET_OK, rcl_get_error_string().str);
+
+  return Napi::Number::New(env, static_cast<int32_t>(sequence_number));
+}
+
 Napi::Object InitActionClientBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("actionCreateClient",
               Napi::Function::New(env, ActionCreateClient));
@@ -225,6 +255,9 @@ Napi::Object InitActionClientBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("actionTakeFeedback",
               Napi::Function::New(env, ActionTakeFeedback));
   exports.Set("actionTakeStatus", Napi::Function::New(env, ActionTakeStatus));
+  exports.Set("getNumEntities", Napi::Function::New(env, GetNumEntities));
+  exports.Set("actionSendCancelRequest",
+              Napi::Function::New(env, ActionSendCancelRequest));
   return exports;
 }
 

--- a/src/rcl_action_server_bindings.cpp
+++ b/src/rcl_action_server_bindings.cpp
@@ -96,23 +96,6 @@ Napi::Value ActionCreateServer(const Napi::CallbackInfo& info) {
   }
 }
 
-Napi::Value ActionSendCancelRequest(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-
-  RclHandle* action_client_handle =
-      RclHandle::Unwrap(info[0].As<Napi::Object>());
-  rcl_action_client_t* action_client =
-      reinterpret_cast<rcl_action_client_t*>(action_client_handle->ptr());
-  void* buffer = info[1].As<Napi::Buffer<char>>().Data();
-
-  int64_t sequence_number;
-  THROW_ERROR_IF_NOT_EQUAL(
-      rcl_action_send_cancel_request(action_client, buffer, &sequence_number),
-      RCL_RET_OK, rcl_get_error_string().str);
-
-  return Napi::Number::New(env, static_cast<int32_t>(sequence_number));
-}
-
 Napi::Value ActionTakeResultRequest(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
 
@@ -432,11 +415,31 @@ Napi::Value ActionServerGoalExists(const Napi::CallbackInfo& info) {
   return Napi::Boolean::New(env, exists);
 }
 
+Napi::Value ActionTakeCancelRequest(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* action_server_handle =
+      RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_action_server_t* action_server =
+      reinterpret_cast<rcl_action_server_t*>(action_server_handle->ptr());
+  rmw_request_id_t* header =
+      reinterpret_cast<rmw_request_id_t*>(malloc(sizeof(rmw_request_id_t)));
+
+  void* taken_request = info[1].As<Napi::Buffer<char>>().Data();
+  rcl_ret_t ret =
+      rcl_action_take_cancel_request(action_server, header, taken_request);
+  if (ret != RCL_RET_ACTION_SERVER_TAKE_FAILED) {
+    auto js_obj = RclHandle::NewInstance(env, header, nullptr,
+                                         [](void* ptr) { free(ptr); });
+    return js_obj;
+  }
+
+  return env.Undefined();
+}
+
 Napi::Object InitActionServerBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("actionCreateServer",
               Napi::Function::New(env, ActionCreateServer));
-  exports.Set("actionSendCancelRequest",
-              Napi::Function::New(env, ActionSendCancelRequest));
   exports.Set("actionTakeResultRequest",
               Napi::Function::New(env, ActionTakeResultRequest));
   exports.Set("actionTakeGoalRequest",
@@ -464,6 +467,8 @@ Napi::Object InitActionServerBindings(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, ActionProcessCancelRequest));
   exports.Set("actionServerGoalExists",
               Napi::Function::New(env, ActionServerGoalExists));
+  exports.Set("actionTakeCancelRequest",
+              Napi::Function::New(env, ActionTakeCancelRequest));
   return exports;
 }
 

--- a/test/test-action-client.js
+++ b/test/test-action-client.js
@@ -283,4 +283,16 @@ describe('rclnodejs action client', function () {
 
     client.destroy();
   });
+
+  it('Test getNumEntities', function () {
+    let client = new rclnodejs.ActionClient(node, fibonacci, 'fibonacci');
+    const numEntities = client.getNumEntities();
+    assert.strictEqual(numEntities.subscriptionsNumber, 2);
+    assert.strictEqual(numEntities.guardConditionsNumber, 0);
+    assert.strictEqual(numEntities.timersNumber, 0);
+    assert.strictEqual(numEntities.clientsNumber, 3);
+    assert.strictEqual(numEntities.servicesNumber, 0);
+
+    client.destroy();
+  });
 });

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -345,6 +345,7 @@ goalHandlePromise.then((goalHandle) => {
   expectType<boolean>(goalHandle.isCanceled());
   expectType<boolean>(goalHandle.isAborted());
 });
+expectType<object>(actionClient.getNumEntities());
 
 // ---- ActionServer -----
 const actionServer = new rclnodejs.ActionServer(

--- a/types/action_client.d.ts
+++ b/types/action_client.d.ts
@@ -173,5 +173,11 @@ declare module 'rclnodejs' {
      * Destroy the underlying action client handle.
      */
     destroy(): void;
+
+    /**
+     * Get the number of wait set entities that make up an action entity.
+     * @return - The number of subscriptions, guard_conditions, timers, and clients and services.
+     */
+    getNumEntities(): object;
   }
 }


### PR DESCRIPTION
This PR introduces a new method, GetNumEntities(), for the action client to retrieve the counts of various wait set entities. It adds corresponding tests and bindings in both the native C++ layer and the JavaScript API, and updates the documentation accordingly.
- Introduces GetNumEntities() in rcl_action_client_bindings.cpp and exposes it as getNumEntities() in the ActionClient class.
- Updates tests in both TypeScript and JavaScript to verify the returned counts.
- Removes duplicate and unused cancel request functions from client and server bindings.

Fix: #1122