### PR TITLE
Support setting domain id for Context

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,7 +255,7 @@ let rcl = {
       throw new TypeError('argv elements must be strings (and not null).');
     }
 
-    rclnodejs.init(context.handle, argv);
+    rclnodejs.init(context.handle, argv, context._domainId);
 
     if (_rosVersionChecked) {
       // no further processing required

--- a/lib/context.js
+++ b/lib/context.js
@@ -63,11 +63,13 @@ class Context {
    * Call rcl.init(context) to initialize this context state for
    * use in creating nodes, etc.
    * @constructor
+   * @param {bigint} - Optional, The domain ID of this context.
    */
-  constructor() {
+  constructor(domainId) {
     this._handle = rclnodejs.createContext();
     this._isShutdown = false;
     this._nodes = [];
+    this._domainId = domainId;
     Context._instances.push(this);
   }
 
@@ -222,7 +224,7 @@ class Context {
 
   /**
    * Get the domain ID of this context.
-   * @returns {Number} domain ID of this context
+   * @returns {bigint} domain ID of this context
    */
   get domainId() {
     return rclnodejs.getDomainId(this.handle);

--- a/src/rcl_context_bindings.cpp
+++ b/src/rcl_context_bindings.cpp
@@ -18,6 +18,7 @@
 #include <rcl/rcl.h>
 
 #include <cstdio>
+#include <rcpputils/scope_exit.hpp>
 #include <string>
 
 #include "macros.h"
@@ -34,6 +35,15 @@ Napi::Value Init(const Napi::CallbackInfo& info) {
   THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
                            rcl_init_options_init(&init_options, allocator),
                            rcl_get_error_string().str);
+
+  RCPPUTILS_SCOPE_EXIT({
+    rcl_ret_t fini_ret = rcl_init_options_fini(&init_options);
+    if (RCL_RET_OK != fini_ret) {
+      Napi::Error::New(env, rcl_get_error_string().str)
+          .ThrowAsJavaScriptException();
+      rcl_reset_error();
+    }
+  });
 
   // Preprocess Context
   RclHandle* context_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
@@ -53,6 +63,18 @@ Napi::Value Init(const Napi::CallbackInfo& info) {
       argv[i] = reinterpret_cast<char*>(malloc(len * sizeof(char)));
       snprintf(argv[i], len, "%s", arg.c_str());
     }
+  }
+  // Set up the domain id.
+  size_t domain_id = RCL_DEFAULT_DOMAIN_ID;
+  if (info.Length() > 2 && info[2].IsBigInt()) {
+    bool lossless;
+    domain_id = info[2].As<Napi::BigInt>().Uint64Value(&lossless);
+  }
+  rcl_ret_t ret = rcl_init_options_set_domain_id(&init_options, domain_id);
+  if (RCL_RET_OK != ret) {
+    Napi::Error::New(env, "failed to set domain id to init options")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
   THROW_ERROR_IF_NOT_EQUAL(
@@ -141,7 +163,7 @@ Napi::Value GetDomainId(const Napi::CallbackInfo& info) {
     return env.Undefined();
   }
 
-  return Napi::Number::New(env, domain_id);
+  return Napi::BigInt::New(env, domain_id);
 }
 
 Napi::Object InitContextBindings(Napi::Env env, Napi::Object exports) {

--- a/src/rcl_context_bindings.cpp
+++ b/src/rcl_context_bindings.cpp
@@ -19,6 +19,7 @@
 
 #include <cstdio>
 #include <rcpputils/scope_exit.hpp>
+// NOLINTNEXTLINE
 #include <string>
 
 #include "macros.h"

--- a/src/rcl_graph_bindings.cpp
+++ b/src/rcl_graph_bindings.cpp
@@ -19,6 +19,7 @@
 #include <rcl/rcl.h>
 
 #include <rcpputils/scope_exit.hpp>
+// NOLINTNEXTLINE
 #include <string>
 
 #include "macros.h"

--- a/src/rcl_graph_bindings.cpp
+++ b/src/rcl_graph_bindings.cpp
@@ -19,7 +19,6 @@
 #include <rcl/rcl.h>
 
 #include <rcpputils/scope_exit.hpp>
-// NOLINTNEXTLINE
 #include <string>
 
 #include "macros.h"

--- a/test/test-context.js
+++ b/test/test-context.js
@@ -81,9 +81,16 @@ describe('context test suite', function () {
     assert.strictEqual(context.nodes.length, 0);
   });
 
-  it('context number id', async function () {
+  it('context domain id', async function () {
+    let context = new rclnodejs.Context(BigInt(123));
+    await rclnodejs.init(context);
+    assert.strictEqual(typeof context.domainId, 'bigint');
+    assert.strictEqual(context.domainId, BigInt(123));
+  });
+
+  it('context with default domain id', async function () {
     let context = new rclnodejs.Context();
     await rclnodejs.init(context);
-    assert.strictEqual(typeof context.domainId, 'number');
+    assert.strictEqual(typeof context.domainId, 'bigint');
   });
 });

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -28,7 +28,8 @@ expectType<string | undefined>(rclnodejs.DistroUtils.getDistroName(2105));
 
 // ---- Context -----
 expectType<rclnodejs.Context>(rclnodejs.Context.defaultContext());
-expectType<number>(rclnodejs.Context.defaultContext().domainId());
+expectType<rclnodejs.Context>(new rclnodejs.Context(123n));
+expectType<bigint>(rclnodejs.Context.defaultContext().domainId());
 
 // ---- NodeOptions ----
 const nodeOptions = new rclnodejs.NodeOptions();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "lib": ["es2017"]
+    "lib": ["es2020"]
   },
   "include": [
         "types/**/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es6",
+    "target": "es2020",
     /* Strict Type-Checking Options */
     "strict": true,
     /* Additional Checks */

--- a/types/context.d.ts
+++ b/types/context.d.ts
@@ -38,8 +38,9 @@ declare module 'rclnodejs' {
      * Create a new instance in uninitialized state.
      * Call rcl.init(context) to initialize this context state for
      * use in creating nodes, etc.
+     * @param {bigint} - Optional, The domain ID of this context.
      */
-    constructor();
+    constructor(domainId?: bigint);
 
     /**
      * Test if this context has not been initialized by rcl.init(context).
@@ -92,6 +93,6 @@ declare module 'rclnodejs' {
      * Get the domain ID of this context.
      * @returns domain ID of this context
      */
-    domainId(): number;
+    domainId(): bigint;
   }
 }


### PR DESCRIPTION
This PR adds support for setting the domain id for the Context, ensuring that the domain id is handled and returned as a BigInt throughout the API. Key changes include:
- Adjusting type assertions in tests to expect BigInt for domain ids.
- Updating the C++ bindings to accept an optional BigInt argument and return a BigInt.
- Modifying the Context API and initialization code in JavaScript to handle the new domain id.

Fix: #1163