### PR TITLE
Support type description service

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -167,6 +167,14 @@
           }
         ],
         [
+          # After Humble, e.g., Jazzy, Kilted.
+          'ros_version > 2205', {
+            'sources': [
+              './src/rcl_type_description_service_bindings.cpp',
+            ]
+          }
+        ],
+        [
           'runtime=="electron"', {
             "defines": ["NODE_RUNTIME_ELECTRON=1"]
           }

--- a/lib/node.js
+++ b/lib/node.js
@@ -150,7 +150,10 @@ class Node extends rclnodejs.ShadowNode {
       this._parameterService.start();
     }
 
-    if (options.startTypeDescriptionService) {
+    if (
+      DistroUtils.getDistroId() >= DistroUtils.getDistroId('jazzy') &&
+      options.startTypeDescriptionService
+    ) {
       this._typeDescriptionService = new TypeDescriptionService(this);
       this._typeDescriptionService.start();
     }

--- a/lib/node.js
+++ b/lib/node.js
@@ -39,6 +39,7 @@ const Service = require('./service.js');
 const Subscription = require('./subscription.js');
 const TimeSource = require('./time_source.js');
 const Timer = require('./timer.js');
+const TypeDescriptionService = require('./type_description_service.js');
 const Entity = require('./entity.js');
 
 // Parameter event publisher constants
@@ -101,6 +102,7 @@ class Node extends rclnodejs.ShadowNode {
     this._parameterDescriptors = new Map();
     this._parameters = new Map();
     this._parameterService = null;
+    this._typeDescriptionService = null;
     this._parameterEventPublisher = null;
     this._setParametersCallbacks = [];
     this._logger = new Logging(rclnodejs.getNodeLoggerName(this.handle));
@@ -146,6 +148,11 @@ class Node extends rclnodejs.ShadowNode {
     if (options.startParameterServices) {
       this._parameterService = new ParameterService(this);
       this._parameterService.start();
+    }
+
+    if (options.startTypeDescriptionService) {
+      this._typeDescriptionService = new TypeDescriptionService(this);
+      this._typeDescriptionService.start();
     }
   }
 

--- a/lib/node_options.js
+++ b/lib/node_options.js
@@ -109,16 +109,16 @@ class NodeOptions {
   }
 
   /**
-   * Get the startTypeDescriptionService option.
+   * Get the startTypeDescriptionService option, only available for ROS2 > Humble.
    * Default value = true;
-   * @returns {boolean} -
+   * @returns {boolean} - true if the type description service is enabled.
    */
   get startTypeDescriptionService() {
     return this._startTypeDescriptionService;
   }
 
   /**
-   * Set startTypeDescriptionService.
+   * Set startTypeDescriptionService, only available for ROS2 > Humble
    * @param {boolean} willStartTypeDescriptionService
    */
   set startTypeDescriptionService(willStartTypeDescriptionService) {

--- a/lib/node_options.js
+++ b/lib/node_options.js
@@ -26,16 +26,19 @@ class NodeOptions {
    * @param {boolean} [startParameterServices=true]
    * @param {array} [parameterOverrides=[]]
    * @param {boolean} [automaticallyDeclareParametersFromOverrides=false]
+   * @param {boolean} [startTypeDescriptionService=true]
    */
   constructor(
     startParameterServices = true,
     parameterOverrides = [],
-    automaticallyDeclareParametersFromOverrides = false
+    automaticallyDeclareParametersFromOverrides = false,
+    startTypeDescriptionService = true
   ) {
     this._startParameterServices = startParameterServices;
     this._parameterOverrides = parameterOverrides;
     this._automaticallyDeclareParametersFromOverrides =
       automaticallyDeclareParametersFromOverrides;
+    this._startTypeDescriptionService = startTypeDescriptionService;
   }
 
   /**
@@ -103,6 +106,23 @@ class NodeOptions {
    */
   set automaticallyDeclareParametersFromOverrides(declareParamsFlag) {
     this._automaticallyDeclareParametersFromOverrides = declareParamsFlag;
+  }
+
+  /**
+   * Get the startTypeDescriptionService option.
+   * Default value = true;
+   * @returns {boolean} -
+   */
+  get startTypeDescriptionService() {
+    return this._startTypeDescriptionService;
+  }
+
+  /**
+   * Set startTypeDescriptionService.
+   * @param {boolean} willStartTypeDescriptionService
+   */
+  set startTypeDescriptionService(willStartTypeDescriptionService) {
+    this._startTypeDescriptionService = willStartTypeDescriptionService;
   }
 
   /**

--- a/lib/type_description_service.js
+++ b/lib/type_description_service.js
@@ -1,0 +1,82 @@
+// Copyright (c) 2025, The Robot Web Tools Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const loader = require('./interface_loader.js');
+const rclnodejs = require('bindings')('rclnodejs');
+const Service = require('./service.js');
+
+// This class is used to create a TypeDescriptionService which can be used to
+// retrieve information about types used by the node’s publishers, subscribers,
+// services or actions.
+class TypeDescriptionService {
+  constructor(node) {
+    this._node = node;
+    this._serviceName = this._node.name() + '/get_type_description';
+    this._typeDescriptionServiceHandle = rclnodejs.initTypeDescriptionService(
+      this._node.handle
+    );
+    this._typeClass = loader.loadInterface(
+      'type_description_interfaces/srv/GetTypeDescription'
+    );
+    this._typeDescriptionService = null;
+  }
+
+  start() {
+    if (this._typeDescriptionService) {
+      return;
+    }
+
+    this._typeDescriptionService = new Service(
+      this._node.handle,
+      this._typeDescriptionServiceHandle,
+      this._serviceName,
+      this._typeClass,
+      this._node._validateOptions(undefined),
+      (request, response) => {
+        const responseToBeSent = new this._typeClass.Response();
+        const requestReceived = new this._typeClass.Request(request);
+        rclnodejs.handleRequest(
+          this._node.handle,
+          requestReceived.serialize(),
+          responseToBeSent.serialize()
+        );
+        responseToBeSent.deserialize(responseToBeSent.refObject);
+        rclnodejs.sendResponse(
+          this._typeDescriptionServiceHandle,
+          responseToBeSent.serialize(),
+          response._header
+        );
+        return null;
+      }
+    );
+    this._node._services.push(this._typeDescriptionService);
+    this._node.syncHandles();
+  }
+
+  /**
+   * Get the node this
+   * @return {Node} - The supported node.
+   */
+  get node() {
+    return this._node;
+  }
+
+  static toTypeHash(topicTypeHash) {
+    return `RIHS0${topicTypeHash.version}_${topicTypeHash.value.toString('hex')}`;
+  }
+}
+
+module.exports = TypeDescriptionService;

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -34,6 +34,9 @@
 #include "rcl_subscription_bindings.h"
 #include "rcl_time_point_bindings.h"
 #include "rcl_timer_bindings.h"
+#if ROS_VERSION > 2205  // ROS2 > Humble
+#include "rcl_type_description_service_bindings.h"
+#endif
 #include "rcl_utilities.h"
 #include "shadow_node.h"
 
@@ -79,6 +82,9 @@ Napi::Object InitModule(Napi::Env env, Napi::Object exports) {
   rclnodejs::InitSubscriptionBindings(env, exports);
   rclnodejs::InitTimePointBindings(env, exports);
   rclnodejs::InitTimerBindings(env, exports);
+#if ROS_VERSION > 2205  // ROS2 > Humble
+  rclnodejs::InitTypeDescriptionServiceBindings(env, exports);
+#endif
   rclnodejs::InitLifecycleBindings(env, exports);
   rclnodejs::ShadowNode::Init(env, exports);
   rclnodejs::RclHandle::Init(env, exports);

--- a/src/rcl_type_description_service_bindings.cpp
+++ b/src/rcl_type_description_service_bindings.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2025, The Robot Web Tools Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rcl_type_description_service_bindings.h"
+
+#include <napi.h>
+#include <rcl/rcl.h>
+#include <rmw/types.h>
+
+#include "rcl_handle.h"
+
+namespace rclnodejs {
+
+Napi::Value InitTypeDescriptionService(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  rcl_service_t* service =
+      reinterpret_cast<rcl_service_t*>(malloc(sizeof(rcl_service_t)));
+  *service = rcl_get_zero_initialized_service();
+  rcl_ret_t ret = rcl_node_type_description_service_init(service, node);
+  if (RCL_RET_OK != ret) {
+    Napi::Error::New(env, "Failed to initialize type description service")
+        .ThrowAsJavaScriptException();
+  }
+
+  auto service_handle =
+      RclHandle::NewInstance(env, service, node_handle, [node, env](void* ptr) {
+        rcl_service_t* service = reinterpret_cast<rcl_service_t*>(ptr);
+        rcl_ret_t ret = rcl_service_fini(service, node);
+        if (RCL_RET_OK != ret) {
+          Napi::Error::New(env, "Failed to destroy type description service")
+              .ThrowAsJavaScriptException();
+        }
+        free(ptr);
+      });
+  return service_handle;
+}
+
+Napi::Value HandleRequest(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(
+      RclHandle::Unwrap(info[0].As<Napi::Object>())->ptr());
+  void* request = info[1].As<Napi::Buffer<char>>().Data();
+  void* taken_response = info[2].As<Napi::Buffer<char>>().Data();
+
+  rmw_request_id_t header;
+  rcl_node_type_description_service_handle_request(
+      node, &header,
+      static_cast<
+          type_description_interfaces__srv__GetTypeDescription_Request*>(
+          request),
+      static_cast<
+          type_description_interfaces__srv__GetTypeDescription_Response*>(
+          taken_response));
+  return env.Undefined();
+}
+
+Napi::Object InitTypeDescriptionServiceBindings(Napi::Env env,
+                                                Napi::Object exports) {
+  exports.Set("handleRequest", Napi::Function::New(env, HandleRequest));
+  exports.Set("initTypeDescriptionService",
+              Napi::Function::New(env, InitTypeDescriptionService));
+
+  return exports;
+}
+
+}  // namespace rclnodejs

--- a/src/rcl_type_description_service_bindings.h
+++ b/src/rcl_type_description_service_bindings.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2025, The Robot Web Tools Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SRC_RCL_TYPE_DESCRIPTION_SERVICE_BINDINGS_H_
+#define SRC_RCL_TYPE_DESCRIPTION_SERVICE_BINDINGS_H_
+
+#include <napi.h>
+
+namespace rclnodejs {
+
+Napi::Object InitTypeDescriptionServiceBindings(Napi::Env env,
+                                                Napi::Object exports);
+
+}
+
+#endif  // SRC_RCL_TYPE_DESCRIPTION_SERVICE_BINDINGS_H_

--- a/test/test-extra-destroy-methods.js
+++ b/test/test-extra-destroy-methods.js
@@ -89,7 +89,7 @@ describe('Node extra destroy methods testing', function () {
     var node = rclnodejs.createNode('node4');
     const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
     var service = node.createService(AddTwoInts, 'add_two_ints', () => {});
-    assert.deepStrictEqual(node._services.length, 7);
+    assert.deepStrictEqual(node._services.length, 8);
 
     assertThrowsError(
       function () {
@@ -101,7 +101,7 @@ describe('Node extra destroy methods testing', function () {
     );
 
     node.destroyService(service);
-    assert.deepStrictEqual(node._services.length, 6);
+    assert.deepStrictEqual(node._services.length, 7);
   });
 
   it('destroyTimer()', function () {

--- a/test/test-extra-destroy-methods.js
+++ b/test/test-extra-destroy-methods.js
@@ -89,13 +89,9 @@ describe('Node extra destroy methods testing', function () {
   it('destroyService()', function () {
     var node = rclnodejs.createNode('node4');
     const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
+    const initialServiceCount = node._services.length;
     var service = node.createService(AddTwoInts, 'add_two_ints', () => {});
-    if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
-      assert.deepStrictEqual(node._services.length, 7);
-    } else {
-      assert.deepStrictEqual(node._services.length, 8);
-    }
-
+    assert.deepStrictEqual(node._services.length, initialServiceCount + 1);
     assertThrowsError(
       function () {
         node.destroyService('service');
@@ -106,11 +102,7 @@ describe('Node extra destroy methods testing', function () {
     );
 
     node.destroyService(service);
-    if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
-      assert.deepStrictEqual(node._services.length, 6);
-    } else {
-      assert.deepStrictEqual(node._services.length, 7);
-    }
+    assert.deepStrictEqual(node._services.length, initialServiceCount);
   });
 
   it('destroyTimer()', function () {

--- a/test/test-extra-destroy-methods.js
+++ b/test/test-extra-destroy-methods.js
@@ -18,6 +18,7 @@ const assert = require('assert');
 const rclnodejs = require('../index.js');
 const assertUtils = require('./utils.js');
 const assertThrowsError = assertUtils.assertThrowsError;
+const DistroUtils = require('../lib/distro.js');
 
 describe('Node extra destroy methods testing', function () {
   before(function () {
@@ -89,7 +90,11 @@ describe('Node extra destroy methods testing', function () {
     var node = rclnodejs.createNode('node4');
     const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
     var service = node.createService(AddTwoInts, 'add_two_ints', () => {});
-    assert.deepStrictEqual(node._services.length, 8);
+    if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
+      assert.deepStrictEqual(node._services.length, 7);
+    } else {
+      assert.deepStrictEqual(node._services.length, 8);
+    }
 
     assertThrowsError(
       function () {
@@ -101,7 +106,11 @@ describe('Node extra destroy methods testing', function () {
     );
 
     node.destroyService(service);
-    assert.deepStrictEqual(node._services.length, 7);
+    if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
+      assert.deepStrictEqual(node._services.length, 6);
+    } else {
+      assert.deepStrictEqual(node._services.length, 7);
+    }
   });
 
   it('destroyTimer()', function () {

--- a/test/test-type-description-service.js
+++ b/test/test-type-description-service.js
@@ -30,8 +30,8 @@ describe('type description service test suite', function () {
     rclnodejs.shutdown();
   });
 
-  it('Test type description service', (done) => {
-    if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
+  it('Test type description service', function (done) {
+    if (DistroUtils.getDistroId() > DistroUtils.getDistroId('humble')) {
       this.skip();
       return;
     }

--- a/test/test-type-description-service.js
+++ b/test/test-type-description-service.js
@@ -31,7 +31,7 @@ describe('type description service test suite', function () {
   });
 
   it('Test type description service', function (done) {
-    if (DistroUtils.getDistroId() > DistroUtils.getDistroId('humble')) {
+    if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
       this.skip();
       return;
     }

--- a/test/test-type-description-service.js
+++ b/test/test-type-description-service.js
@@ -1,0 +1,71 @@
+// Copyright (c) 2025, The Robot Web Tools Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const DistroUtils = require('../lib/distro.js');
+const rclnodejs = require('../index.js');
+const TypeDescriptionService = require('../lib/type_description_service.js');
+
+describe('type description service test suite', function () {
+  this.timeout(60 * 1000);
+
+  beforeEach(function () {
+    return rclnodejs.init();
+  });
+
+  afterEach(function () {
+    rclnodejs.shutdown();
+  });
+
+  it('Test type description service', (done) => {
+    if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
+      this.skip();
+      return;
+    }
+    // Create a node and a publisher
+    const nodeName = 'test_type_description_service';
+    const node = rclnodejs.createNode(nodeName);
+    const topic = 'test_get_type_description_publisher';
+    const topicType = 'std_msgs/msg/String';
+    node.createPublisher(topicType, topic);
+    const infos = node.getPublishersInfoByTopic(
+      '/test_get_type_description_publisher',
+      false
+    );
+    assert.strictEqual(infos.length, 1);
+
+    // Create a client to get the type description.
+    const request = {
+      type_name: topicType,
+      type_hash: TypeDescriptionService.toTypeHash(infos[0].topic_type_hash),
+      include_type_sources: true,
+    };
+    const serviceName = '/test_type_description_service/get_type_description';
+    const GetTypeDescription =
+      'type_description_interfaces/srv/GetTypeDescription';
+    const client = node.createClient(GetTypeDescription, serviceName);
+    client.sendRequest(request, (response) => {
+      assert.strictEqual(response.successful, true);
+      assert.strictEqual(
+        response.type_description.type_description.type_name,
+        topicType
+      );
+      assert.notStrictEqual(response.type_sources.length, 0);
+      done();
+    });
+    rclnodejs.spin(node);
+  });
+});


### PR DESCRIPTION
This PR adds support for the ROS 2 Type Description Service, including native bindings, JavaScript API, test coverage, build integration, and an option to start the service automatically.

- Introduces C++ N-API bindings for the type description service and integrates them in the module initialization.
- Implements a JavaScript `TypeDescriptionService` class, updates `NodeOptions`/`Node` to optionally start the service, and adds tests.
- Updates `binding.gyp` to include the new source and extends test files to handle distro version differences.

See doc: https://docs.ros.org/en/jazzy/Releases/Release-Jazzy-Jalisco.html#add-get-type-description-service

Fix: #1143