### PR TITLE
Only run workflow on develop branch for arm64 arch

### DIFF
--- a/.github/workflows/identify-ros-distro.yml
+++ b/.github/workflows/identify-ros-distro.yml
@@ -10,11 +10,11 @@ on:
         description: "The ROS compatible Linux version"
         value: ${{ jobs.identify-ros-distro.outputs.linuxos }}
 env:
-  ROLLING_VAR: ${{ contains(github.ref, 'develop') }}
-  KILTED_VAR: ${{ contains(github.ref, 'kilted') }}
-  JAZZY_VAR: ${{ contains(github.ref, 'jazzy') }}
-  IRON_VAR: ${{ contains(github.ref, 'iron') }}
-  HUMBLE_VAR: ${{ contains(github.ref, 'humble') }}
+  ROLLING_VAR: ${{ contains(github.ref, 'develop') || contains(github.base_ref, 'develop') }}
+  KILTED_VAR: ${{ contains(github.ref, 'kilted') || contains(github.base_ref, 'kilted') }}
+  JAZZY_VAR: ${{ contains(github.ref, 'jazzy') || contains(github.base_ref, 'jazzy') }}
+  IRON_VAR: ${{ contains(github.ref, 'iron') || contains(github.base_ref, 'iron') }}
+  HUMBLE_VAR: ${{ contains(github.ref, 'humble') || contains(github.base_ref, 'humble') }}
 
 jobs:
   identify-ros-distro:

--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          if [[ "${{ github.base_ref }}" == "develop" ]]; then
+          if [[ ${{ contains(github.base_ref, 'develop') || contains(github.ref, 'develop') }}" ]]; then
             echo "arm64-matrix=[{\"architecture\":\"arm64\",\"node-version\":\"22.X\",\"ubuntu-version\":\"24.04-arm\"}]" >> $GITHUB_OUTPUT
           else
             echo "arm64-matrix=[]" >> $GITHUB_OUTPUT

--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+          if [[ "${{ github.base_ref }}" == "develop" ]]; then
             echo "arm64-matrix=[{\"architecture\":\"arm64\",\"node-version\":\"22.X\",\"ubuntu-version\":\"24.04-arm\"}]" >> $GITHUB_OUTPUT
           else
             echo "arm64-matrix=[]" >> $GITHUB_OUTPUT

--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -1,4 +1,3 @@
-
 name:  rclnodejs - Linux Build and Test
 
 on:
@@ -24,8 +23,21 @@ jobs:
   identify-ros-distro:
     uses: ./.github/workflows/identify-ros-distro.yml
 
+  matrix-prep:
+    runs-on: ubuntu-latest
+    outputs:
+      arm64-matrix: ${{ steps.set-matrix.outputs.arm64-matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+            echo "arm64-matrix=[{\"architecture\":\"arm64\",\"node-version\":\"22.X\",\"ubuntu-version\":\"24.04-arm\"}]" >> $GITHUB_OUTPUT
+          else
+            echo "arm64-matrix=[]" >> $GITHUB_OUTPUT
+          fi
+
   build:
-    needs: identify-ros-distro
+    needs: [identify-ros-distro, matrix-prep]
     runs-on: ubuntu-${{ matrix.ubuntu-version }}
     container:
       image: ${{ needs.identify-ros-distro.outputs.linuxos }}
@@ -35,12 +47,8 @@ jobs:
         node-version: [20.X, 22.X, 24.X]
         architecture: [x64]
         ubuntu-version: [latest]
-        # Add arm64 support for rolling.
-        include:
-          - architecture: arm64
-            node-version: 22.X
-            ubuntu-version: 24.04-arm
-            exclude: ${{ !contains(github.ref, 'develop') }}
+        # Include arm64 configuration from matrix-prep job
+        include: ${{ fromJSON(needs.matrix-prep.outputs.arm64-matrix) }}
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
       uses: actions/setup-node@v4

--- a/.github/workflows/linux-build-and-test.yml
+++ b/.github/workflows/linux-build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          if [[ ${{ contains(github.base_ref, 'develop') || contains(github.ref, 'develop') }}" ]]; then
+          if [[ ${{ contains(github.base_ref, 'develop') || contains(github.ref, 'develop') }} ]]; then
             echo "arm64-matrix=[{\"architecture\":\"arm64\",\"node-version\":\"22.X\",\"ubuntu-version\":\"24.04-arm\"}]" >> $GITHUB_OUTPUT
           else
             echo "arm64-matrix=[]" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR ensures ARM64 build jobs only run on the `develop` branch and extends branch checks to pull request contexts.

- Added a `matrix-prep` job that outputs an ARM64 matrix only when targeting `develop`.
- Updated the build job to depend on `matrix-prep` and dynamically include ARM64 config.
- Enhanced ROS distro detection to consider both `github.ref` and `github.base_ref` for branch-based flags.

Fix: #1131