### PR TITLE
Update README for topics demo

### DIFF
--- a/electron_demo/topics/README.md
+++ b/electron_demo/topics/README.md
@@ -1,57 +1,79 @@
-# Rclnodejs Electron demo
+# Topics Demo - Electron and rclnodejs
 
-## Introduction
+A minimal Electron application demonstrating basic ROS2 topic communication using rclnodejs. This demo provides a simple interface for publishing and subscribing to string messages, making it the perfect starting point for learning rclnodejs with Electron.
 
-This is a minimal rclnodejs demo using Electron. More information about Electron, please check with [Electron documentation](https://electronjs.org/docs/latest/tutorial/quick-start).
+![Demo Screenshot](./electron-demo.gif)
 
-The demo includes the following files:
+## 📨 Features
 
-- `package.json` - Points to the app's main file and lists its details and dependencies.
-- `main.js` - Introduces the `rclnodejs` native module, starts the app and creates a browser window to render HTML. This is the app's **main process**.
-- `index.html` - Includes a text editor where you can input the the topic to be published. This is the app's **renderer process**.
-- `renderer.js` - Communicate with main process to publish a topic and get it through a subscription.
+- **Simple Publisher**: Text input interface for publishing string messages
+- **Real-time Subscriber**: Live display of received messages
+- **Message Counter**: Tracks published and received message counts
+- **Clean UI**: Minimal, user-friendly interface
+- **Educational**: Perfect introduction to ROS2 topics with Electron
 
-## To run the demo
+### ROS2 Integration
 
-Before starting, please ensure you have installed [nodejs](https://nodejs.org/en).
+- **Topic**: `ts_demo` (std_msgs/String)
+- **Publisher**: Sends user-input text messages
+- **Subscriber**: Receives and displays messages in real-time
+- **Node Name**: `electron_demo_node`
 
-1. Clone this repository.
+## 📋 Prerequisites
+
+- **Node.js** (>= 16.13.0) - JavaScript runtime
+- **ROS 2** (Humble, Jazzy, or newer) - Robot Operating System 2
+- **rclnodejs compatible environment** - Linux recommended (tested on Ubuntu/WSL)
+
+## 🛠️ Installation
+
+1. **Navigate to the demo directory**:
+
+   ```bash
+   cd rclnodejs/electron_demo/topics
+   ```
+
+2. **Source your ROS 2 environment**:
+
+   ```bash
+   source /opt/ros/jazzy/setup.bash  # or your ROS 2 distro
+   ```
+
+3. **Install dependencies**:
+
+   ```bash
+   npm install
+   ```
+
+4. **Rebuild rclnodejs for Electron**:
+   ```bash
+   ./node_modules/.bin/electron-rebuild
+   ```
+
+## 🚀 Running the Demo
+
+Start the application:
 
 ```bash
-git clone https://github.com/RobotWebTools/rclnodejs.git
-```
-
-2. Go into the demo.
-
-```bash
-cd rclnodejs/electron_demo
-```
-
-3. [SOURCE THE ROS 2 SETUP FILE](https://docs.ros.org/en/jazzy/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#source-the-setup-files)
-
-4. Install dependencies
-
-```bash
-npm install
-```
-
-5. Rebuild rclnodejs for Electron
-
-```bash
-# Every time you run "npm install", run this:
-./node_modules/.bin/electron-rebuild
-```
-
-6. Run the app
-
-```
 npm start
 ```
 
-If it works, you can see the demo as:
-![demo screenshot](./electron-demo.gif)
+The demo window will open with:
 
-## Resources for Learning Electron
+- **Text input field** for typing messages to publish
+- **Send button** to publish messages to the `ts_demo` topic
+- **Message display area** showing received messages
+- **Counters** for published and received messages
 
-- [electronjs.org/docs](https://electronjs.org/docs) - all of Electron's documentation.
-- [Native Node Modules](https://www.electronjs.org/docs/latest/tutorial/using-native-node-modules) - Use a native node module.
+## 📁 Project Structure
+
+- **`package.json`** - Project configuration and dependencies
+- **`main.js`** - Electron main process with rclnodejs integration
+- **`index.html`** - Application interface and layout
+- **`renderer.js`** - Renderer process handling UI interactions and ROS2 communication
+
+## 🔗 Related Resources
+
+- [Electron Documentation](https://electronjs.org/docs) - Complete Electron framework guide
+- [Native Node Modules](https://www.electronjs.org/docs/latest/tutorial/using-native-node-modules) - Using native modules with Electron
+- [rclnodejs Documentation](../../README.md) - Core rclnodejs API reference

--- a/electron_demo/topics/package.json
+++ b/electron_demo/topics/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "Apache",
   "dependencies": {
-    "rclnodejs": "^0.27.4"
+    "rclnodejs": "^1.5.1"
   },
   "devDependencies": {
     "@electron/rebuild": "^3.6.0",


### PR DESCRIPTION
This PR updates the documentation and dependencies for the Electron topics demo. It modernizes the README with better formatting, clearer structure, and enhanced user guidance while updating the rclnodejs dependency to a newer version.

- Updated rclnodejs dependency from version 0.27.4 to 1.5.1
- Completely rewrote README with improved structure, emoji icons, and comprehensive setup instructions
- Enhanced documentation with features overview, prerequisites, and project structure sections

Fix: #1281 