### PR TITLE
Correct the index.js to be required for example/

### DIFF
--- a/example/actions/action_client/action-client-cancel-example.js
+++ b/example/actions/action_client/action-client-cancel-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 const Fibonacci = rclnodejs.require('test_msgs/action/Fibonacci');
 
 class FibonacciActionClient {

--- a/example/actions/action_client/action-client-example.js
+++ b/example/actions/action_client/action-client-example.js
@@ -14,9 +14,8 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 const Fibonacci = rclnodejs.require('test_msgs/action/Fibonacci');
-const GoalStatus = rclnodejs.require('action_msgs/msg/GoalStatus');
 
 class FibonacciActionClient {
   constructor(node) {

--- a/example/actions/action_server/action-server-defer-example.js
+++ b/example/actions/action_server/action-server-defer-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 const Fibonacci = rclnodejs.require('test_msgs/action/Fibonacci');
 
 class FibonacciActionServer {

--- a/example/actions/action_server/action-server-example.js
+++ b/example/actions/action_server/action-server-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 const Fibonacci = rclnodejs.require('test_msgs/action/Fibonacci');
 
 class FibonacciActionServer {

--- a/example/actions/action_server/action-server-single-goal-example.js
+++ b/example/actions/action_server/action-server-single-goal-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 const Fibonacci = rclnodejs.require('test_msgs/action/Fibonacci');
 
 class FibonacciActionServer {

--- a/example/graph/ros-graph-example.js
+++ b/example/graph/ros-graph-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../index.js');
 
 console.log(
   'This example creates the following nodes and outputs the corresponding ROS2 graph:'

--- a/example/lifecycle/lifecycle-node-example.js
+++ b/example/lifecycle/lifecycle-node-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../index.js');
 
 const NODE_NAME = 'test_node';
 const TOPIC = 'test';

--- a/example/parameter/parameter-declaration-example.js
+++ b/example/parameter/parameter-declaration-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../index.js');
 
 const ParameterType = rclnodejs.ParameterType;
 const Parameter = rclnodejs.Parameter;

--- a/example/parameter/parameter-override-example.js
+++ b/example/parameter/parameter-override-example.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../index.js');
 
 const ParameterType = rclnodejs.ParameterType;
 const Parameter = rclnodejs.Parameter;

--- a/example/rate/rate-example.js
+++ b/example/rate/rate-example.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../index.js');
 
 /**
  * This example demonstrates a rate limited loop running at

--- a/example/rosidl/rosidl-parse-action-example.js
+++ b/example/rosidl/rosidl-parse-action-example.js
@@ -12,7 +12,6 @@
 
 'use strict';
 
-s;
 const rosInstallPath = process.env.AMENT_PREFIX_PATH;
 const packageName = 'test_msgs';
 const packagePath = rosInstallPath + '/share/test_msgs/action/Fibonacci.action';

--- a/example/rosidl/rosidl-parse-action-example.js
+++ b/example/rosidl/rosidl-parse-action-example.js
@@ -12,8 +12,7 @@
 
 'use strict';
 
-const parser = require('../rosidl_parser/rosidl_parser.js');
-
+s;
 const rosInstallPath = process.env.AMENT_PREFIX_PATH;
 const packageName = 'test_msgs';
 const packagePath = rosInstallPath + '/share/test_msgs/action/Fibonacci.action';

--- a/example/rosidl/rosidl-parse-msg-example.js
+++ b/example/rosidl/rosidl-parse-msg-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const parser = require('../rosidl_parser/rosidl_parser.js');
+const parser = require('../../rosidl_parser/rosidl_parser.js');
 
 const rosInstallPath = process.env.AMENT_PREFIX_PATH;
 const packageName = 'std_msgs';

--- a/example/rosidl/rosidl-parse-srv-example.js
+++ b/example/rosidl/rosidl-parse-srv-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const parser = require('../rosidl_parser/rosidl_parser.js');
+const parser = require('../../rosidl_parser/rosidl_parser.js');
 
 const rosInstallPath = process.env.AMENT_PREFIX_PATH;
 const packageName = 'std_srvs';

--- a/example/services/client/client-example.js
+++ b/example/services/client/client-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 
 async function main() {
   await rclnodejs.init();

--- a/example/services/service/service-example.js
+++ b/example/services/service/service-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 
 rclnodejs
   .init()

--- a/example/timer/timer-example.js
+++ b/example/timer/timer-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../index.js');
 
 rclnodejs
   .init()

--- a/example/topics/publisher/publisher-content-filter-example.js
+++ b/example/topics/publisher/publisher-content-filter-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 
 async function main() {
   await rclnodejs.init();

--- a/example/topics/publisher/publisher-example.js
+++ b/example/topics/publisher/publisher-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 
 rclnodejs.init().then(() => {
   const node = rclnodejs.createNode('publisher_example_node');

--- a/example/topics/publisher/publisher-message-example.js
+++ b/example/topics/publisher/publisher-message-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 
 rclnodejs
   .init()

--- a/example/topics/publisher/publisher-multiarray-example.js
+++ b/example/topics/publisher/publisher-multiarray-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 
 rclnodejs
   .init()

--- a/example/topics/publisher/publisher-qos-example.js
+++ b/example/topics/publisher/publisher-qos-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 const { QoS } = rclnodejs;
 
 rclnodejs.init().then(() => {

--- a/example/topics/publisher/publisher-raw-message.js
+++ b/example/topics/publisher/publisher-raw-message.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 
 rclnodejs
   .init()

--- a/example/topics/subscriber/subscription-content-filter-example.js
+++ b/example/topics/subscriber/subscription-content-filter-example.js
@@ -14,8 +14,7 @@
 
 'use strict';
 
-const { assertDefined } = require('dtslint/bin/util.js');
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 
 /**
  * This example demonstrates the use of content-filtering

--- a/example/topics/subscriber/subscription-example.js
+++ b/example/topics/subscriber/subscription-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 
 rclnodejs.init().then(() => {
   const node = rclnodejs.createNode('subscription_example_node');

--- a/example/topics/subscriber/subscription-message-example.js
+++ b/example/topics/subscriber/subscription-message-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 
 rclnodejs
   .init()

--- a/example/topics/subscriber/subscription-multiarray-example.js
+++ b/example/topics/subscriber/subscription-multiarray-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 
 rclnodejs
   .init()

--- a/example/topics/subscriber/subscription-qos-example.js
+++ b/example/topics/subscriber/subscription-qos-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 const { QoS } = rclnodejs;
 
 rclnodejs.init().then(() => {

--- a/example/topics/subscriber/subscription-raw-message.js
+++ b/example/topics/subscriber/subscription-raw-message.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 
 rclnodejs.init().then(() => {
   const node = rclnodejs.createNode('subscription_message_example_node');

--- a/example/topics/subscriber/subscription-service-event-example.js
+++ b/example/topics/subscriber/subscription-service-event-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 
 async function main() {
   await rclnodejs.init();

--- a/example/topics/validator/validator-example.js
+++ b/example/topics/validator/validator-example.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const rclnodejs = require('../index.js');
+const rclnodejs = require('../../../index.js');
 const { validator } = rclnodejs;
 
 console.log(


### PR DESCRIPTION
This PR fixes incorrect relative import paths in example files to properly reference the main index.js file. The changes update require statements to use the correct number of directory traversals based on each file's location within the example folder structure.

- Updates require paths from `../index.js` to appropriate relative paths (`../../index.js` or `../../../index.js`)
- Corrects rosidl parser imports to use proper relative paths
- Removes unused imports and fixes a syntax error in one file

Fix: #1202