### PR TITLE
Reorg the README structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ rclnodejs.init().then(() => {
 - [API Documentation](#api-documentation)
 - [Using TypeScript](#using-rclnodejs-with-typescript)
 - [ROS2 Interface Message Generation](#ros2-interface-message-generation-important)
-- [IDL Message Generation](#idl-message-generation)
 - [Examples](https://github.com/RobotWebTools/rclnodejs/tree/develop/example)
 - [Electron demo](https://github.com/RobotWebTools/rclnodejs/tree/develop/electron_demo)
 - [Efficient Usage Tips](./docs/EFFICIENCY.md)
@@ -148,18 +147,6 @@ let stringMsgObject = rclnodejs.createMessageObject('std_msgs/msg/String');
 stringMsgObject.data = 'hello world';
 ```
 
-## IDL Message Generation
-
-In addition to the standard ROS2 message generation (`.msg`, `.srv`, and `.action`), rclnodejs provides advanced support for generating JavaScript message files directly from IDL (Interface Definition Language) files. This feature is particularly useful when working with custom IDL files or when you need more control over the message generation process.
-
-### Running `generate-messages-idl`
-
-To generate messages from IDL files, use the `generate-messages-idl` npm script:
-
-```bash
-npm run generate-messages-idl
-```
-
 ### Maintaining Generated JavaScript Message Files
 
 Message files are generated as a post-install step of the rclnodejs
@@ -177,6 +164,18 @@ npx generate-ros-messages
 
 The newly generated JavaScript files can be found at
 `<yourproject>/node_modules/rclnodejs/generated/`.
+
+### IDL Message Generation
+
+In addition to the standard ROS2 message generation (`.msg`, `.srv`, and `.action`), rclnodejs provides advanced support for generating JavaScript message files directly from IDL (Interface Definition Language) files. This feature is particularly useful when working with custom IDL files or when you need more control over the message generation process.
+
+#### Running `generate-messages-idl`
+
+To generate messages from IDL files, use the `generate-messages-idl` npm script:
+
+```bash
+npm run generate-messages-idl
+```
 
 ## Contributing
 


### PR DESCRIPTION
This PR restructures the README by moving the “IDL Message Generation” section to sit below the generated message maintenance instructions and updating its heading levels, while removing the old table-of-contents entry.

- Removed outdated TOC entry and original section block
- Re-added “IDL Message Generation” under “Maintaining Generated JavaScript Message Files” with proper `###`/`####` hierarchy

Fix: #764 