### PR TITLE
Add nodejs 24 for actions

### DIFF
--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.X, 22.X, 23.X]
+        node-version: [20.X, 22.X, 24.X]
     steps:
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4


### PR DESCRIPTION
Per nodejs release [roadmap](https://nodejs.org/en/about/previous-releases), v24 will be the next LTS release, so this patch replaces nodejs v23 with v24 for actions on Linux platform.

Fix: #1127