### PR TITLE
Fix test-type-description-service.js flakiness

### DIFF
--- a/test/test-type-description-service.js
+++ b/test/test-type-description-service.js
@@ -21,9 +21,13 @@ const TypeDescriptionService = require('../lib/type_description_service.js');
 
 describe('type description service test suite', function () {
   this.timeout(60 * 1000);
+  let node;
 
-  beforeEach(function () {
-    return rclnodejs.init();
+  beforeEach(async function () {
+    await rclnodejs.init();
+    const nodeName = 'test_type_description_service';
+    node = rclnodejs.createNode(nodeName);
+    rclnodejs.spin(node);
   });
 
   afterEach(function () {
@@ -35,9 +39,7 @@ describe('type description service test suite', function () {
       this.skip();
       return;
     }
-    // Create a node and a publisher
-    const nodeName = 'test_type_description_service';
-    const node = rclnodejs.createNode(nodeName);
+    // Create a publisher
     const topic = 'test_get_type_description_publisher';
     const topicType = 'std_msgs/msg/String';
     node.createPublisher(topicType, topic);
@@ -66,6 +68,5 @@ describe('type description service test suite', function () {
       assert.notStrictEqual(response.type_sources.length, 0);
       done();
     });
-    rclnodejs.spin(node);
   });
 });


### PR DESCRIPTION
This PR addresses the flakiness in the test-type-description-service.js test suite by updating the asynchronous initialization pattern.  
- Converts beforeEach to an async function, awaiting rclnodejs.init()  
- Creates and spins a test node in beforeEach instead of within individual tests

Fix: #1154