### PR TITLE
Remove unnecessary files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -26,3 +26,7 @@ tutorials/
 .nyc_output/
 .vscode/
 .husky/
+scripts/cpplint.js
+scripts/npm-pack.sh
+scripts/npmjs-readme.md
+scripts/run_test.js


### PR DESCRIPTION
This PR updates the npm package configuration to exclude unnecessary script files from the published package.
- Adds individual script files under `scripts/` to `.npmignore`.

Fix: #1191