### PR TITLE
Support getting logger name for subscription, publisher, service and client

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -157,6 +157,14 @@ class Client extends Entity {
       introspectionState
     );
   }
+
+  /**
+   * Get the logger name for this client.
+   * @returns {string} The logger name for this client.
+   */
+  get loggerName() {
+    return rclnodejs.getNodeLoggerName(this._nodeHandle);
+  }
 }
 
 module.exports = Client;

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -26,6 +26,7 @@ const Entity = require('./entity.js');
 class Publisher extends Entity {
   constructor(handle, typeClass, topic, options, node, eventCallbacks) {
     super(handle, typeClass, options);
+    this._node = node;
     if (node && eventCallbacks) {
       this._events = eventCallbacks.createEventHandlers(this.handle);
       node._events.push(...this._events);
@@ -125,6 +126,14 @@ class Publisher extends Entity {
    */
   set events(events) {
     this._events = events;
+  }
+
+  /**
+   * Get the logger name for this publisher.
+   * @returns {string} The logger name for this publisher.
+   */
+  get loggerName() {
+    return rclnodejs.getNodeLoggerName(this._node.handle);
   }
 }
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -149,6 +149,14 @@ class Service extends Entity {
   getOptions() {
     return rclnodejs.getOptions(this._handle);
   }
+
+  /**
+   * Get the logger name for this service.
+   * @returns {string} The logger name for this service.
+   */
+  get loggerName() {
+    return rclnodejs.getNodeLoggerName(this._nodeHandle);
+  }
 }
 
 module.exports = Service;

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -42,6 +42,7 @@ class Subscription extends Entity {
     this._topic = topic;
     this._callback = callback;
     this._isRaw = options.isRaw || false;
+    this._node = node;
 
     if (node && eventCallbacks) {
       this._events = eventCallbacks.createEventHandlers(this.handle);
@@ -167,6 +168,14 @@ class Subscription extends Entity {
    */
   set events(events) {
     this._events = events;
+  }
+
+  /**
+   * Get the logger name for this subscription.
+   * @returns {string} The logger name for this subscription.
+   */
+  get loggerName() {
+    return rclnodejs.getNodeLoggerName(this._node.handle);
   }
 }
 

--- a/test/test-publisher.js
+++ b/test/test-publisher.js
@@ -52,6 +52,12 @@ describe('rclnodejs publisher test suite', function () {
     assert.strictEqual(publisher.subscriptionCount, 1);
   });
 
+  it('Test loggerName', function () {
+    const node = rclnodejs.createNode('publisher_node');
+    const publisher = node.createPublisher(String, 'topic');
+    assert.strictEqual(typeof publisher.loggerName, 'string');
+  });
+
   it('Wait for all acked', function () {
     const node = rclnodejs.createNode('publisher_node');
     const String = 'std_msgs/msg/String';

--- a/test/test-publisher.js
+++ b/test/test-publisher.js
@@ -54,6 +54,7 @@ describe('rclnodejs publisher test suite', function () {
 
   it('Test loggerName', function () {
     const node = rclnodejs.createNode('publisher_node');
+    const String = 'std_msgs/msg/String';
     const publisher = node.createPublisher(String, 'topic');
     assert.strictEqual(typeof publisher.loggerName, 'string');
   });

--- a/test/test-service.js
+++ b/test/test-service.js
@@ -93,4 +93,21 @@ describe('Test service class', function () {
     );
     node.destroy();
   });
+
+  it('Test loggerName', function () {
+    const node = rclnodejs.createNode('test_node');
+    const service = node.createService(
+      'example_interfaces/srv/AddTwoInts',
+      'add_two_ints',
+      { qos: rclnodejs.QoS.profileSystemDefault },
+      (request, response) => {
+        let result = response.template;
+        result.sum = request.a + request.b;
+      }
+    );
+    const client = clientNode.createClient(AddTwoInts, 'single_ps_channel2');
+
+    assert.strictEqual(typeof service.loggerName, 'string');
+    assert.strictEqual(typeof client.loggerName, 'string');
+  });
 });

--- a/test/test-service.js
+++ b/test/test-service.js
@@ -105,7 +105,7 @@ describe('Test service class', function () {
         result.sum = request.a + request.b;
       }
     );
-    const client = clientNode.createClient(AddTwoInts, 'single_ps_channel2');
+    const client = node.createClient(AddTwoInts, 'single_ps_channel2');
 
     assert.strictEqual(typeof service.loggerName, 'string');
     assert.strictEqual(typeof client.loggerName, 'string');

--- a/test/test-service.js
+++ b/test/test-service.js
@@ -96,8 +96,9 @@ describe('Test service class', function () {
 
   it('Test loggerName', function () {
     const node = rclnodejs.createNode('test_node');
+    const AddTwoInts = 'example_interfaces/srv/AddTwoInts';
     const service = node.createService(
-      'example_interfaces/srv/AddTwoInts',
+      AddTwoInts,
       'add_two_ints',
       { qos: rclnodejs.QoS.profileSystemDefault },
       (request, response) => {

--- a/test/test-subscription.js
+++ b/test/test-subscription.js
@@ -38,6 +38,7 @@ describe('rclnodejs subscription test suite', function () {
 
   it('Test loggerName', function () {
     const node = rclnodejs.createNode('publisher_node');
+    const String = 'std_msgs/msg/String';
     const subscription = node.createSubscription(String, 'topic', (msg) => {});
     assert.strictEqual(typeof subscription.loggerName, 'string');
   });

--- a/test/test-subscription.js
+++ b/test/test-subscription.js
@@ -35,4 +35,10 @@ describe('rclnodejs subscription test suite', function () {
     const subscription = node.createSubscription(String, 'topic', (msg) => {});
     assert.strictEqual(subscription.publisherCount, 1);
   });
+
+  it('Test loggerName', function () {
+    const node = rclnodejs.createNode('publisher_node');
+    const subscription = node.createSubscription(String, 'topic', (msg) => {});
+    assert.strictEqual(typeof subscription.loggerName, 'string');
+  });
 });

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -163,6 +163,7 @@ expectType<boolean>(publisher.waitForAllAcked(BigInt(1000)));
 node.createPublisher(TYPE_CLASS, TOPIC, publisher.options, (event: object) => {
   const receivedEvent = event;
 });
+expectType<string>(publisher.loggerName);
 
 // ---- LifecyclePublisher ----
 const lifecyclePublisher = lifecycleNode.createLifecyclePublisher(
@@ -221,6 +222,7 @@ expectType<boolean>(subscription.isDestroyed());
 expectType<boolean>(subscription.setContentFilter(contentFilter));
 expectType<boolean>(subscription.clearContentFilter());
 expectType<boolean>(subscription.hasContentFilter());
+expectType<string>(subscription.loggerName);
 
 // ---- Service ----
 const service = node.createService(
@@ -241,6 +243,7 @@ expectType<void>(
 );
 expectType<boolean>(service.isDestroyed());
 expectType<object>(service.getOptions());
+expectType<string>(service.loggerName);
 
 // ---- Client ----
 const client = node.createClient(
@@ -259,6 +262,7 @@ expectType<void>(
   )
 );
 expectType<boolean>(client.isDestroyed());
+expectType<string>(client.loggerName);
 
 // ---- Timer ----
 const timerCallback = () => {};

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -52,6 +52,11 @@ declare module 'rclnodejs' {
       serviceEventPubQOS: QoS,
       introspectionState: ServiceIntrospectionStates
     ): void;
+
+    /**
+     * Get the logger name for this client.
+     */
+    readonly loggerName: string;
   }
 
   namespace Client {

--- a/types/publisher.d.ts
+++ b/types/publisher.d.ts
@@ -37,5 +37,10 @@ declare module 'rclnodejs' {
      * @return {boolean} `true` if all published message data is acknowledged before the timeout, otherwise `false`.
      */
     waitForAllAcked(timeout: bigint): boolean;
+
+    /**
+     * Get the logger name for this publisher.
+     */
+    readonly loggerName: string;
   }
 }

--- a/types/service.d.ts
+++ b/types/service.d.ts
@@ -94,5 +94,10 @@ declare module 'rclnodejs' {
      * @return The options of this service.
      */
     getOptions(): object;
+
+    /**
+     * Get the logger name for this service.
+     */
+    readonly loggerName: string;
   }
 }

--- a/types/subscription.d.ts
+++ b/types/subscription.d.ts
@@ -72,5 +72,10 @@ declare module 'rclnodejs' {
      * @returns The number of publishers
      */
     publisherCount(): number;
+
+    /**
+     * Get the logger name for this subscription.
+     */
+    readonly loggerName: string;
   }
 }


### PR DESCRIPTION
This pull request adds support for getting the logger name for ROS 2 entities (subscription, publisher, service, and client) by exposing a `loggerName` getter property on each entity class.

- Adds `loggerName` getter property to Publisher, Subscription, Service, and Client classes
- Stores node references in Publisher and Subscription constructors to enable logger name access
- Adds comprehensive test coverage for the new `loggerName` property across all entity types

Fix: #1219 