### PR TITLE
Add functions to run ros2 run/launch

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ const {
   serializeMessage,
   deserializeMessage,
 } = require('./lib/serialization.js');
+const { spawn } = require('child_process');
 
 /**
  * Get the version of the generator that was used for the currently present interfaces.
@@ -88,6 +89,79 @@ async function getCurrentGeneratorVersion() {
 }
 
 let _rosVersionChecked = false;
+
+/**
+ * Run a ROS2 package executable using 'ros2 run' command.
+ * @param {string} packageName - The name of the ROS2 package.
+ * @param {string} executableName - The name of the executable to run.
+ * @param {string[]} [args=[]] - Additional arguments to pass to the executable.
+ * @return {Promise<{process: ChildProcess}>} A Promise that resolves with the process.
+ */
+function ros2Run(packageName, executableName, args = []) {
+  return new Promise((resolve, reject) => {
+    if (typeof packageName !== 'string' || !packageName.trim()) {
+      reject(new Error('Package name must be a non-empty string'));
+      return;
+    }
+
+    if (typeof executableName !== 'string' || !executableName.trim()) {
+      reject(new Error('Executable name must be a non-empty string'));
+      return;
+    }
+
+    if (!Array.isArray(args)) {
+      reject(new Error('Arguments must be an array'));
+      return;
+    }
+
+    const command = 'ros2';
+    const cmdArgs = ['run', packageName, executableName, ...args];
+    const childProcess = spawn(command, cmdArgs);
+
+    childProcess.on('error', (error) => {
+      reject(new Error(`Failed to start ros2 run: ${error.message}`));
+    });
+
+    resolve({
+      process: childProcess,
+    });
+  });
+}
+
+/**
+ * Run a ROS2 launch file using 'ros2 launch' command.
+ * @param {string} packageName - The name of the ROS2 package.
+ * @param {string} launchFile - The name of the launch file to run.
+ * @param {string[]} [args=[]] - Additional arguments to pass to the launch file.
+ * @return {Promise<{process: ChildProcess}>} A Promise that resolves with the process.
+ */
+function ros2Launch(packageName, launchFile, args = []) {
+  return new Promise((resolve, reject) => {
+    if (typeof packageName !== 'string' || !packageName.trim()) {
+      reject(new Error('Package name must be a non-empty string'));
+      return;
+    }
+    if (typeof launchFile !== 'string' || !launchFile.trim()) {
+      reject(new Error('Launch file name must be a non-empty string'));
+      return;
+    }
+    if (!Array.isArray(args)) {
+      reject(new Error('Arguments must be an array'));
+      return;
+    }
+    const command = 'ros2';
+    const cmdArgs = ['launch', packageName, launchFile, ...args];
+    const childProcess = spawn(command, cmdArgs);
+
+    childProcess.on('error', (error) => {
+      reject(new Error(`Failed to start ros2 launch: ${error.message}`));
+    });
+
+    resolve({
+      process: childProcess,
+    });
+  });
+}
 
 /**
  * A module that exposes the rclnodejs interfaces.
@@ -443,6 +517,28 @@ let rcl = {
   removeSignalHandlers() {
     // this will not throw even if the handler is already removed
     process.removeListener('SIGINT', _sigHandler);
+  },
+
+  /**
+   * Run a ROS2 package executable using 'ros2 run' command.
+   * @param {string} packageName - The name of the ROS2 package.
+   * @param {string} executableName - The name of the executable to run.
+   * @param {string[]} [args=[]] - Additional arguments to pass to the executable.
+   * @return {Promise<{process: ChildProcess}>} A Promise that resolves with the process.
+   */
+  ros2Run(packageName, executableName, args = []) {
+    return ros2Run(packageName, executableName, args);
+  },
+
+  /**
+   * Run a ROS2 launch file using 'ros2 launch' command.
+   * @param {string} packageName - The name of the ROS2 package.
+   * @param {string} launchFile - The name of the launch file to run.
+   * @param {string[]} [args=[]] - Additional arguments to pass to the launch file.
+   * @return {Promise<{process: ChildProcess}>} A Promise that resolves with the process.
+   */
+  ros2Launch(packageName, launchFile, args = []) {
+    return ros2Launch(packageName, launchFile, args);
   },
 };
 

