### PR TITLE
Fix test-type-description-service.js flakiness

### DIFF
--- a/test/test-type-description-service.js
+++ b/test/test-type-description-service.js
@@ -62,15 +62,15 @@ describe('type description service test suite', function () {
     const GetTypeDescription =
       'type_description_interfaces/srv/GetTypeDescription';
     const client = node.createClient(GetTypeDescription, serviceName);
-    const result = await client.waitForService(30 * 1000);
+    const result = await client.waitForService(5000);
     if (!result) {
       throw new Error('Service not available');
     }
 
     const promise = new Promise((resolve) => {
       const timer = setInterval(() => {
-        clearInterval(timer);
         client.sendRequest(request, (response) => {
+          clearInterval(timer);
           assert.strictEqual(response.successful, true);
           assert.strictEqual(
             response.type_description.type_description.type_name,
@@ -79,7 +79,7 @@ describe('type description service test suite', function () {
           assert.notStrictEqual(response.type_sources.length, 0);
           resolve();
         });
-      }, 5000);
+      }, 2000);
     });
     await promise;
   });

--- a/test/test-type-description-service.js
+++ b/test/test-type-description-service.js
@@ -69,7 +69,7 @@ describe('type description service test suite', function () {
 
     const promise = new Promise((resolve) => {
       const timer = setInterval(() => {
-        console.log('Sending request to get type description...');
+        clearInterval(timer);
         client.sendRequest(request, (response) => {
           assert.strictEqual(response.successful, true);
           assert.strictEqual(
@@ -77,7 +77,6 @@ describe('type description service test suite', function () {
             topicType
           );
           assert.notStrictEqual(response.type_sources.length, 0);
-          clearInterval(timer);
           resolve();
         });
       }, 5000);

--- a/test/test-type-description-service.js
+++ b/test/test-type-description-service.js
@@ -68,15 +68,19 @@ describe('type description service test suite', function () {
     }
 
     const promise = new Promise((resolve) => {
-      client.sendRequest(request, (response) => {
-        assert.strictEqual(response.successful, true);
-        assert.strictEqual(
-          response.type_description.type_description.type_name,
-          topicType
-        );
-        assert.notStrictEqual(response.type_sources.length, 0);
-        resolve();
-      });
+      const timer = setInterval(() => {
+        console.log('Sending request to get type description...');
+        client.sendRequest(request, (response) => {
+          assert.strictEqual(response.successful, true);
+          assert.strictEqual(
+            response.type_description.type_description.type_name,
+            topicType
+          );
+          assert.notStrictEqual(response.type_sources.length, 0);
+          clearInterval(timer);
+          resolve();
+        });
+      }, 5000);
     });
     await promise;
   });

--- a/test/test-type-description-service.js
+++ b/test/test-type-description-service.js
@@ -15,7 +15,6 @@
 'use strict';
 
 const assert = require('assert');
-const assertUtils = require('./utils.js');
 const DistroUtils = require('../lib/distro.js');
 const rclnodejs = require('../index.js');
 const TypeDescriptionService = require('../lib/type_description_service.js');
@@ -63,22 +62,23 @@ describe('type description service test suite', function () {
     const GetTypeDescription =
       'type_description_interfaces/srv/GetTypeDescription';
     const client = node.createClient(GetTypeDescription, serviceName);
-    return client.waitForService(60 * 1000).then((result) => {
-      if (!result) {
-        throw new Error('Service not available');
-      }
-      return new Promise((resolve) => {
-        client.sendRequest(request, (response) => {
-          assert.strictEqual(response.successful, true);
-          assert.strictEqual(
-            response.type_description.type_description.type_name,
-            topicType
-          );
-          assert.notStrictEqual(response.type_sources.length, 0);
-          resolve();
-        });
+    const result = await client.waitForService(30 * 1000);
+    if (!result) {
+      throw new Error('Service not available');
+    }
+
+    const promise = new Promise((resolve) => {
+      client.sendRequest(request, (response) => {
+        assert.strictEqual(response.successful, true);
+        assert.strictEqual(
+          response.type_description.type_description.type_name,
+          topicType
+        );
+        assert.notStrictEqual(response.type_sources.length, 0);
+        resolve();
       });
     });
+    await promise;
   });
 
   it('Test type description service configured by parameter', function (done) {


### PR DESCRIPTION
This PR addresses test flakiness in the type description service tests by refining the asynchronous wait logic and cleaning up unused imports. Key changes include:

- Removal of the unused assertUtils import.
- Transition from a promise chain to async/await for waiting on the service and handling the response.
- Introduction of an interval-based polling mechanism to send the request and clear the timer upon response.

Fix: #1154