### PR TITLE
Rename actions

### DIFF
--- a/.github/workflows/linux-arm64-pr-test.yml
+++ b/.github/workflows/linux-arm64-pr-test.yml
@@ -1,4 +1,4 @@
-name: Linux ARM64 - Pull Request
+name: Linux arm64 - Pull Request
 
 on:
   pull_request:

--- a/.github/workflows/linux-arm64-push-test.yml
+++ b/.github/workflows/linux-arm64-push-test.yml
@@ -1,4 +1,4 @@
-name: Linux ARM64 - Push to Branches
+name: Linux arm64
 
 on:
   push:

--- a/.github/workflows/linux-x64-push-test.yml
+++ b/.github/workflows/linux-x64-push-test.yml
@@ -1,4 +1,4 @@
-name: Linux x64 - Push to Branches
+name: Linux x64
 
 on:
   push:

--- a/.github/workflows/windows-push-test.yml
+++ b/.github/workflows/windows-push-test.yml
@@ -1,4 +1,4 @@
-name: Windows - Push to Branches
+name: Windows
 
 on:
   push:


### PR DESCRIPTION
This pull request simplifies the naming convention for GitHub Actions workflows by removing verbose descriptive text and standardizing the format. The changes make workflow names more concise while maintaining clear identification of the target platform and trigger type.

- Shortened workflow names by removing "Push to Branches" suffix
- Standardized case formatting for ARM64 architecture (ARM64 → arm64)
- Maintained descriptive suffixes only where necessary (Pull Request workflows)

Fix: #1250 