### PR TITLE
Correct exmple errors

### DIFF
--- a/example/actions/action_server/action-server-defer-example.js
+++ b/example/actions/action_server/action-server-defer-example.js
@@ -83,7 +83,7 @@ class FibonacciActionServer {
   handleAcceptedCallback(goalHandle) {
     this._node.getLogger().info('Deferring execution...');
     this._goalHandle = goalHandle;
-    // Set timeout period to 3s.
+    // Set timeout period to 3s (in nanoseconds).
     this._timer = this._node.createTimer(3000000000n, () =>
       this.timerCallback()
     );

--- a/example/actions/action_server/action-server-defer-example.js
+++ b/example/actions/action_server/action-server-defer-example.js
@@ -83,7 +83,8 @@ class FibonacciActionServer {
   handleAcceptedCallback(goalHandle) {
     this._node.getLogger().info('Deferring execution...');
     this._goalHandle = goalHandle;
-    this._timer = this._node.createTimer(BigInt(3000000), () =>
+    // Set timeout period to 3s.
+    this._timer = this._node.createTimer(3000000000n, () =>
       this.timerCallback()
     );
   }

--- a/example/rosidl/rosidl-parse-action-example.js
+++ b/example/rosidl/rosidl-parse-action-example.js
@@ -15,6 +15,7 @@
 const rosInstallPath = process.env.AMENT_PREFIX_PATH;
 const packageName = 'test_msgs';
 const packagePath = rosInstallPath + '/share/test_msgs/action/Fibonacci.action';
+const parser = require('../../rosidl_parser/rosidl_parser.js');
 
 parser
   .parseActionFile(packageName, packagePath)


### PR DESCRIPTION
This PR fixes errors in two example files related to ROSIDL parsing and action server functionality. The changes address missing module imports and improve code clarity with better numeric formatting.

- Adds missing parser module import in the ROSIDL parse action example
- Updates timer interval from BigInt constructor to BigInt literal notation with explanatory comment

Fix: #1207 