### PR TITLE
Fix the type error of client example

### DIFF
--- a/example/client-example.js
+++ b/example/client-example.js
@@ -38,8 +38,8 @@ async function main() {
   }
 
   const request = {
-    a: Math.floor(Math.random() * 100),
-    b: Math.floor(Math.random() * 100),
+    a: BigInt(Math.floor(Math.random() * 100)),
+    b: BigInt(Math.floor(Math.random() * 100)),
   };
 
   let result = await client.waitForService(1000);


### PR DESCRIPTION
https://github.com/RobotWebTools/rclnodejs/pull/1030 changed to leverage `BigInt` to represent int64, which leads to the type error of the client example. This PR fixes the type error by updating the client example to use `BigInt` instead of `number`.

Fix: #1145