### PR TITLE
Fix example errors

### DIFF
--- a/example/actions/action_client/action-client-cancel-example.js
+++ b/example/actions/action_client/action-client-cancel-example.js
@@ -57,7 +57,7 @@ class FibonacciActionClient {
   feedbackCallback(feedbackMessage) {
     this._node
       .getLogger()
-      .info(`Received feedback: ${feedbackMessage.feedback.sequence}`);
+      .info(`Received feedback: ${feedbackMessage.sequence}`);
   }
 
   async timerCallback(goalHandle) {

--- a/example/timer/timer-example.js
+++ b/example/timer/timer-example.js
@@ -21,7 +21,7 @@ rclnodejs
   .then(() => {
     let node = rclnodejs.createNode('timer_example_node');
 
-    let timer = node.createTimer(BigInt(1000000), () => {
+    let timer = node.createTimer(BigInt(1000000000), () => {
       console.log('One second escaped!');
 
       console.log('Cancel this timer.');


### PR DESCRIPTION
This PR fixes timing and property access errors in example code. The changes correct a timer interval misconfiguration and fix incorrect property access in action client feedback handling.

- Fixed timer interval from 1 millisecond to 1 second (1 billion nanoseconds)
- Corrected feedback message property access by removing redundant `.feedback` accessor

Fix: #1204