### PR TITLE
Support arm64 arch for ROS2 Rolling

### DIFF
--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -26,7 +26,6 @@ jobs:
 
   build:
     needs: identify-ros-distro
-    # Use different runners based on the architecture (x64 or arm64)
     runs-on: ubuntu-${{ matrix.ubuntu-version }}
     container:
       image: ${{ needs.identify-ros-distro.outputs.linuxos }}
@@ -36,11 +35,12 @@ jobs:
         node-version: [20.X, 22.X, 24.X]
         architecture: [x64]
         ubuntu-version: [latest]
-        # Add arm64 support with a specific runner
+        # Add arm64 support for rolling.
         include:
           - architecture: arm64
             node-version: 22.X
             ubuntu-version: 24.04-arm
+            condition: ${{ contains(github.ref, 'develop') }}
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
       uses: actions/setup-node@v4

--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -26,18 +26,27 @@ jobs:
 
   build:
     needs: identify-ros-distro
-    runs-on: ubuntu-latest
+    # Use different runners based on the architecture (x64 or arm64)
+    runs-on: ubuntu-${{ matrix.ubuntu-version }}
     container:
       image: ${{ needs.identify-ros-distro.outputs.linuxos }}
     strategy:
       fail-fast: false
       matrix:
         node-version: [20.X, 22.X, 24.X]
+        architecture: [x64]
+        ubuntu-version: [latest]
+        # Add arm64 support with a specific runner
+        include:
+          - architecture: arm64
+            node-version: 20.X
+            ubuntu-version: latest-arm64
     steps:
-    - name: Setup Node.js ${{ matrix.node-version }}
+    - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
+        architecture: ${{ matrix.architecture }}
 
     - name: Setup ROS2
       uses: ros-tooling/setup-ros@v0.7
@@ -54,6 +63,7 @@ jobs:
     - name: Build and test rclnodejs
       run: |
         source /opt/ros/${{ needs.identify-ros-distro.outputs.distro }}/setup.bash
+        echo "Building and testing rclnodejs on ${{ matrix.architecture }} architecture"
         npm i
         npm run lint
         npm test
@@ -63,7 +73,7 @@ jobs:
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        flag-name: run-${{ matrix.node-version}}
+        flag-name: run-${{ matrix.node-version }}-${{ matrix.architecture }}
         parallel: true
 
   finish:

--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -27,6 +27,7 @@ jobs:
   build:
     needs: identify-ros-distro
     runs-on: ubuntu-${{ matrix.ubuntu-version }}
+    if: ${{ matrix.architecture == 'x64' || contains(github.ref, 'develop') }}
     container:
       image: ${{ needs.identify-ros-distro.outputs.linuxos }}
     strategy:
@@ -40,7 +41,6 @@ jobs:
           - architecture: arm64
             node-version: 22.X
             ubuntu-version: 24.04-arm
-            condition: ${{ contains(github.ref, 'develop') }}
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
       uses: actions/setup-node@v4

--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -39,8 +39,8 @@ jobs:
         # Add arm64 support with a specific runner
         include:
           - architecture: arm64
-            node-version: 20.X
-            ubuntu-version: latest-arm64
+            node-version: 22.X
+            ubuntu-version: 24.04-arm
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
       uses: actions/setup-node@v4
@@ -62,8 +62,8 @@ jobs:
 
     - name: Build and test rclnodejs
       run: |
+        uname -a
         source /opt/ros/${{ needs.identify-ros-distro.outputs.distro }}/setup.bash
-        echo "Building and testing rclnodejs on ${{ matrix.architecture }} architecture"
         npm i
         npm run lint
         npm test

--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -27,7 +27,6 @@ jobs:
   build:
     needs: identify-ros-distro
     runs-on: ubuntu-${{ matrix.ubuntu-version }}
-    if: ${{ matrix.architecture == 'x64' || contains(github.ref, 'develop') }}
     container:
       image: ${{ needs.identify-ros-distro.outputs.linuxos }}
     strategy:
@@ -41,6 +40,7 @@ jobs:
           - architecture: arm64
             node-version: 22.X
             ubuntu-version: 24.04-arm
+            exclude: ${{ !contains(github.ref, 'develop') }}
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
       uses: actions/setup-node@v4


### PR DESCRIPTION
This PR adds support for the arm64 architecture in the Linux build and test workflow. Key changes include:

- Parameterized the "runs-on" configuration to use an Ubuntu version from the matrix.
- Introduced a new matrix for "architecture" with an include block for arm64 support.
- Updated Node.js setup and coveralls flag names to include the architecture.

Fix: #1131