### PR TITLE
Add Humble into arm workflow

### DIFF
--- a/.github/workflows/linux-arm64-build-and-test.yml
+++ b/.github/workflows/linux-arm64-build-and-test.yml
@@ -30,9 +30,13 @@ jobs:
         node-version: [22.X]
         architecture: [arm64]
         ros_distribution:
+          - humble
           - jazzy
           - kilted
         include:
+          # Humble Hawksbill (May 2022 - May 2027)
+          - docker_image: ubuntu:jammy
+            ros_distribution: humble
           # Jazzy Jalisco (May 2024 - May 2029)
           - docker_image: ubuntu:noble
             ros_distribution: jazzy

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -27,15 +27,6 @@ jobs:
           - jazzy
           - kilted
           - rolling
-        include:
-          # Humble Hawksbill (May 2022 - May 2027)
-          - ros_distribution: humble
-          # Jazzy Jalisco (May 2024 - May 2029)
-          - ros_distribution: jazzy
-          # Kilted Kaiju (May 2025 - Dec 2026)
-          - ros_distribution: kilted
-          # Rolling Ridley (No End-Of-Life)
-          - ros_distribution: rolling
     steps:
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4


### PR DESCRIPTION
This PR aims to update the build and test workflows to include the ROS distribution "humble" for the ARM environment.  
- Removed the ROS distribution mapping (including "humble") from the Windows workflow.  
- Added "humble" to the ROS distribution list and provided a corresponding docker image mapping in the linux-arm64 workflow.

Fix: #1156