### PR TITLE
Pump setup-node & checkout

### DIFF
--- a/.github/workflows/linux-arm64-build-and-test.yml
+++ b/.github/workflows/linux-arm64-build-and-test.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
         architecture: ${{ matrix.architecture }}
@@ -53,7 +53,7 @@ jobs:
       run: |
         sudo apt install ros-${{ matrix.ros_distribution }}-test-msgs
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Build and test rclnodejs
       run: |

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -42,7 +42,7 @@ jobs:
             ros_distribution: rolling
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
         architecture: ${{ matrix.architecture }}
@@ -56,7 +56,7 @@ jobs:
       run: |
         sudo apt install ros-${{ matrix.ros_distribution }}-test-msgs
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Build and test rclnodejs
       run: |

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
           - rolling
     steps:
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -41,7 +41,7 @@ jobs:
     - name: Prebuild - Setup VS Dev Environment
       uses: seanmiddleditch/gha-setup-vsdevenv@v4
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Build rclnodejs
       shell: cmd


### PR DESCRIPTION
This PR updates GitHub Actions dependencies by bumping both the setup-node and checkout actions from v4 to v5 across all CI workflow files.

- Updates `actions/setup-node` from v4 to v5
- Updates `actions/checkout` from v4 to v5

Fix: #1255