### PR TITLE
Indicate the usage of generating messages from .idl files

### DIFF
--- a/scripts/generate_messages.js
+++ b/scripts/generate_messages.js
@@ -19,9 +19,15 @@
 
 const generator = require('../rosidl_gen/index.js');
 const tsdGenerator = require('../rostsd_gen/index.js');
+const useIDL = !!process.argv.find((arg) => arg === '--idl');
 
 async function main() {
   console.log('Start generation of ROS2 JavaScript messages...');
+  if (!useIDL) {
+    console.log(
+      'See details https://github.com/RobotWebTools/rclnodejs?tab=readme-ov-file#idl-message-generation for generating from .idl files'
+    );
+  }
 
   try {
     await generator.generateAll(true);


### PR DESCRIPTION
This PR adds an informational message to guide users on generating ROS2 JavaScript messages from .idl files. The change introduces a command-line flag detection mechanism and displays a helpful message with documentation link when the `--idl` flag is not used.

- Adds detection for the `--idl` command-line argument
- Displays informational message with documentation link when IDL generation is not being used

Fix: #1185