### PR TITLE
Remove terser as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "rebuild:dev": "npm run clean && node-gyp -j 16 rebuild --debug",
     "generate-messages": "node scripts/generate_messages.js",
     "generate-messages-idl": "node scripts/generate_messages.js --idl",
-    "generate-messages:dev": "node scripts/generate_messages.js --debug && npx --yes prettier --ignore-path --write generated/**/*.js",
+    "generate-messages:dev": "node scripts/generate_messages.js --debug",
     "generate-tsd-messages": "node scripts/generate_tsd.js",
     "clean": "node-gyp clean && npx rimraf ./generated",
     "install": "node scripts/install.js",
@@ -83,7 +83,6 @@
     "is-close": "^1.3.3",
     "json-bigint": "^1.0.0",
     "node-addon-api": "^8.3.1",
-    "terser": "^5.39.0",
     "walk": "^2.3.15"
   },
   "husky": {

--- a/rosidl_gen/idl_generator.js
+++ b/rosidl_gen/idl_generator.js
@@ -15,7 +15,6 @@
 'use strict';
 
 const dot = require('dot');
-const { minify } = require('terser');
 const fse = require('fs-extra');
 const path = require('path');
 const parser = require('../rosidl_parser/rosidl_parser.js');
@@ -37,18 +36,8 @@ const dots = dot.process({
  * @param {string} code
  */
 async function writeGeneratedCode(dir, fileName, code) {
-  let result = null;
-  if (!isDebug && fileName.endsWith('.js')) {
-    try {
-      result = await minify(code);
-    } catch (error) {
-      console.error(`Error minifying ${fileName}:`, error);
-      result = null;
-    }
-  }
-
   await fse.mkdirs(dir);
-  await fse.writeFile(path.join(dir, fileName), result ? result.code : code);
+  await fse.writeFile(path.join(dir, fileName), code.replace(/^\s*\n/gm, ''));
 }
 
 async function generateServiceJSStruct(

--- a/rosidl_gen/templates/message.dot
+++ b/rosidl_gen/templates/message.dot
@@ -6,221 +6,220 @@
 'use strict';
 
 {{
-let objectWrapper = it.spec.msgName + 'Wrapper';
-let arrayWrapper = it.spec.msgName + 'ArrayWrapper';
+  let objectWrapper = it.spec.msgName + 'Wrapper';
+  let arrayWrapper = it.spec.msgName + 'ArrayWrapper';
+  let refObjectType = it.spec.msgName + 'RefStruct';
+  let refObjectArrayType = it.spec.msgName + 'RefStructArray';
+  let refArrayType = it.spec.msgName + 'RefArray';
+  const compactMsgDefJSON = JSON.stringify(JSON.parse(it.json));
 
-let refObjectType = it.spec.msgName + 'RefStruct';
-let refObjectArrayType = it.spec.msgName + 'RefStructArray';
-let refArrayType = it.spec.msgName + 'RefArray';
-const compactMsgDefJSON = JSON.stringify(JSON.parse(it.json));
-
-if (it.spec.fields.length === 0) {
-  it.spec.isEmpty = true;
-  /* Following rosidl_generator_c style, put a bool member named '_dummy' */
-  it.spec.fields.push({
-    "type": {
-      "isArray": false,
-      "pkgName": null,
-      "type": "bool",
-      "isDynamicArray": false,
-      "stringUpperBound": null,
-      "isUpperBound": false,
-      "isPrimitiveType": true,
-      "isFixedSizeArray": false,
-      "arraySize": null
-    },
-    "name": "_dummy"
-  });
-}
-
-function getPrimitiveNameByType(type) {
-  if (type.type === 'bool') {
-    return 'Bool';
-  } else if (type.type === 'int8') {
-    return 'Int8';
-  } else if (type.type === 'uint8') {
-    return 'UInt8';
-  } else if (type.type === 'int16') {
-    return 'Int16';
-  } else if (type.type === 'uint16') {
-    return 'UInt16';
-  } else if (type.type === 'int32') {
-    return 'Int32';
-  } else if (type.type === 'uint32') {
-    return 'UInt32';
-  } else if (type.type === 'int64') {
-    return 'Int64';
-  } else if (type.type === 'uint64') {
-    return 'UInt64';
-  } else if (type.type === 'float64') {
-    return 'Float64';
-  } else if (type.type === 'float32') {
-    return 'Float32';
-  } else if (type.type === 'char') {
-    return 'Char';
-  } else if (type.type === 'byte') {
-    return 'Byte';
-  } else if (type.type === 'string' || type.type === 'wstring') {
-    return 'String';
-  } else {
-    return '';
-  }
-}
-
-function getTypedArrayName(type) {
-  const t = type.type.toLowerCase();
-  let typedArrayName = null;
-
-  switch (t) {
-    case 'byte':
-    case 'octet':
-    case 'uint8':
-      typedArrayName = 'Uint8Array';
-      break;
-    case 'char':
-    case 'int8':
-      typedArrayName = 'Int8Array';
-      break;
-    case 'int16':
-    case 'short':
-      typedArrayName = 'Int16Array';
-      break;
-    case 'uint16':
-    case 'unsigned short':
-      typedArrayName = 'Uint16Array';
-      break;
-    case 'int32':
-    case 'long':
-      typedArrayName = 'Int32Array';
-      break;
-    case 'uint32':
-    case 'unsigned long':
-      typedArrayName = 'Uint32Array';
-      break;
-    case 'float':
-    case 'float32':
-      typedArrayName = 'Float32Array';
-      break;
-    case 'double':
-    case 'float64':
-      typedArrayName = 'Float64Array';
-      break;
-    default:
-      typedArrayName = '';
-  }
-  return typedArrayName;
-}
-
-function getTypedArrayElementName(type) {
-  const t = type.type.toLowerCase();
-  if (t === 'int8') {
-    return 'int8';
-  } else if (t === 'uint8') {
-    return 'uint8';
-  } else if (t === 'int16') {
-    return 'int16';
-  } else if (t === 'uint16') {
-    return 'uint16';
-  } else if (t === 'int32') {
-    return 'int32';
-  } else if (t === 'uint32') {
-    return 'uint32';
-  } else if (t === 'float64') {
-    return 'double';
-  } else if (t === 'float32') {
-    return 'float';
-  } else if (t === 'char') {
-    return 'int8';
-  } else if (t === 'byte') {
-    return 'uint8';
-  } else {
-    return '';
-  }
-}
-
-const primitiveBaseType = ['Bool', 'Int8', 'UInt8', 'Int16', 'UInt16', 'Int32', 'UInt32',
-                           'Int64', 'UInt64', 'Float64', 'Float32', 'Char', 'Byte', 'String'];
-const typedArrayType = ['int8', 'uint8', 'int16', 'uint16', 'int32', 'uint32',
-                        'float64', 'float32', 'char', 'byte'];
-
-let existedModules = [];
-
-function isExisted(requiredModule) {
-  return existedModules.indexOf(requiredModule) !== -1;
-}
-
-function isPrimitivePackage(baseType) {
-  return primitiveBaseType.indexOf(baseType.type) !== -1;
-}
-
-function isTypedArrayType(type) {
-  return typedArrayType.indexOf(type.type.toLowerCase()) !== -1;
-}
-
-function isBigInt(type) {
-  return ['int64', 'uint64'].indexOf(type.type.toLowerCase()) !== -1;
-}
-
-const willUseTypedArray = isTypedArrayType(it.spec.baseType);
-const currentTypedArray = getTypedArrayName(it.spec.baseType);
-const currentTypedArrayElementType = getTypedArrayElementName(it.spec.baseType);
-
-function shouldRequire(baseType, fieldType) {
-  let requiredModule = '{{=getPackageNameByType(fieldType)}}/{{=getModulePathByType(fieldType)}}';
-  let shouldRequire = !isPrimitivePackage(baseType) && (fieldType.isArray || !fieldType.isPrimitiveType || fieldType.type === 'string');
-
-  if (shouldRequire && !isExisted(requiredModule)) {
-    existedModules.push(requiredModule);
-    return true;
-  } else {
-    return false;
-  }
-}
-
-function getWrapperNameByType(type) {
-  if (type.isPrimitiveType) {
-    return getPrimitiveNameByType(type) + 'Wrapper';
-  } else {
-    return type.type + 'Wrapper';
-  }
-}
-
-function getModulePathByType(type, messageInfo) {
-  if (type.isPrimitiveType) {
-    return 'std_msgs__msg__' + getPrimitiveNameByType(type) + '.js';
+  if (it.spec.fields.length === 0) {
+    it.spec.isEmpty = true;
+    /* Following rosidl_generator_c style, put a bool member named '_dummy' */
+    it.spec.fields.push({
+      "type": {
+        "isArray": false,
+        "pkgName": null,
+        "type": "bool",
+        "isDynamicArray": false,
+        "stringUpperBound": null,
+        "isUpperBound": false,
+        "isPrimitiveType": true,
+        "isFixedSizeArray": false,
+        "arraySize": null
+      },
+      "name": "_dummy"
+    });
   }
 
-  if (
-    messageInfo &&
-    messageInfo.subFolder === 'action' &&
-    messageInfo.pkgName === type.pkgName &&
-    (type.type.endsWith('_Goal') || type.type.endsWith('_Result') || type.type.endsWith('_Feedback'))
-  ) {
-    return type.pkgName + '__action__' + type.type + '.js';
+  function getPrimitiveNameByType(type) {
+    if (type.type === 'bool') {
+      return 'Bool';
+    } else if (type.type === 'int8') {
+      return 'Int8';
+    } else if (type.type === 'uint8') {
+      return 'UInt8';
+    } else if (type.type === 'int16') {
+      return 'Int16';
+    } else if (type.type === 'uint16') {
+      return 'UInt16';
+    } else if (type.type === 'int32') {
+      return 'Int32';
+    } else if (type.type === 'uint32') {
+      return 'UInt32';
+    } else if (type.type === 'int64') {
+      return 'Int64';
+    } else if (type.type === 'uint64') {
+      return 'UInt64';
+    } else if (type.type === 'float64') {
+      return 'Float64';
+    } else if (type.type === 'float32') {
+      return 'Float32';
+    } else if (type.type === 'char') {
+      return 'Char';
+    } else if (type.type === 'byte') {
+      return 'Byte';
+    } else if (type.type === 'string' || type.type === 'wstring') {
+      return 'String';
+    } else {
+      return '';
+    }
   }
 
-  /* We should use '__msg__' to require "service_msgs/msg/ServiceEventInfo.msg" for service event message. */
-  if (messageInfo && messageInfo.isServiceEvent && (type.type !== 'ServiceEventInfo')) {
-    return type.pkgName + `__${it.spec.subFolder}__` + type.type + '.js';
-  }
-  return type.pkgName + '__msg__' + type.type + '.js';
-}
+  function getTypedArrayName(type) {
+    const t = type.type.toLowerCase();
+    let typedArrayName = null;
 
-function getPackageNameByType(type) {
-  if (type.isPrimitiveType) {
-    return 'std_msgs';
-  } else {
-    return type.pkgName;
+    switch (t) {
+      case 'byte':
+      case 'octet':
+      case 'uint8':
+        typedArrayName = 'Uint8Array';
+        break;
+      case 'char':
+      case 'int8':
+        typedArrayName = 'Int8Array';
+        break;
+      case 'int16':
+      case 'short':
+        typedArrayName = 'Int16Array';
+        break;
+      case 'uint16':
+      case 'unsigned short':
+        typedArrayName = 'Uint16Array';
+        break;
+      case 'int32':
+      case 'long':
+        typedArrayName = 'Int32Array';
+        break;
+      case 'uint32':
+      case 'unsigned long':
+        typedArrayName = 'Uint32Array';
+        break;
+      case 'float':
+      case 'float32':
+        typedArrayName = 'Float32Array';
+        break;
+      case 'double':
+      case 'float64':
+        typedArrayName = 'Float64Array';
+        break;
+      default:
+        typedArrayName = '';
+    }
+    return typedArrayName;
   }
-}
 
-function extractMemberNames(fields) {
-  let memberNames = [];
-  fields.forEach(field => {
-    memberNames.push(field.name);
-  });
-  return JSON.stringify(memberNames);
-}
+  function getTypedArrayElementName(type) {
+    const t = type.type.toLowerCase();
+    if (t === 'int8') {
+      return 'int8';
+    } else if (t === 'uint8') {
+      return 'uint8';
+    } else if (t === 'int16') {
+      return 'int16';
+    } else if (t === 'uint16') {
+      return 'uint16';
+    } else if (t === 'int32') {
+      return 'int32';
+    } else if (t === 'uint32') {
+      return 'uint32';
+    } else if (t === 'float64') {
+      return 'double';
+    } else if (t === 'float32') {
+      return 'float';
+    } else if (t === 'char') {
+      return 'int8';
+    } else if (t === 'byte') {
+      return 'uint8';
+    } else {
+      return '';
+    }
+  }
+
+  const primitiveBaseType = ['Bool', 'Int8', 'UInt8', 'Int16', 'UInt16', 'Int32', 'UInt32',
+                             'Int64', 'UInt64', 'Float64', 'Float32', 'Char', 'Byte', 'String'];
+  const typedArrayType = ['int8', 'uint8', 'int16', 'uint16', 'int32', 'uint32',
+                          'float64', 'float32', 'char', 'byte'];
+
+  let existedModules = [];
+
+  function isExisted(requiredModule) {
+    return existedModules.indexOf(requiredModule) !== -1;
+  }
+
+  function isPrimitivePackage(baseType) {
+    return primitiveBaseType.indexOf(baseType.type) !== -1;
+  }
+
+  function isTypedArrayType(type) {
+    return typedArrayType.indexOf(type.type.toLowerCase()) !== -1;
+  }
+
+  function isBigInt(type) {
+    return ['int64', 'uint64'].indexOf(type.type.toLowerCase()) !== -1;
+  }
+
+  const willUseTypedArray = isTypedArrayType(it.spec.baseType);
+  const currentTypedArray = getTypedArrayName(it.spec.baseType);
+  const currentTypedArrayElementType = getTypedArrayElementName(it.spec.baseType);
+
+  function shouldRequire(baseType, fieldType) {
+    let requiredModule = '{{=getPackageNameByType(fieldType)}}/{{=getModulePathByType(fieldType)}}';
+    let shouldRequire = !isPrimitivePackage(baseType) && (fieldType.isArray || !fieldType.isPrimitiveType || fieldType.type === 'string');
+
+    if (shouldRequire && !isExisted(requiredModule)) {
+      existedModules.push(requiredModule);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  function getWrapperNameByType(type) {
+    if (type.isPrimitiveType) {
+      return getPrimitiveNameByType(type) + 'Wrapper';
+    } else {
+      return type.type + 'Wrapper';
+    }
+  }
+
+  function getModulePathByType(type, messageInfo) {
+    if (type.isPrimitiveType) {
+      return 'std_msgs__msg__' + getPrimitiveNameByType(type) + '.js';
+    }
+
+    if (
+      messageInfo &&
+      messageInfo.subFolder === 'action' &&
+      messageInfo.pkgName === type.pkgName &&
+      (type.type.endsWith('_Goal') || type.type.endsWith('_Result') || type.type.endsWith('_Feedback'))
+    ) {
+      return type.pkgName + '__action__' + type.type + '.js';
+    }
+
+    /* We should use '__msg__' to require "service_msgs/msg/ServiceEventInfo.msg" for service event message. */
+    if (messageInfo && messageInfo.isServiceEvent && (type.type !== 'ServiceEventInfo')) {
+      return type.pkgName + `__${it.spec.subFolder}__` + type.type + '.js';
+    }
+    return type.pkgName + '__msg__' + type.type + '.js';
+  }
+
+  function getPackageNameByType(type) {
+    if (type.isPrimitiveType) {
+      return 'std_msgs';
+    } else {
+      return type.pkgName;
+    }
+  }
+
+  function extractMemberNames(fields) {
+    let memberNames = [];
+    fields.forEach(field => {
+      memberNames.push(field.name);
+    });
+    return JSON.stringify(memberNames);
+  }
 }}
 
 {{? willUseTypedArray}}


### PR DESCRIPTION
This PR removes the terser dependency from the project, eliminating JavaScript minification capabilities and replacing them with a simpler whitespace cleanup approach.

- Removed terser dependency and import
- Replaced minification logic with regex-based empty line removal
- Updated development script to remove prettier formatting step

Fix: #1293