--- a/index.js
+++ b/index.js
@@ -121,9 +121,10 @@ function ros2Run(packageName, executableName, args = []) {
     childProcess.on('error', (error) => {
       reject(new Error(`Failed to start ros2 run: ${error.message}`));
     });
-
-    resolve({
-      process: childProcess,
+    childProcess.on('spawn', () => {
+      resolve({
+        process: childProcess,
+      });
     });
   });
 }
@@ -157,8 +158,10 @@ function ros2Launch(packageName, launchFile, args = []) {
       reject(new Error(`Failed to start ros2 launch: ${error.message}`));
     });
 
-    resolve({
-      process: childProcess,
+    childProcess.on('spawn', () => {
+      resolve({
+        process: childProcess,
+      });
     });
   });
 }
@@ -526,9 +529,7 @@ let rcl = {
    * @param {string[]} [args=[]] - Additional arguments to pass to the executable.
    * @return {Promise<{process: ChildProcess}>} A Promise that resolves with the process.
    */
-  ros2Run(packageName, executableName, args = []) {
-    return ros2Run(packageName, executableName, args);
-  },
+  ros2Run: ros2Run,
 
   /**
    * Run a ROS2 launch file using 'ros2 launch' command.
@@ -537,9 +538,7 @@ let rcl = {
    * @param {string[]} [args=[]] - Additional arguments to pass to the launch file.
    * @return {Promise<{process: ChildProcess}>} A Promise that resolves with the process.
    */
-  ros2Launch(packageName, launchFile, args = []) {
-    return ros2Launch(packageName, launchFile, args);
-  },
+  ros2Launch: ros2Launch,
 };
 
 const _sigHandler = () => {

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -2,6 +2,7 @@
 
 import { expectType, expectAssignable } from 'tsd';
 import * as rclnodejs from 'rclnodejs';
+import { ChildProcess } from 'child_process';
 
 const NODE_NAME = 'test_node';
 const LIFECYCLE_NODE_NAME = 'lifecycle_test_node';
@@ -17,6 +18,12 @@ expectType<string | undefined>(rclnodejs.DistroUtils.getDistroName());
 expectType<boolean>(rclnodejs.isShutdown());
 expectType<void>(rclnodejs.shutdown());
 expectType<void>(rclnodejs.removeSignalHandlers());
+expectType<Promise<{ process: ChildProcess }>>(
+  rclnodejs.ros2Run('package_name', 'executable_name', ['arg1', 'arg2'])
+);
+expectType<Promise<{ process: ChildProcess }>>(
+  rclnodejs.ros2Launch('package_name', 'launch_file', ['arg1', 'arg2'])
+);
 
 // ---- DistroUtil ----
 expectType<rclnodejs.DistroUtils.DistroId>(rclnodejs.DistroUtils.getDistroId());

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,7 @@
 /// <reference path="./base.d.ts" />
 
+import { ChildProcess } from 'child_process';
+
 declare module 'rclnodejs' {
   type Class = new (...args: any[]) => any;
 
@@ -207,4 +209,30 @@ declare module 'rclnodejs' {
    * @returns An Object representing the deserialized message.
    */
   function deserializeMessage(buffer: Buffer, typeClass: Class): object;
+
+  /**
+   * Run a ROS2 package executable using 'ros2 run' command.
+   * @param {string} packageName - The name of the ROS2 package.
+   * @param {string} executableName - The name of the executable to run.
+   * @param {string[]} [args=[]] - Additional arguments to pass to the executable.
+   * @return {Promise<{process: ChildProcess}>} A Promise that resolves with the process.
+   */
+  function ros2Run(
+    packageName: string,
+    executableName: string,
+    args: string[]
+  ): Promise<{ process: ChildProcess }>;
+
+  /**
+   * Run a ROS2 launch file using 'ros2 launch' command.
+   * @param {string} packageName - The name of the ROS2 package.
+   * @param {string} launchFile - The name of the launch file to run.
+   * @param {string[]} [args=[]] - Additional arguments to pass to the launch file.
+   * @return {Promise<{process: ChildProcess}>} A Promise that resolves with the process.
+   */
+  function ros2Launch(
+    packageName: string,
+    launchFile: string,
+    args: string[]
+  ): Promise<{ process: ChildProcess }>;
 }


### PR DESCRIPTION
This PR adds functions to run ROS2 package executables and launch files programmatically from within Node.js applications using the `ros2 run` and `ros2 launch` commands.

- Adds `ros2Run()` function to execute ROS2 package executables with optional arguments
- Adds `ros2Launch()` function to run ROS2 launch files with optional arguments
- Includes comprehensive input validation for both functions

Fix: #1220 