### PR TITLE
Correct the parameter type of ActionServer constructor

### DIFF
--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -390,7 +390,8 @@ const actionServer = new rclnodejs.ActionServer(
   node,
   'example_interfaces/action/Fibonacci',
   'fibonacci',
-  executeCallback
+  executeCallback,
+  goalCallback
 );
 expectType<rclnodejs.ActionServer<'example_interfaces/action/Fibonacci'>>(
   actionServer
@@ -402,6 +403,13 @@ expectType<void>(
   actionServer.registerExecuteCallback(() => new Fibonacci.Result())
 );
 expectType<void>(actionServer.destroy());
+
+function goalCallback(
+  goal: rclnodejs.ActionGoal<'example_interfaces/action/Fibonacci'>
+): rclnodejs.GoalResponse {
+  expectType<number>(goal.order);
+  return rclnodejs.GoalResponse.ACCEPT;
+}
 
 function executeCallback(
   goalHandle: rclnodejs.ServerGoalHandle<'example_interfaces/action/Fibonacci'>

--- a/types/action_server.d.ts
+++ b/types/action_server.d.ts
@@ -78,7 +78,7 @@ declare module 'rclnodejs' {
     goalHandle: ServerGoalHandle<T>
   ) => Promise<ActionResult<T>> | ActionResult<T>;
   type GoalCallback<T extends TypeClass<ActionTypeClassName>> = (
-    goalHandle: ServerGoalHandle<T>
+    goal: ActionGoal<T>
   ) => GoalResponse;
   type HandleAcceptedCallback<T extends TypeClass<ActionTypeClassName>> = (
     goalHandle: ServerGoalHandle<T>


### PR DESCRIPTION
This PR corrects the parameter type of the ActionServer constructor by adding a missing `goalCallback` parameter to properly match the expected type signature.

- Added `goalCallback` parameter to ActionServer constructor call
- Implemented the `goalCallback` function with proper type annotations

Fix: #1209