### PR TITLE
Support get_type_description service via parameter

### DIFF
--- a/lib/type_description_service.js
+++ b/lib/type_description_service.js
@@ -18,6 +18,12 @@ const loader = require('./interface_loader.js');
 const rclnodejs = require('bindings')('rclnodejs');
 const Service = require('./service.js');
 
+const {
+  ParameterType,
+  Parameter,
+  ParameterDescriptor,
+} = require('../lib/parameter.js');
+
 // This class is used to create a TypeDescriptionService which can be used to
 // retrieve information about types used by the node’s publishers, subscribers,
 // services or actions.
@@ -32,10 +38,30 @@ class TypeDescriptionService {
       'type_description_interfaces/srv/GetTypeDescription'
     );
     this._typeDescriptionService = null;
+
+    this._enabled = false;
+    const startTypeDescriptionServiceParam = 'start_type_description_service';
+    if (!node.hasParameter(startTypeDescriptionServiceParam)) {
+      node.declareParameter(
+        new Parameter(
+          startTypeDescriptionServiceParam,
+          ParameterType.PARAMETER_BOOL,
+          true
+        ),
+        new ParameterDescriptor(
+          startTypeDescriptionServiceParam,
+          ParameterType.PARAMETER_BOOL,
+          'If enabled, start the ~/get_type_description service.',
+          true
+        )
+      );
+    }
+    const param = node.getParameter(startTypeDescriptionServiceParam);
+    this._enabled = param.value;
   }
 
   start() {
-    if (this._typeDescriptionService) {
+    if (!this._enabled || this._typeDescriptionService) {
       return;
     }
 

--- a/test/test-parameter-service.js
+++ b/test/test-parameter-service.js
@@ -120,7 +120,7 @@ describe('Parameter_server tests', function () {
     let success = false;
     client.sendRequest(request, (response) => {
       const result = response.result;
-      assert.equal(result.names.length, 4); // account for use_sim_time  and start_type_description_service parameter
+      assert.equal(result.names.length, 4); // account for use_sim_time and start_type_description_service parameter
       assert.ok(result.names.includes('p1'));
       assert.ok(result.names.includes('p2'));
       success = true;

--- a/test/test-parameter-service.js
+++ b/test/test-parameter-service.js
@@ -18,7 +18,7 @@ const assert = require('assert');
 
 const rclnodejs = require('../index.js');
 const assertUtils = require('./utils.js');
-const assertThrowsError = assertUtils.assertThrowsError;
+const DistroUtils = require('../lib/distro.js');
 
 const {
   ParameterType,
@@ -120,7 +120,11 @@ describe('Parameter_server tests', function () {
     let success = false;
     client.sendRequest(request, (response) => {
       const result = response.result;
-      assert.equal(result.names.length, 4); // account for use_sim_time and start_type_description_service parameter
+      if (DistroUtils.getDistroId() >= DistroUtils.getDistroId('jazzy')) {
+        assert.equal(result.names.length, 4); // account for use_sim_time and start_type_description_service parameter
+      } else {
+        assert.equal(result.names.length, 3); // account for use_sim_time parameter
+      }
       assert.ok(result.names.includes('p1'));
       assert.ok(result.names.includes('p2'));
       success = true;

--- a/test/test-parameter-service.js
+++ b/test/test-parameter-service.js
@@ -120,7 +120,7 @@ describe('Parameter_server tests', function () {
     let success = false;
     client.sendRequest(request, (response) => {
       const result = response.result;
-      assert.equal(result.names.length, 3); // account for use_sim_time parameter
+      assert.equal(result.names.length, 4); // account for use_sim_time  and start_type_description_service parameter
       assert.ok(result.names.includes('p1'));
       assert.ok(result.names.includes('p2'));
       success = true;

--- a/test/test-type-description-service.js
+++ b/test/test-type-description-service.js
@@ -88,6 +88,10 @@ describe('type description service test suite', function () {
         }
         if (stdout.includes('start_type_description_service')) {
           done();
+        } else {
+          done(
+            new Error("'start_type_description_service' not found in stdout.")
+          );
         }
       }
     );

--- a/test/test-type-description-service.js
+++ b/test/test-type-description-service.js
@@ -19,6 +19,7 @@ const assertUtils = require('./utils.js');
 const DistroUtils = require('../lib/distro.js');
 const rclnodejs = require('../index.js');
 const TypeDescriptionService = require('../lib/type_description_service.js');
+const { exec } = require('child_process');
 
 describe('type description service test suite', function () {
   this.timeout(60 * 1000);
@@ -72,5 +73,23 @@ describe('type description service test suite', function () {
       assert.notStrictEqual(response.type_sources.length, 0);
       done();
     });
+  });
+
+  it('Test type description service configured by parameter', function (done) {
+    exec(
+      'ros2 param list /test_type_description_service',
+      (error, stdout, stderr) => {
+        if (error || stderr) {
+          done(
+            new Error(
+              'Test type description service configured by parameter failed.'
+            )
+          );
+        }
+        if (stdout.includes('start_type_description_service')) {
+          done();
+        }
+      }
+    );
   });
 });

--- a/test/test-type-description-service.js
+++ b/test/test-type-description-service.js
@@ -36,14 +36,13 @@ describe('type description service test suite', function () {
     const nodeName = 'test_type_description_service';
     node = rclnodejs.createNode(nodeName);
     rclnodejs.spin(node);
-    await assertUtils.createDelay(1000);
   });
 
   afterEach(function () {
     rclnodejs.shutdown();
   });
 
-  it('Test type description service', function (done) {
+  it('Test type description service', async function () {
     // Create a publisher
     const topic = 'test_get_type_description_publisher';
     const topicType = 'std_msgs/msg/String';
@@ -64,14 +63,21 @@ describe('type description service test suite', function () {
     const GetTypeDescription =
       'type_description_interfaces/srv/GetTypeDescription';
     const client = node.createClient(GetTypeDescription, serviceName);
-    client.sendRequest(request, (response) => {
-      assert.strictEqual(response.successful, true);
-      assert.strictEqual(
-        response.type_description.type_description.type_name,
-        topicType
-      );
-      assert.notStrictEqual(response.type_sources.length, 0);
-      done();
+    return client.waitForService(60 * 1000).then((result) => {
+      if (!result) {
+        throw new Error('Service not available');
+      }
+      return new Promise((resolve) => {
+        client.sendRequest(request, (response) => {
+          assert.strictEqual(response.successful, true);
+          assert.strictEqual(
+            response.type_description.type_description.type_name,
+            topicType
+          );
+          assert.notStrictEqual(response.type_sources.length, 0);
+          resolve();
+        });
+      });
     });
   });
 
@@ -91,6 +97,31 @@ describe('type description service test suite', function () {
         } else {
           done(
             new Error("'start_type_description_service' not found in stdout.")
+          );
+        }
+      }
+    );
+  });
+
+  it('Test start_type_description_service parameter value', function (done) {
+    exec(
+      'ros2 param get /test_type_description_service start_type_description_service',
+      (error, stdout, stderr) => {
+        if (error || stderr) {
+          done(
+            new Error(
+              'Test type description service configured by parameter failed.'
+            )
+          );
+        }
+        if (stdout.includes('Boolean value is: True')) {
+          done();
+        } else {
+          console.log(stdout);
+          done(
+            new Error(
+              "'start_type_description_service param value' not found in stdout."
+            )
           );
         }
       }


### PR DESCRIPTION
This PR adds support for starting the type description service via a configurable parameter and includes a new test case to verify that configuration.  
- Added a new test case in test/test-type-description-service.js to check the parameter configuration.  
- Updated lib/type_description_service.js to declare and retrieve the "start_type_description_service" parameter and conditionally start the service.

Fix: #1161