### PR TITLE
Support getting the lifecycle state machine status

### DIFF
--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -592,6 +592,15 @@ class LifecycleNode extends Node {
   }
 
   /**
+   * Check if state machine is initialized.
+   *
+   * @returns {boolean} true if the state machine is initialized; otherwise false.
+   */
+  get isInitialized() {
+    return rclnodejs.isInitialized(this._stateMachineHandle);
+  }
+
+  /**
    * The GetState service handler.
    * @param {Object} request - The GetState service request.
    * @param {Object} response - The GetState service response.

--- a/src/rcl_lifecycle_bindings.cpp
+++ b/src/rcl_lifecycle_bindings.cpp
@@ -360,6 +360,18 @@ Napi::Value GetLifecycleShutdownTransitionLabel(
   return Napi::String::New(env, rcl_lifecycle_shutdown_label);
 }
 
+Napi::Value IsInitialized(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  RclHandle* state_machine_handle =
+      RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_lifecycle_state_machine_t* state_machine =
+      reinterpret_cast<rcl_lifecycle_state_machine_t*>(
+          state_machine_handle->ptr());
+  const bool is_initialized =
+      RCL_RET_OK == rcl_lifecycle_state_machine_is_initialized(state_machine);
+  return Napi::Boolean::New(env, is_initialized);
+}
+
 Napi::Object InitLifecycleBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("createLifecycleStateMachine",
               Napi::Function::New(env, CreateLifecycleStateMachine));
@@ -383,6 +395,7 @@ Napi::Object InitLifecycleBindings(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, GetLifecycleTransitionIdToLabel));
   exports.Set("getLifecycleShutdownTransitionLabel",
               Napi::Function::New(env, GetLifecycleShutdownTransitionLabel));
+  exports.Set("isInitialized", Napi::Function::New(env, IsInitialized));
   return exports;
 }
 

--- a/test/test-lifecycle.js
+++ b/test/test-lifecycle.js
@@ -72,6 +72,7 @@ describe('LifecycleNode test suite', function () {
   it('lifecycleNode initial state', function () {
     const state = node.currentState;
     assert.equal(state.id, StateInterface.PRIMARY_STATE_UNCONFIGURED);
+    assert.equal(node.isInitialized, true);
   });
 
   it('lifecycleNode transitions', function () {

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -120,6 +120,7 @@ expectType<rclnodejs.lifecycle.State>(lifecycleNode.activate());
 expectType<rclnodejs.lifecycle.State>(lifecycleNode.deactivate());
 expectType<rclnodejs.lifecycle.State>(lifecycleNode.cleanup());
 expectType<rclnodejs.lifecycle.State>(lifecycleNode.shutdown());
+expectType<boolean>(lifecycleNode.isInitialized);
 
 // ---- Publisher ----
 const publisher = node.createPublisher(TYPE_CLASS, TOPIC);

--- a/types/lifecycle.d.ts
+++ b/types/lifecycle.d.ts
@@ -326,6 +326,13 @@ declare module 'rclnodejs' {
         topic: string,
         options?: Options
       ): LifecyclePublisher<T>;
+
+      /**
+       * Check if state machine is initialized.
+       *
+       * @returns {boolean} true if the state machine is initialized; otherwise false.
+       */
+      get isInitialized(): boolean;
     }
   } // lifecycle namespace
 } // rclnodejs namespace


### PR DESCRIPTION
This PR introduces support for retrieving the lifecycle state machine status by adding a new "isInitialized" property.  
- Added a type test for the new boolean property in the TypeScript tests.  
- Implemented a corresponding native binding in C++ to expose the state.  
- Exposed the property via a getter in the JavaScript lifecycle module.

Fix: #1135