### PR TITLE
Update author email

### DIFF
--- a/benchmark/rclcpp/package.xml
+++ b/benchmark/rclcpp/package.xml
@@ -4,7 +4,7 @@
   <name>rclcpp_benchmark</name>
   <version>0.0.1</version>
   <description>Benchmark for rclcpp</description>
-  <maintainer email="minggang.wang@intel.com">Minggang Wang</maintainer>
+  <maintainer email="minggangw@gmail.com">Minggang Wang</maintainer>
   <license>Apache License 2.0</license>
   
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "generate-ros-messages": "./scripts/generate_messages.js"
   },
   "authors": [
-    "Minggang Wang <minggang.wang@intel.com>",
+    "Minggang Wang <minggangw@gmail.com>",
     "Kenny Yuan <kaining.yuan@intel.com>",
     "Wanming Lin <wanming.lin@intel.com>",
     "Zhong Qiu <zhongx.qiu@intel.com>"

--- a/rosidl_gen/generator.json
+++ b/rosidl_gen/generator.json
@@ -4,7 +4,7 @@
   "description": "Generate JavaScript object from ROS IDL(.msg/.srv/.action/.idl) files",
   "main": "index.js",
   "authors": [
-    "Minggang Wang <minggang.wang@intel.com>",
+    "Minggang Wang <minggangw@gmail.com>",
     "Kenny Yuan <kaining.yuan@intel.com>"
   ],
   "license": "Apache-2.0"


### PR DESCRIPTION
This PR updates the author email address for Minggang Wang from their Intel corporate email to a personal Gmail address across multiple configuration files.

- Updates author email from minggang.wang@intel.com to minggangw@gmail.com
- Maintains consistency across all project configuration files
- Updates both author listings and maintainer information

Fix: #1279