### PR TITLE
Remove is-close dependency

### DIFF
--- a/lib/parameter.js
+++ b/lib/parameter.js
@@ -19,7 +19,7 @@
 
 'use strict';
 
-const IsClose = require('is-close');
+const { isClose } = require('./utils.js');
 
 /**
  * The plus/minus tolerance for determining number equivalence.
@@ -623,8 +623,8 @@ class FloatingPointRange extends Range {
     const max = Math.max(this.fromValue, this.toValue);
 
     if (
-      IsClose.isClose(value, min, this.tolerance) ||
-      IsClose.isClose(value, max, this.tolerance)
+      isClose(value, min, this.tolerance) ||
+      isClose(value, max, this.tolerance)
     ) {
       return true;
     }
@@ -633,13 +633,7 @@ class FloatingPointRange extends Range {
     }
     if (this.step != 0.0) {
       const distanceInSteps = Math.round((value - min) / this.step);
-      if (
-        !IsClose.isClose(
-          min + distanceInSteps * this.step,
-          value,
-          this.tolerance
-        )
-      ) {
+      if (!isClose(min + distanceInSteps * this.step, value, this.tolerance)) {
         return false;
       }
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -41,6 +41,10 @@ function detectUbuntuCodename() {
  * The comparison uses the formula:
  *   abs(a - b) <= max(rtol * max(abs(a), abs(b)), atol)
  *
+ * Implementation checks:
+ *   1. Absolute tolerance: abs(a - b) <= atol
+ *   2. Relative tolerance: abs(a - b) / max(abs(a), abs(b)) <= rtol
+ *
  * @param {number} a - The first number to compare
  * @param {number} b - The second number to compare
  * @param {number} [rtol=1e-9] - The relative tolerance parameter (default: 1e-9)
@@ -48,9 +52,10 @@ function detectUbuntuCodename() {
  * @returns {boolean} True if the numbers are close within the tolerance
  *
  * @example
- * isClose(1.0, 1.0) // true
- * isClose(1.0, 1.1, 0.01) // false - difference 0.1 > 0.01 * max(1.0, 1.1) = 0.011
- * isClose(10, 10.00001, 1e-6) // true - difference 0.00001 <= 1e-6 * 10 = 0.00001
+ * isClose(1.0, 1.0) // true - exact equality
+ * isClose(1.0, 1.1, 0.01) // false - relative diff: 0.1/1.1 ≈ 0.091 > 0.01
+ * isClose(10, 10.00001, 1e-6) // true - relative diff: 0.00001/10 = 1e-6 <= 1e-6
+ * isClose(0, 0.05, 0, 0.1) // true - absolute diff: 0.05 <= 0.1 (atol)
  */
 function isClose(a, b, rtol = 1e-9, atol = 0.0) {
   // Handle exact equality
@@ -72,6 +77,12 @@ function isClose(a, b, rtol = 1e-9, atol = 0.0) {
 
   // Check relative tolerance
   const relativeScaler = Math.max(Math.abs(a), Math.abs(b));
+
+  // Handle division by zero when both values are zero or very close to zero
+  if (relativeScaler === 0) {
+    return true; // Both are zero, already handled by absolute tolerance
+  }
+
   const relativeDiff = absDiff / relativeScaler;
 
   return rtol >= relativeDiff;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,6 +32,51 @@ function detectUbuntuCodename() {
   }
 }
 
+/**
+ * Check if two numbers are equal within a given tolerance.
+ *
+ * This function compares two numbers using both relative and absolute tolerance,
+ * matching the behavior of the 'is-close' npm package.
+ *
+ * The comparison uses the formula:
+ *   abs(a - b) <= max(rtol * max(abs(a), abs(b)), atol)
+ *
+ * @param {number} a - The first number to compare
+ * @param {number} b - The second number to compare
+ * @param {number} [rtol=1e-9] - The relative tolerance parameter (default: 1e-9)
+ * @param {number} [atol=0.0] - The absolute tolerance parameter (default: 0.0)
+ * @returns {boolean} True if the numbers are close within the tolerance
+ *
+ * @example
+ * isClose(1.0, 1.0) // true
+ * isClose(1.0, 1.1, 0.01) // false - difference 0.1 > 0.01 * max(1.0, 1.1) = 0.011
+ * isClose(10, 10.00001, 1e-6) // true - difference 0.00001 <= 1e-6 * 10 = 0.00001
+ */
+function isClose(a, b, rtol = 1e-9, atol = 0.0) {
+  // Handle exact equality
+  if (a === b) {
+    return true;
+  }
+
+  // Handle non-finite numbers
+  if (!Number.isFinite(a) || !Number.isFinite(b)) {
+    return false;
+  }
+
+  const absDiff = Math.abs(a - b);
+
+  // Check absolute tolerance first (optimization)
+  if (atol >= absDiff) {
+    return true;
+  }
+
+  // Check relative tolerance
+  const relativeScaler = Math.max(Math.abs(a), Math.abs(b));
+  const relativeDiff = absDiff / relativeScaler;
+
+  return rtol >= relativeDiff;
+}
 module.exports = {
   detectUbuntuCodename,
+  isClose,
 };

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "debug": "^4.4.0",
     "dot": "^1.1.3",
     "fs-extra": "^11.2.0",
-    "is-close": "^1.3.3",
     "json-bigint": "^1.0.0",
     "node-addon-api": "^8.3.1",
     "walk": "^2.3.15"

--- a/test/test-node-oo.js
+++ b/test/test-node-oo.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const IsClose = require('is-close');
+const { isClose } = require('../lib/utils.js');
 const assert = require('assert');
 const rclnodejs = require('../index.js');
 const assertUtils = require('./utils.js');
@@ -374,7 +374,7 @@ describe('rcl node methods testing', function () {
 
     const seconds = Number(time.secondsAndNanoseconds.seconds);
     const dateSeconds = Date.now() / 1000;
-    assert.ok(IsClose.isClose(seconds, dateSeconds, 1));
+    assert.ok(isClose(seconds, dateSeconds, 1));
   });
 
   it('node.getNodeNames', function () {

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const IsClose = require('is-close');
+const { isClose } = require('../lib/utils.js');
 const assert = require('assert');
 const rclnodejs = require('../index.js');
 const assertUtils = require('./utils.js');
@@ -387,7 +387,7 @@ describe('rcl node methods testing', function () {
 
     const seconds = Number(time.secondsAndNanoseconds.seconds);
     const dateSeconds = Date.now() / 1000;
-    assert.ok(IsClose.isClose(seconds, dateSeconds, 1));
+    assert.ok(isClose(seconds, dateSeconds, 1));
   });
 
   it('node.getNodeNames', function () {

--- a/test/test-parameters.js
+++ b/test/test-parameters.js
@@ -17,7 +17,7 @@
 const assert = require('assert');
 const assertUtils = require('./utils.js');
 const assertThrowsError = assertUtils.assertThrowsError;
-const IsClose = require('is-close');
+const { isClose } = require('../lib/utils.js');
 const rclnodejs = require('../index.js');
 const loader = require('../lib/interface_loader.js');
 
@@ -276,9 +276,9 @@ describe('rclnodejs parameters test suite', function () {
 
   describe('range tests', function () {
     it('Math IsClose test', function () {
-      assert.ok(IsClose.isClose(1.0, 1.0, DEFAULT_NUMERIC_RANGE_TOLERANCE));
-      assert.ok(!IsClose.isClose(1.0, 1.1, DEFAULT_NUMERIC_RANGE_TOLERANCE));
-      assert.ok(IsClose.isClose(1.0, 1.1, 0.11));
+      assert.ok(isClose(1.0, 1.0, DEFAULT_NUMERIC_RANGE_TOLERANCE));
+      assert.ok(!isClose(1.0, 1.1, DEFAULT_NUMERIC_RANGE_TOLERANCE));
+      assert.ok(isClose(1.0, 1.1, 0.11));
     });
 
     it('IntegerRange test', function () {


### PR DESCRIPTION
This PR removes the external `is-close` dependency and replaces it with a custom implementation in the project's utility module. The change eliminates a third-party dependency while maintaining the same floating-point comparison functionality.

Key changes:
- Implemented a custom `isClose` function in `lib/utils.js` that matches the behavior of the `is-close` npm package
- Updated all imports across test files and production code to use the new internal implementation
- Removed the `is-close` dependency from `package.json`

Fix: #1294 