### PR TITLE
Remove compare-versions dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const DistroUtils = require('./lib/distro.js');
 const RMWUtils = require('./lib/rmw.js');
 const { Clock, ROSClock } = require('./lib/clock.js');
 const ClockType = require('./lib/clock_type.js');
-const compareVersions = require('compare-versions');
+const { compareVersions } = require('./lib/utils.js');
 const Context = require('./lib/context.js');
 const debug = require('debug')('rclnodejs');
 const Duration = require('./lib/duration.js');
@@ -364,8 +364,7 @@ let rcl = {
 
     const version = await getCurrentGeneratorVersion();
     const forced =
-      version === null ||
-      compareVersions.compare(version, generator.version(), '<');
+      version === null || compareVersions(version, generator.version(), '<');
     if (forced) {
       debug(
         'The generator will begin to create JavaScript code from ROS IDL files...'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -238,6 +238,66 @@ function isClose(a, b, rtol = 1e-9, atol = 0.0) {
   return rtol >= relativeDiff;
 }
 
+/**
+ * Compare two semantic version strings.
+ *
+ * Supports version strings in the format: x.y.z or x.y.z.w
+ * where x, y, z, w are integers.
+ *
+ * @param {string} version1 - First version string (e.g., '1.2.3')
+ * @param {string} version2 - Second version string (e.g., '1.2.4')
+ * @param {string} operator - Comparison operator: '<', '<=', '>', '>=', '==', '!='
+ * @returns {boolean} Result of the comparison
+ *
+ * @example
+ * compareVersions('1.2.3', '1.2.4', '<')   // true
+ * compareVersions('2.0.0', '1.9.9', '>')   // true
+ * compareVersions('1.2.3', '1.2.3', '==')  // true
+ * compareVersions('1.2.3', '1.2.3', '>=')  // true
+ */
+function compareVersions(version1, version2, operator) {
+  // Parse version strings into arrays of integers
+  const v1Parts = version1.split('.').map((part) => parseInt(part, 10));
+  const v2Parts = version2.split('.').map((part) => parseInt(part, 10));
+
+  // Pad arrays to same length with zeros
+  const maxLength = Math.max(v1Parts.length, v2Parts.length);
+  while (v1Parts.length < maxLength) v1Parts.push(0);
+  while (v2Parts.length < maxLength) v2Parts.push(0);
+
+  // Compare each part
+  let cmp = 0;
+  for (let i = 0; i < maxLength; i++) {
+    if (v1Parts[i] > v2Parts[i]) {
+      cmp = 1;
+      break;
+    } else if (v1Parts[i] < v2Parts[i]) {
+      cmp = -1;
+      break;
+    }
+  }
+
+  // Apply operator
+  switch (operator) {
+    case '<':
+      return cmp < 0;
+    case '<=':
+      return cmp <= 0;
+    case '>':
+      return cmp > 0;
+    case '>=':
+      return cmp >= 0;
+    case '==':
+    case '===':
+      return cmp === 0;
+    case '!=':
+    case '!==':
+      return cmp !== 0;
+    default:
+      throw new Error(`Invalid operator: ${operator}`);
+  }
+}
+
 module.exports = {
   // General utilities
   detectUbuntuCodename,
@@ -259,4 +319,6 @@ module.exports = {
   mkdirSync: ensureDirSync, // Alias for fs-extra compatibility
   removeSync,
   readJsonSync,
+
+  compareVersions,
 };

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "@rclnodejs/ref-array-di": "^1.2.2",
     "@rclnodejs/ref-struct-di": "^1.1.1",
     "bindings": "^1.5.0",
-    "compare-versions": "^6.1.1",
     "debug": "^4.4.0",
     "json-bigint": "^1.0.0",
     "node-addon-api": "^8.3.1",

--- a/rosidl_parser/rosidl_parser.js
+++ b/rosidl_parser/rosidl_parser.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const compareVersions = require('compare-versions');
+const { compareVersions } = require('../lib/utils.js');
 const path = require('path');
 const execFile = require('child_process').execFile;
 
@@ -22,7 +22,7 @@ const pythonExecutable = require('./py_utils').getPythonExecutable('python3');
 
 const contextSupportedVersion = '21.0.0.0';
 const currentVersion = process.version;
-const isContextSupported = compareVersions.compare(
+const isContextSupported = compareVersions(
   currentVersion.substring(1, currentVersion.length),
   contextSupportedVersion,
   '>='


### PR DESCRIPTION
This PR removes the external `compare-versions` dependency by implementing a custom version comparison function in the project's utils module.

- Replaces the external `compare-versions` package with a custom implementation
- Updates import statements to use the new local function
- Removes the dependency from package.json

Fix: #1301