### PR TITLE
Add demo links to README of npm package

### DIFF
--- a/scripts/npmjs-readme.md
+++ b/scripts/npmjs-readme.md
@@ -121,6 +121,8 @@ Send a request in a client
 
 ```
 
+Check out more [examples](https://github.com/RobotWebTools/rclnodejs/tree/develop/example).
+
 ## Using rclnodejs with TypeScript
 
 In your node project install the rclnodejs package as described above. You will also need the TypeScript compiler and node typings installed.
@@ -162,7 +164,13 @@ const msg: rclnodejs.std_msgs.msg.String = {
 };
 ```
 
+Check out more TypeScript [demos](https://github.com/RobotWebTools/rclnodejs/tree/develop/ts_demo).
+
 **Note** that the interface.d.ts file is updated each time the generate_messages.js script is run.
+
+## Using rclnodejs with Electron
+
+Check out [demos](https://github.com/RobotWebTools/rclnodejs/tree/develop/electron_demo).
 
 ## License
 


### PR DESCRIPTION
This PR adds demo links to the npm package README to help users find example code and implementations. The changes provide better guidance for developers looking to use rclnodejs in different contexts.

- Adds links to JavaScript examples after the basic usage section
- Adds links to TypeScript demos in the TypeScript section
- Introduces a new section for Electron usage with demo links

Fix: #1216