### PR TITLE
Remove json-bigint dependency

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -358,12 +358,22 @@ function parseJSONWithBigInt(str) {
   const processed = str.replace(
     /(?:[:,[])\s*(-?\d+)(?=\s*[,}\]])/g,
     (match, number) => {
-      const num = Number(number);
-      // If the number is not safe, convert it to a string
-      if (!Number.isSafeInteger(num)) {
-        // Preserve the prefix character (: or , or [)
-        const prefix = match.charAt(0);
-        return `${prefix} "${number}"`;
+      // Use BigInt to check if the number is safe without losing precision
+      // BigInt can accurately represent arbitrarily large integers
+      try {
+        const bigIntValue = BigInt(number);
+        // Check if the value is outside the safe integer range
+        if (
+          bigIntValue < BigInt(Number.MIN_SAFE_INTEGER) ||
+          bigIntValue > BigInt(Number.MAX_SAFE_INTEGER)
+        ) {
+          // Preserve the prefix character (: or , or [)
+          const prefix = match.charAt(0);
+          return `${prefix} "${number}"`;
+        }
+      } catch {
+        // If BigInt conversion fails, keep the original match
+        return match;
       }
       return match;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -298,22 +298,31 @@ function compareVersions(version1, version2, operator) {
   }
 }
 
-// Module-level constants for parseJSONWithBigInt
-const CONTEXT_SUPPORTED_VERSION = '21.0.0.0';
-const isContextSupported = compareVersions(
-  process.version.substring(1),
-  CONTEXT_SUPPORTED_VERSION,
-  '>='
-);
+// Feature detection for JSON.parse context parameter support
+// Test once at module load time to avoid repeated checks
+let isContextSupported = false;
+try {
+  // Try to use context parameter with a simple test
+  JSON.parse('{"test":1}', (key, value, context) => {
+    if (context && context.source !== undefined) {
+      isContextSupported = true;
+    }
+    return value;
+  });
+} catch (e) {
+  // Context parameter not supported, will use regex fallback
+  isContextSupported = false;
+}
 
 /**
  * Parse JSON string with support for large integers (beyond Number.MAX_SAFE_INTEGER).
  * Large integers are automatically converted to strings to preserve precision.
  *
- * For Node.js >= 21.0.0, uses native JSON.parse() with context parameter.
- * For older versions, preprocesses the JSON string with regex to convert unsafe integers.
- *
- * Replaces: json-bigint package
+ * Uses feature detection to determine the best parsing strategy:
+ * - If context parameter is supported (Node.js >= 21.0.0, modern runtimes):
+ *   Uses native JSON.parse() with context parameter for optimal performance
+ * - Otherwise (older environments):
+ *   Preprocesses JSON string with regex to convert unsafe integers before parsing
  *
  * @param {string} str - JSON string to parse
  * @returns {any} Parsed JSON object with unsafe integers as strings
@@ -326,7 +335,7 @@ const isContextSupported = compareVersions(
  * // Returns: { value: 100 }
  */
 function parseJSONWithBigInt(str) {
-  // For Node.js >= 21.0.0, use native context parameter
+  // For environments supporting context parameter, use it
   // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
   if (isContextSupported) {
     return JSON.parse(str, (key, value, context) => {
@@ -340,9 +349,9 @@ function parseJSONWithBigInt(str) {
     });
   }
 
-  // For older Node.js versions, preprocess the JSON string to convert
-  // large integers (outside the safe integer range) to strings before parsing.
-  // This replaces the functionality of json-bigint package.
+  // For environments without context parameter support, preprocess the JSON string
+  // to convert large integers (outside the safe integer range) to strings before parsing.
+  //
   // The regex matches integers that are actual JSON values, not inside strings.
   // It matches after: colon (:), comma (,), or open bracket ([)
   // and before: comma (,), close brace (}), or close bracket (])

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -298,6 +298,67 @@ function compareVersions(version1, version2, operator) {
   }
 }
 
+/**
+ * Parse JSON string with support for large integers (beyond Number.MAX_SAFE_INTEGER).
+ * Large integers are automatically converted to strings to preserve precision.
+ *
+ * For Node.js >= 21.0.0, uses native JSON.parse() with context parameter.
+ * For older versions, preprocesses the JSON string with regex to convert unsafe integers.
+ *
+ * Replaces: json-bigint package
+ *
+ * @param {string} str - JSON string to parse
+ * @returns {any} Parsed JSON object with unsafe integers as strings
+ *
+ * @example
+ * parseJSONWithBigInt('{"value": 9007199254740992}')
+ * // Returns: { value: '9007199254740992' }
+ *
+ * parseJSONWithBigInt('{"value": 100}')
+ * // Returns: { value: 100 }
+ */
+function parseJSONWithBigInt(str) {
+  const contextSupportedVersion = '21.0.0.0';
+  const currentVersion = process.version;
+  const isContextSupported = compareVersions(
+    currentVersion.substring(1, currentVersion.length),
+    contextSupportedVersion,
+    '>='
+  );
+
+  // For nodejs >= 21.0.0, we leverage context parameter to
+  // convert unsafe integer to string.
+  // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
+  if (isContextSupported) {
+    return JSON.parse(str, (key, value, context) => {
+      if (
+        Number.isInteger(value) &&
+        !Number.isSafeInteger(Number(context.source))
+      ) {
+        return context.source;
+      }
+      return value;
+    });
+  }
+
+  // For older Node.js versions, preprocess the JSON string to convert
+  // large integers (outside the safe integer range) to strings before parsing.
+  // This replaces the functionality of json-bigint package.
+  const processed = str.replace(
+    /:\s*(-?\d+)(?=\s*[,}\]])/g,
+    (match, number) => {
+      const num = Number(number);
+      // If the number is not safe, keep it as a string
+      if (!Number.isSafeInteger(num)) {
+        return `: "${number}"`;
+      }
+      return match;
+    }
+  );
+
+  return JSON.parse(processed);
+}
+
 module.exports = {
   // General utilities
   detectUbuntuCodename,
@@ -320,5 +381,7 @@ module.exports = {
   removeSync,
   readJsonSync,
 
+  // Version and JSON utilities
   compareVersions,
+  parseJSONWithBigInt,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -309,7 +309,7 @@ try {
     }
     return value;
   });
-} catch (e) {
+} catch {
   // Context parameter not supported, will use regex fallback
   isContextSupported = false;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -298,6 +298,14 @@ function compareVersions(version1, version2, operator) {
   }
 }
 
