### PR TITLE
Add support for Kilted

### DIFF
--- a/.github/workflows/identify-ros-distro.yml
+++ b/.github/workflows/identify-ros-distro.yml
@@ -11,6 +11,7 @@ on:
         value: ${{ jobs.identify-ros-distro.outputs.linuxos }}
 env:
   ROLLING_VAR: ${{ contains(github.ref, 'develop') }}
+  KILTED_VAR: ${{ contains(github.ref, 'kilted') }}
   JAZZY_VAR: ${{ contains(github.ref, 'jazzy') }}
   IRON_VAR: ${{ contains(github.ref, 'iron') }}
   HUMBLE_VAR: ${{ contains(github.ref, 'humble') }}
@@ -27,6 +28,9 @@ jobs:
         run: |
           if ${ROLLING_VAR} == true; then
             echo "::set-output name=distro::rolling"
+            echo "::set-output name=linuxos::ubuntu:24.04"
+          elif ${KILTED_VAR} == true; then
+            echo "::set-output name=distro::kilted"
             echo "::set-output name=linuxos::ubuntu:24.04"
           elif ${JAZZY_VAR} == true; then
             echo "::set-output name=distro::jazzy"

--- a/.github/workflows/linux-build-and-test-compatibility.yml
+++ b/.github/workflows/linux-build-and-test-compatibility.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         node-version: [20.X, 22.X]
         ros_distribution:
+          - kilted
           - jazzy
           - humble
           - rolling

--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -5,11 +5,13 @@ on:
   push:
     branches:
       - develop
+      - kilted
       - jazzy
       - humble-hawksbill
   pull_request:
     branches:
       - develop
+      - kilted
       - jazzy
       - humble-hawksbill
   workflow_dispatch:
@@ -41,6 +43,7 @@ jobs:
       uses: ros-tooling/setup-ros@v0.7
       with:
         required-ros-distributions: ${{ needs.identify-ros-distro.outputs.distro }}
+        use-ros2-testing: true
 
     - name: Install test-msgs on Linux
       run: |

--- a/.github/workflows/windows-build-and-test-compatibility.yml
+++ b/.github/workflows/windows-build-and-test-compatibility.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         node-version: [22.X]
         ros_distribution:
+          - kilted
           - jazzy
           - humble
           - rolling

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - develop
+      - kilted
       - jazzy
       - humble-hawksbill
   pull_request:
     branches:
       - develop
+      - kilted
       - jazzy
       - humble-hawksbill
   workflow_dispatch:
@@ -34,6 +36,7 @@ jobs:
       uses: ros-tooling/setup-ros@v0.7
       with:
         required-ros-distributions: ${{ needs.identify-ros-distro.outputs.distro }}
+        use-ros2-testing: true
 
     - name: Install ROS2 Rolling (Conditional)
       if: ${{ needs.identify-ros-distro.outputs.distro == 'rolling' }}

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -63,4 +63,4 @@ jobs:
       run: |
         call "c:\dev\${{ needs.identify-ros-distro.outputs.distro }}\ros2-windows\setup.bat"
         cmd /c "if ${{ needs.identify-ros-distro.outputs.distro }}==foxy (set RMW_IMPLEMENTATION=rmw_cyclonedds_cpp&&npm test)"
-        cmd /c "if NOT ${{ needs.identify-ros-distro.outputs.distro }}==foxy if NOT ${{ needs.identify-ros-distro.outputs.distro }}==rolling (npm test)"
+        cmd /c "if NOT ${{ needs.identify-ros-distro.outputs.distro }}==foxy if NOT ${{ needs.identify-ros-distro.outputs.distro }}==rolling if NOT ${{ needs.identify-ros-distro.outputs.distro }}==kilted (npm test)"

--- a/lib/distro.js
+++ b/lib/distro.js
@@ -25,6 +25,7 @@ const DistroId = {
   HUMBLE: 2205,
   IRON: 2305,
   JAZZY: 2405,
+  KILTED: 2505,
   ROLLING: 5000,
 };
 
@@ -35,6 +36,7 @@ DistroNameIdMap.set('galactic', DistroId.GALACTIC);
 DistroNameIdMap.set('humble', DistroId.HUMBLE);
 DistroNameIdMap.set('iron', DistroId.IRON);
 DistroNameIdMap.set('jazzy', DistroId.JAZZY);
+DistroNameIdMap.set('kilted', DistroId.KILTED);
 DistroNameIdMap.set('rolling', DistroId.ROLLING);
 
 const DistroUtils = {

--- a/test/test-distro.js
+++ b/test/test-distro.js
@@ -28,7 +28,7 @@ describe('rclnodejs distro utils', function () {
     );
     assert.equal(
       distroNames.length,
-      7,
+      8,
       'Incorrect number of known distro names'
     );
 


### PR DESCRIPTION
This PR adds support for the new "Kilted" distro by updating the distro constants, mapping, and associated configurations across tests and CI workflows.  
- Updated test expectation in test/test-distro.js from 7 to 8 known distro names.  
- Added KILTED in lib/distro.js and updated the DistroNameIdMap accordingly.  
- Modified multiple GitHub workflow files to include the new "kilted" branch and appropriate testing steps.

Fix: #1124