### PR TITLE
Support to log the state machine data

### DIFF
--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -601,6 +601,15 @@ class LifecycleNode extends Node {
   }
 
   /**
+   * Log the state machine data.
+   *
+   * @returns {undefined} void.
+   */
+  print() {
+    rclnodejs.print(this._stateMachineHandle);
+  }
+
+  /**
    * The GetState service handler.
    * @param {Object} request - The GetState service request.
    * @param {Object} response - The GetState service response.

--- a/src/rcl_lifecycle_bindings.cpp
+++ b/src/rcl_lifecycle_bindings.cpp
@@ -372,6 +372,17 @@ Napi::Value IsInitialized(const Napi::CallbackInfo& info) {
   return Napi::Boolean::New(env, is_initialized);
 }
 
+Napi::Value Print(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  RclHandle* state_machine_handle =
+      RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_lifecycle_state_machine_t* state_machine =
+      reinterpret_cast<rcl_lifecycle_state_machine_t*>(
+          state_machine_handle->ptr());
+  rcl_print_state_machine(state_machine);
+  return env.Undefined();
+}
+
 Napi::Object InitLifecycleBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("createLifecycleStateMachine",
               Napi::Function::New(env, CreateLifecycleStateMachine));
@@ -396,6 +407,7 @@ Napi::Object InitLifecycleBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("getLifecycleShutdownTransitionLabel",
               Napi::Function::New(env, GetLifecycleShutdownTransitionLabel));
   exports.Set("isInitialized", Napi::Function::New(env, IsInitialized));
+  exports.Set("print", Napi::Function::New(env, Print));
   return exports;
 }
 

--- a/test/test-lifecycle.js
+++ b/test/test-lifecycle.js
@@ -356,4 +356,10 @@ describe('LifecycleNode test suite', function () {
     assert.equal(serviceMsgs.length, 0, 'Unexpected lifecycle services found');
     testNode.destroy();
   });
+
+  it('lifecycleNode initial state', function () {
+    assert.doesNotThrow(() => {
+      node.print();
+    });
+  });
 });

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -127,6 +127,7 @@ expectType<rclnodejs.lifecycle.State>(lifecycleNode.deactivate());
 expectType<rclnodejs.lifecycle.State>(lifecycleNode.cleanup());
 expectType<rclnodejs.lifecycle.State>(lifecycleNode.shutdown());
 expectType<boolean>(lifecycleNode.isInitialized);
+expectType<void>(lifecycleNode.print());
 
 // ---- Publisher ----
 const publisher = node.createPublisher(TYPE_CLASS, TOPIC);

--- a/types/lifecycle.d.ts
+++ b/types/lifecycle.d.ts
@@ -333,6 +333,13 @@ declare module 'rclnodejs' {
        * @returns {boolean} true if the state machine is initialized; otherwise false.
        */
       get isInitialized(): boolean;
+
+      /**
+       * Log the state machine data.
+       *
+       * @returns {undefined} void.
+       */
+      print(): void;
     }
   } // lifecycle namespace
 } // rclnodejs namespace


### PR DESCRIPTION
Adds support for logging the lifecycle state machine data.

- Introduces a new C++ binding (`print`) that calls `rcl_print_state_machine`
- Exposes a `print()` method on the JavaScript `LifecycleNode` class
- Adds TypeScript and JS tests to verify the new `print()` functionality

Fix: #1167