+// Module-level constants for parseJSONWithBigInt
+const CONTEXT_SUPPORTED_VERSION = '21.0.0.0';
+const isContextSupported = compareVersions(
+  process.version.substring(1),
+  CONTEXT_SUPPORTED_VERSION,
+  '>='
+);
+
 /**
  * Parse JSON string with support for large integers (beyond Number.MAX_SAFE_INTEGER).
  * Large integers are automatically converted to strings to preserve precision.
@@ -318,16 +326,7 @@ function compareVersions(version1, version2, operator) {
  * // Returns: { value: 100 }
  */
 function parseJSONWithBigInt(str) {
-  const contextSupportedVersion = '21.0.0.0';
-  const currentVersion = process.version;
-  const isContextSupported = compareVersions(
-    currentVersion.substring(1, currentVersion.length),
-    contextSupportedVersion,
-    '>='
-  );
-
-  // For nodejs >= 21.0.0, we leverage context parameter to
-  // convert unsafe integer to string.
+  // For Node.js >= 21.0.0, use native context parameter
   // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
   if (isContextSupported) {
     return JSON.parse(str, (key, value, context) => {
@@ -344,13 +343,18 @@ function parseJSONWithBigInt(str) {
   // For older Node.js versions, preprocess the JSON string to convert
   // large integers (outside the safe integer range) to strings before parsing.
   // This replaces the functionality of json-bigint package.
+  // The regex matches integers that are actual JSON values, not inside strings.
+  // It matches after: colon (:), comma (,), or open bracket ([)
+  // and before: comma (,), close brace (}), or close bracket (])
   const processed = str.replace(
-    /:\s*(-?\d+)(?=\s*[,}\]])/g,
+    /(?:[:,[])\s*(-?\d+)(?=\s*[,}\]])/g,
     (match, number) => {
       const num = Number(number);
-      // If the number is not safe, keep it as a string
+      // If the number is not safe, convert it to a string
       if (!Number.isSafeInteger(num)) {
-        return `: "${number}"`;
+        // Preserve the prefix character (: or , or [)
+        const prefix = match.charAt(0);
+        return `${prefix} "${number}"`;
       }
       return match;
     }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@rclnodejs/ref-struct-di": "^1.1.1",
     "bindings": "^1.5.0",
     "debug": "^4.4.0",
-    "json-bigint": "^1.0.0",
     "node-addon-api": "^8.3.1",
     "walk": "^2.3.15"
   },

--- a/rosidl_parser/rosidl_parser.js
+++ b/rosidl_parser/rosidl_parser.js
@@ -14,19 +14,11 @@
 
 'use strict';
 
-const { compareVersions } = require('../lib/utils.js');
+const { compareVersions, parseJSONWithBigInt } = require('../lib/utils');
 const path = require('path');
 const execFile = require('child_process').execFile;
 
 const pythonExecutable = require('./py_utils').getPythonExecutable('python3');
-
-const contextSupportedVersion = '21.0.0.0';
-const currentVersion = process.version;
-const isContextSupported = compareVersions(
-  currentVersion.substring(1, currentVersion.length),
-  contextSupportedVersion,
-  '>='
-);
 
 const rosidlParser = {
   parseMessageFile(packageName, filePath) {
@@ -39,25 +31,6 @@ const rosidlParser = {
 
   parseActionFile(packageName, filePath) {
     return this._parseFile('parse_action_file', packageName, filePath);
-  },
-
-  _parseJSONObject(str) {
-    // For nodejs >= `contextSupportedVersion`, we leverage context parameter to
-    // convert unsafe integer to string, otherwise, json-bigint is used.
-    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
-    if (isContextSupported) {
-      return JSON.parse(str, (key, value, context) => {
-        if (
-          Number.isInteger(value) &&
-          !Number.isSafeInteger(Number(context.source))
-        ) {
-          return context.source;
-        }
-        return value;
-      });
-    }
-    const JSONbigString = require('json-bigint')({ storeAsString: true });
-    return JSONbigString.parse(str);
   },
 
   _parseFile(command, packageName, filePath) {
@@ -82,7 +55,7 @@ const rosidlParser = {
               )
             );
           } else {
-            resolve(this._parseJSONObject(stdout));
+            resolve(parseJSONWithBigInt(stdout));
           }
         }
       );


### PR DESCRIPTION
This PR removes the `json-bigint` dependency by implementing native JSON parsing with big integer support. The change consolidates JSON parsing logic into a reusable utility function that uses Node.js 21+ native capabilities when available, and falls back to regex preprocessing for older versions.

**Key Changes:**
- Implemented `parseJSONWithBigInt` utility function to replace `json-bigint` package
- Removed `json-bigint` dependency from package.json
- Refactored rosidl_parser.js to use the new utility function

Fix: #1304