### PR TITLE
Remove fs-extra dependency

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,6 +13,156 @@
 // limitations under the License.
 
 const fs = require('fs');
+const fsPromises = require('fs/promises');
+const path = require('path');
+
+/**
+ * Ensure directory exists, create recursively if needed (async)
+ * Replaces: fse.ensureDir() / fse.mkdirs()
+ * @param {string} dirPath - Path to directory
+ * @returns {Promise<void>}
+ */
+async function ensureDir(dirPath) {
+  try {
+    await fsPromises.mkdir(dirPath, { recursive: true });
+  } catch (err) {
+    // Ignore if directory already exists
+    if (err.code !== 'EEXIST') throw err;
+  }
+}
+
+/**
+ * Ensure directory exists, create recursively if needed (sync)
+ * Replaces: fse.mkdirSync()
+ * @param {string} dirPath - Path to directory
+ */
+function ensureDirSync(dirPath) {
+  try {
+    fs.mkdirSync(dirPath, { recursive: true });
+  } catch (err) {
+    // Ignore if directory already exists
+    if (err.code !== 'EEXIST') throw err;
+  }
+}
+
+/**
+ * Check if path exists (async)
+ * Replaces: fse.exists()
+ * @param {string} filePath - Path to check
+ * @returns {Promise<boolean>}
+ */
+async function pathExists(filePath) {
+  try {
+    await fsPromises.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Empty a directory (remove all contents but keep the directory)
+ * Replaces: fse.emptyDir()
+ * @param {string} dirPath - Path to directory
+ * @returns {Promise<void>}
+ */
+async function emptyDir(dirPath) {
+  try {
+    const files = await fsPromises.readdir(dirPath);
+    await Promise.all(
+      files.map((file) =>
+        fsPromises.rm(path.join(dirPath, file), {
+          recursive: true,
+          force: true,
+        })
+      )
+    );
+  } catch (err) {
+    // Ignore if directory doesn't exist
+    if (err.code !== 'ENOENT') throw err;
+  }
+}
+
+/**
+ * Copy file or directory recursively
+ * Replaces: fse.copy()
+ * @param {string} src - Source path
+ * @param {string} dest - Destination path
+ * @param {object} options - Copy options
+ * @returns {Promise<void>}
+ */
+async function copy(src, dest, options = {}) {
+  const opts = {
+    recursive: true,
+    force: options.overwrite !== false,
+    ...options,
+  };
+  await fsPromises.cp(src, dest, opts);
+}
+
+/**
+ * Read and parse JSON file synchronously
+ * Replaces: fse.readJsonSync()
+ * @param {string} filePath - Path to JSON file
+ * @param {object} options - Read options
+ * @returns {any} Parsed JSON data
+ */
+function readJsonSync(filePath, options = {}) {
+  const content = fs.readFileSync(filePath, options.encoding || 'utf8');
+  return JSON.parse(content);
+}
+
+/**
+ * Remove file or directory (async)
+ * Replaces: fse.remove()
+ * @param {string} filePath - Path to remove
+ * @returns {Promise<void>}
+ */
+async function remove(filePath) {
+  try {
+    await fsPromises.rm(filePath, { recursive: true, force: true });
+  } catch (err) {
+    // Ignore if path doesn't exist
+    if (err.code !== 'ENOENT') throw err;
+  }
+}
+
+/**
+ * Remove file or directory (sync)
+ * Replaces: fse.removeSync()
+ * @param {string} filePath - Path to remove
+ */
+function removeSync(filePath) {
+  try {
+    fs.rmSync(filePath, { recursive: true, force: true });
+  } catch (err) {
+    // Ignore if path doesn't exist
+    if (err.code !== 'ENOENT') throw err;
+  }
+}
+
+/**
+ * Write file with content (async)
+ * Replaces: fse.writeFile()
+ * @param {string} filePath - Path to file
+ * @param {string|Buffer} data - Content to write
+ * @param {object} options - Write options
+ * @returns {Promise<void>}
+ */
+async function writeFile(filePath, data, options = {}) {
+  await fsPromises.writeFile(filePath, data, options);
+}
+
+/**
+ * Create directory (async)
+ * Replaces: fse.mkdir()
+ * @param {string} dirPath - Path to directory
+ * @param {object} options - mkdir options
+ * @returns {Promise<void>}
+ */
+async function mkdir(dirPath, options = {}) {
+  await fsPromises.mkdir(dirPath, options);
+}
 
 /**
  * Detect Ubuntu codename from /etc/os-release
@@ -87,7 +237,26 @@ function isClose(a, b, rtol = 1e-9, atol = 0.0) {
 
   return rtol >= relativeDiff;
 }
+
 module.exports = {
+  // General utilities
   detectUbuntuCodename,
   isClose,
+
+  // File system utilities (async)
+  ensureDir,
+  mkdirs: ensureDir, // Alias for fs-extra compatibility
+  exists: pathExists, // Renamed to avoid conflict with deprecated fs.exists
+  pathExists,
+  emptyDir,
+  copy,
+  remove,
+  writeFile,
+  mkdir,
+
+  // File system utilities (sync)
+  ensureDirSync,
+  mkdirSync: ensureDirSync, // Alias for fs-extra compatibility
+  removeSync,
+  readJsonSync,
 };

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "bindings": "^1.5.0",
     "compare-versions": "^6.1.1",
     "debug": "^4.4.0",
-    "fs-extra": "^11.2.0",
     "json-bigint": "^1.0.0",
     "node-addon-api": "^8.3.1",
     "walk": "^2.3.15"

--- a/rosidl_convertor/idl_convertor.js
+++ b/rosidl_convertor/idl_convertor.js
@@ -14,15 +14,16 @@
 
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
-const fse = require('fs-extra');
+const fse = require('../lib/utils.js');
 const execFile = require('child_process').execFile;
 const pythonExecutable =
   require('../rosidl_parser/py_utils').getPythonExecutable('python3');
 
 async function convertIDLToROS2IDL(pkgName, idlFilePath, outputDir) {
   const packagePath = path.join(outputDir, pkgName);
-  if (!fse.existsSync(packagePath)) {
+  if (!fs.existsSync(packagePath)) {
     fse.mkdirSync(packagePath);
   }
   return new Promise((resolve, reject) => {

--- a/rosidl_gen/generate_worker.js
+++ b/rosidl_gen/generate_worker.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const fse = require('fs-extra');
+const fse = require('../lib/utils.js');
 const generateJSStructFromIDL = require('./idl_generator.js');
 const packages = require('./packages.js');
 const path = require('path');

--- a/rosidl_gen/idl_generator.js
+++ b/rosidl_gen/idl_generator.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const fse = require('fs-extra');
+const fse = require('../lib/utils.js');
 const path = require('path');
 const parser = require('../rosidl_parser/rosidl_parser.js');
 const actionMsgs = require('./action_msgs.js');

--- a/rosidl_gen/index.js
+++ b/rosidl_gen/index.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const fse = require('fs-extra');
+const fse = require('../lib/utils.js');
 const generateJSStructFromIDL = require('./idl_generator.js');
 const packages = require('./packages.js');
 const path = require('path');

--- a/scripts/run_test.js
+++ b/scripts/run_test.js
@@ -14,13 +14,15 @@
 
 'use strict';
 
-const fs = require('fs-extra');
+const fs = require('fs');
+const utils = require('../lib/utils.js');
 const Mocha = require('mocha');
 const os = require('os');
 const path = require('path');
 
-fs.remove(path.join(path.dirname(__dirname), 'generated'), (err) => {
-  if (!err) {
+utils
+  .remove(path.join(path.dirname(__dirname), 'generated'))
+  .then(() => {
     let mocha = new Mocha();
     const testDir = path.join(__dirname, '../test/');
     // eslint-disable-next-line
@@ -45,5 +47,8 @@ fs.remove(path.join(path.dirname(__dirname), 'generated'), (err) => {
         process.exit(failures);
       });
     });
-  }
-});
+  })
+  .catch((err) => {
+    console.error('Failed to clean generated directory:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
This PR removes the fs-extra dependency by implementing equivalent filesystem utilities using Node.js built-in modules. The change replaces fs-extra with custom utility functions that provide the same functionality while reducing external dependencies.

Key changes:
- Created a comprehensive utils module with filesystem operations equivalent to fs-extra
- Updated all imports to use the new utility module instead of fs-extra
- Removed fs-extra from package.json dependencies

Fix: #1300