### PR TITLE
Add missing methods for node

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1053,7 +1053,15 @@ class Node extends rclnodejs.ShadowNode {
    * @return {Array<{name: string, namespace: string}>} An array of the names and namespaces.
    */
   getNodeNamesAndNamespaces() {
-    return rclnodejs.getNodeNames(this.handle);
+    return rclnodejs.getNodeNames(this.handle, /*getEnclaves=*/ false);
+  }
+
+  /**
+   * Get the list of nodes and their namespaces with enclaves discovered by the provided node.
+   * @return {Array<{name: string, namespace: string, enclave: string}>} An array of the names, namespaces and enclaves.
+   */
+  getNodeNamesAndNamespacesWithEnclaves() {
+    return rclnodejs.getNodeNames(this.handle, /*getEnclaves=*/ true);
   }
 
   /**
@@ -1608,6 +1616,15 @@ class Node extends rclnodejs.ShadowNode {
     if (idx > -1) {
       this._setParametersCallbacks.splice(idx, 1);
     }
+  }
+
+  /**
+   * Get the fully qualified name of the node.
+   *
+   * @returns {string} - Return String containing the fully qualified name of the node.
+   */
+  getFullyQualifiedName() {
+    return rclnodejs.getFullyQualifiedName(this.handle);
   }
 
   // returns on 1st error or result {successful, reason}

--- a/lib/node.js
+++ b/lib/node.js
@@ -1621,7 +1621,7 @@ class Node extends rclnodejs.ShadowNode {
   /**
    * Get the fully qualified name of the node.
    *
-   * @returns {string} - Return String containing the fully qualified name of the node.
+   * @returns {string} - String containing the fully qualified name of the node.
    */
   getFullyQualifiedName() {
     return rclnodejs.getFullyQualifiedName(this.handle);

--- a/src/rcl_node_bindings.cpp
+++ b/src/rcl_node_bindings.cpp
@@ -385,38 +385,65 @@ Napi::Value GetNodeNames(const Napi::CallbackInfo& info) {
 
   RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
   rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  bool get_enclaves = info[1].As<Napi::Boolean>().Value();
   rcutils_string_array_t node_names =
       rcutils_get_zero_initialized_string_array();
   rcutils_string_array_t node_namespaces =
       rcutils_get_zero_initialized_string_array();
+  rcutils_string_array_t enclaves = rcutils_get_zero_initialized_string_array();
   rcl_allocator_t allocator = rcl_get_default_allocator();
 
-  THROW_ERROR_IF_NOT_EQUAL(
-      RCL_RET_OK,
-      rcl_get_node_names(node, allocator, &node_names, &node_namespaces),
-      "Failed to get_node_names.");
+  if (get_enclaves) {
+    THROW_ERROR_IF_NOT_EQUAL(
+        RCL_RET_OK,
+        rcl_get_node_names_with_enclaves(node, allocator, &node_names,
+                                         &node_namespaces, &enclaves),
+        "Failed to get_node_names.");
+  } else {
+    THROW_ERROR_IF_NOT_EQUAL(
+        RCL_RET_OK,
+        rcl_get_node_names(node, allocator, &node_names, &node_namespaces),
+        "Failed to get_node_names.");
+  }
 
   Napi::Array result_list = Napi::Array::New(env, node_names.size);
 
   for (size_t i = 0; i < node_names.size; ++i) {
     Napi::Object item = Napi::Object::New(env);
-
     item.Set("name", Napi::String::New(env, node_names.data[i]));
     item.Set("namespace", Napi::String::New(env, node_namespaces.data[i]));
-
+    if (get_enclaves) {
+      item.Set("enclave", Napi::String::New(env, enclaves.data[i]));
+    }
     result_list.Set(i, item);
   }
 
   rcutils_ret_t fini_names_ret = rcutils_string_array_fini(&node_names);
   rcutils_ret_t fini_namespaces_ret =
       rcutils_string_array_fini(&node_namespaces);
-
+  rcutils_ret_t fini_enclaves_ret = rcutils_string_array_fini(&enclaves);
   THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, fini_names_ret,
                            "Failed to destroy node_names");
   THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, fini_namespaces_ret,
                            "Failed to destroy node_namespaces");
-
+  THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, fini_enclaves_ret,
+                           "Failed to fini enclaves string array");
   return result_list;
+}
+
+Napi::Value GetFullyQualifiedName(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  const char* fully_qualified_node_name =
+      rcl_node_get_fully_qualified_name(node);
+  if (!fully_qualified_node_name) {
+    Napi::Error::New(env, "Fully qualified name not set")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  return Napi::String::New(env, fully_qualified_node_name);
 }
 
 Napi::Object InitNodeBindings(Napi::Env env, Napi::Object exports) {
@@ -439,6 +466,8 @@ Napi::Object InitNodeBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("countServices", Napi::Function::New(env, CountServices));
 #endif
   exports.Set("getNodeNames", Napi::Function::New(env, GetNodeNames));
+  exports.Set("getFullyQualifiedName",
+              Napi::Function::New(env, GetFullyQualifiedName));
   return exports;
 }
 

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -48,6 +48,17 @@ describe('rclnodejs node test suite', function () {
       assert.deepStrictEqual(node.namespace(), '/ns');
     });
 
+    it('Get fully qualified name', function () {
+      let nodeName = 'example_node_with_ns',
+        nodeNamespace = '/ns';
+
+      var node = rclnodejs.createNode(nodeName, nodeNamespace);
+      assert.deepStrictEqual(
+        node.getFullyQualifiedName(),
+        '/ns/example_node_with_ns'
+      );
+    });
+
     it('Try creating a node with the empty namespace', function () {
       let nodeName = 'example_node_with_empty_ns',
         nodeNamespace = '';
@@ -396,6 +407,17 @@ describe('rcl node methods testing', function () {
 
     assert.ok(currentNode);
     assert.strictEqual(currentNode.namespace, '/my_ns');
+  });
+
+  it('node.getNodeNamesAndNamespacesWithEnclaves', function () {
+    var nodeNames = node.getNodeNamesAndNamespacesWithEnclaves();
+    var currentNode = nodeNames.find(function (nodeName) {
+      return nodeName.name === 'my_node';
+    });
+
+    assert.strictEqual(currentNode.name, 'my_node');
+    assert.strictEqual(currentNode.namespace, '/my_ns');
+    assert.strictEqual(currentNode.enclave, '/');
   });
 
   it('node.countPublishers', async () => {

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -68,7 +68,7 @@ expectType<rclnodejs.NamesAndTypesQueryResult[]>(node.getTopicNamesAndTypes());
 expectType<string[]>(node.getNodeNames());
 expectType<rclnodejs.NodeNamesQueryResult[]>(node.getNodeNamesAndNamespaces());
 expectType<rclnodejs.NodeNamesQueryResultWithEnclaves[]>(
-  node.getNodeNamesAndNamespacesEnclaves()
+  node.getNodeNamesAndNamespacesWithEnclaves()
 );
 expectType<Array<object>>(node.getPublishersInfoByTopic('topic', false));
 expectType<Array<object>>(node.getSubscriptionsInfoByTopic('topic', false));

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -67,6 +67,9 @@ expectType<rclnodejs.NamesAndTypesQueryResult[]>(
 expectType<rclnodejs.NamesAndTypesQueryResult[]>(node.getTopicNamesAndTypes());
 expectType<string[]>(node.getNodeNames());
 expectType<rclnodejs.NodeNamesQueryResult[]>(node.getNodeNamesAndNamespaces());
+expectType<rclnodejs.NodeNamesQueryResultWithEnclaves[]>(
+  node.getNodeNamesAndNamespacesEnclaves()
+);
 expectType<Array<object>>(node.getPublishersInfoByTopic('topic', false));
 expectType<Array<object>>(node.getSubscriptionsInfoByTopic('topic', false));
 expectType<number>(node.countPublishers(TOPIC));
@@ -76,6 +79,7 @@ expectType<number>(node.countServices(SERVICE_NAME));
 expectType<rclnodejs.Options<string | rclnodejs.QoS>>(
   rclnodejs.Node.getDefaultOptions()
 );
+expectType<string>(node.getFullyQualifiedName());
 
 // ---- LifecycleNode ----
 const lifecycleNode = rclnodejs.createLifecycleNode(LIFECYCLE_NODE_NAME);

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -792,7 +792,7 @@ declare module 'rclnodejs' {
      *
      * @returns An array of the names, namespaces and enclaves.
      */
-    getNodeNamesAndNamespacesEnclaves(): Array<NodeNamesQueryResultWithEnclaves>;
+    getNodeNamesAndNamespacesWithEnclaves(): Array<NodeNamesQueryResultWithEnclaves>;
 
     /**
      * Return the number of publishers on a given topic.

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -143,6 +143,24 @@ declare module 'rclnodejs' {
   };
 
   /**
+   * Result of Node.getNodeNames() query
+   *
+   * @example
+   * ```
+   * [
+   *   { name: 'gazebo',                namespace: '/', enclave: '/'},
+   *   { name: 'robot_state_publisher', namespace: '/', enclave: '/' },
+   *   { name: 'cam2image',             namespace: '/demo' , enclave: '/'}
+   * ]
+   * ```
+   */
+  type NodeNamesQueryResultWithEnclaves = {
+    name: string;
+    namespace: string;
+    enclave: string;
+  };
+
+  /**
    * Node is the primary entrypoint in a ROS system for communication.
    * It can be used to create ROS entities such as publishers, subscribers,
    * services, clients and timers.
@@ -770,6 +788,13 @@ declare module 'rclnodejs' {
     getNodeNamesAndNamespaces(): Array<NodeNamesQueryResult>;
 
     /**
+     * Get the list of nodes and their namespaces with enclaves discovered by the provided node.
+     *
+     * @returns An array of the names, namespaces and enclaves.
+     */
+    getNodeNamesAndNamespacesEnclaves(): Array<NodeNamesQueryResultWithEnclaves>;
+
+    /**
      * Return the number of publishers on a given topic.
      * @param topic - The name of the topic.
      * @returns Number of publishers on the given topic.
@@ -796,5 +821,12 @@ declare module 'rclnodejs' {
      * @returns Number of services.
      */
     countServices(serviceName: string): number;
+
+    /**
+     * Get the fully qualified name of the node.
+     *
+     * @returns String containing the fully qualified name of the node.
+     */
+    getFullyQualifiedName(): string;
   }
 }


### PR DESCRIPTION
Adds support for querying node names with enclaves and retrieving a node’s fully qualified name.

- Introduce `getNodeNamesAndNamespacesWithEnclaves()` and `getFullyQualifiedName()` in the JS API  
- Implement optional enclave retrieval and new fully qualified name binding in C++  
- Add corresponding unit and type-check tests

Fix: #1139