### PR TITLE
Support to resolve topic/service name

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1692,6 +1692,42 @@ class Node extends rclnodejs.ShadowNode {
     return rclnodejs.getRMWImplementationIdentifier();
   }
 
+  /**
+   * Return a topic name expanded and remapped.
+   * @param {string} topicName - Topic name to be expanded and remapped.
+   * @param {boolean} [onlyExpand=false] - If `true`, remapping rules won't be applied.
+   * @returns {string} - A fully qualified topic name.
+   */
+  resolveTopicName(topicName, onlyExpand = false) {
+    if (typeof topicName !== 'string') {
+      throw new TypeError('Invalid argument: expected string');
+    }
+    return rclnodejs.resolveName(
+      this.handle,
+      topicName,
+      onlyExpand,
+      /*isService=*/ false
+    );
+  }
+
+  /**
+   * Return a service name expanded and remapped.
+   * @param {string} service - Service name to be expanded and remapped.
+   * @param {boolean} [onlyExpand=false] - If `true`, remapping rules won't be applied.
+   * @returns {string} - A fully qualified service name.
+   */
+  resolveServiceName(service, onlyExpand = false) {
+    if (typeof service !== 'string') {
+      throw new TypeError('Invalid argument: expected string');
+    }
+    return rclnodejs.resolveName(
+      this.handle,
+      service,
+      onlyExpand,
+      /*isService=*/ true
+    );
+  }
+
   // returns on 1st error or result {successful, reason}
   _validateParameters(parameters = [], declareParameterMode = false) {
     for (const parameter of parameters) {

--- a/src/rcl_node_bindings.cpp
+++ b/src/rcl_node_bindings.cpp
@@ -476,6 +476,37 @@ Napi::Value GetRMWImplementationIdentifier(const Napi::CallbackInfo& info) {
   return Napi::String::New(info.Env(), rmw_get_implementation_identifier());
 }
 
+Napi::Value ResolveName(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  const rcl_node_options_t* node_options = rcl_node_get_options(node);
+  std::string topic_name = info[1].As<Napi::String>().Utf8Value();
+  bool only_expand = info[2].As<Napi::Boolean>().Value();
+  bool is_service = info[3].As<Napi::Boolean>().Value();
+
+  char* output_cstr = nullptr;
+  rcl_ret_t ret =
+      rcl_node_resolve_name(node, topic_name.c_str(), node_options->allocator,
+                            is_service, only_expand, &output_cstr);
+
+  auto name_deleter = [&]() {
+    node_options->allocator.deallocate(output_cstr,
+                                       node_options->allocator.state);
+  };
+
+  RCPPUTILS_SCOPE_EXIT({ name_deleter(); });
+
+  if (RCL_RET_OK != ret) {
+    Napi::Error::New(env, ("failed to resolve name"))
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  return Napi::String::New(env, output_cstr);
+}
+
 Napi::Object InitNodeBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("getParameterOverrides",
               Napi::Function::New(env, GetParameterOverrides));
@@ -500,6 +531,7 @@ Napi::Object InitNodeBindings(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, GetFullyQualifiedName));
   exports.Set("getRMWImplementationIdentifier",
               Napi::Function::New(env, GetRMWImplementationIdentifier));
+  exports.Set("resolveName", Napi::Function::New(env, ResolveName));
   return exports;
 }
 

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -654,3 +654,36 @@ describe('Node arguments', function () {
     rclnodejs.shutdown();
   });
 });
+
+describe('Test node resolve name', function () {
+  let node = null;
+  before(async function () {
+    await rclnodejs.init();
+    node = rclnodejs.createNode(
+      'topic_resolver',
+      '/my_ns',
+      Context.defaultContext(),
+      NodeOptions.defaultOptions,
+      ['--ros-args', '-r', 'foo:=bar']
+    );
+  });
+
+  after(function () {
+    node.destroy();
+    rclnodejs.shutdown();
+  });
+
+  it('Resolve topic name', function (done) {
+    assert.deepStrictEqual(node.resolveTopicName('foo'), '/my_ns/bar');
+    assert.deepStrictEqual(node.resolveTopicName('/abs'), '/abs');
+    assert.deepStrictEqual(node.resolveTopicName('foo', true), '/my_ns/foo');
+    done();
+  });
+
+  it('Resolve service name', function (done) {
+    assert.deepStrictEqual(node.resolveServiceName('foo'), '/my_ns/bar');
+    assert.deepStrictEqual(node.resolveServiceName('/abs'), '/abs');
+    assert.deepStrictEqual(node.resolveServiceName('foo', true), '/my_ns/foo');
+    done();
+  });
+});

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -91,6 +91,8 @@ const nodeWithArgs = rclnodejs.createNode(
   false
 );
 expectType<rclnodejs.Node>(nodeWithArgs);
+expectType<string>(node.resolveTopicName(TOPIC, true));
+expectType<string>(node.resolveServiceName(SERVICE_NAME, true));
 
 // ---- LifecycleNode ----
 const lifecycleNode = rclnodejs.createLifecycleNode(LIFECYCLE_NODE_NAME);

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -838,5 +838,21 @@ declare module 'rclnodejs' {
      * @returns - The RMW implementation identifier.
      */
     getRMWImplementationIdentifier(): string;
+
+    /**
+     * Return a topic name expanded and remapped.
+     * @param topicName - Topic name to be expanded and remapped.
+     * @param onlyExpand - If `true`, remapping rules won't be applied, default is false.
+     * @returns A fully qualified topic name.
+     */
+    resolveTopicName(topicName: string, onlyExpand?: boolean): string;
+
+    /**
+     * Return a service name expanded and remapped.
+     * @param service - Service name to be expanded and remapped.
+     * @param onlyExpand - If `true`, remapping rules won't be applied, default is false.
+     * @returns A fully qualified service name.
+     */
+    resolveServiceName(service: string, onlyExpand?: boolean): string;
   }
 }


### PR DESCRIPTION
This pull request introduces support for resolving topic and service names with remapping and expansion functionality. Key changes include:

- Addition of new tests in both TypeScript and JavaScript to verify the resolution behavior.
- Implementation of a new C++ binding function (ResolveName) to expose the name resolution logic.
- Updates to the Node class in JavaScript to provide resolveTopicName and resolveServiceName methods.

Fix: #1174