### PR TITLE
Add JSON-Safe serialization modes

### DIFF
--- a/example/topics/README.md
+++ b/example/topics/README.md
@@ -146,6 +146,26 @@ The `subscriber/` directory contains examples of nodes that subscribe to topics:
 - **Features**: ROS 2 service introspection capabilities
 - **Run Command**: `node subscriber/subscription-service-event-example.js`
 
+### 8. Serialization Modes Subscriber (`subscription-serialization-modes-example.js`)
+
+**Purpose**: Demonstrates different serialization modes for message handling.
+
+- **Message Type**: `sensor_msgs/msg/LaserScan`
+- **Topic**: `scan`
+- **Functionality**: Shows how 'typed', 'plain', and 'json' modes affect message serialization
+- **Features**: Message serialization control for web applications and JSON compatibility
+- **Run Command**: `node subscriber/subscription-serialization-modes-example.js`
+
+### 9. JSON Utilities Subscriber (`subscription-json-utilities-example.js`)
+
+**Purpose**: Demonstrates manual message conversion utilities.
+
+- **Message Type**: `sensor_msgs/msg/LaserScan`
+- **Topic**: `scan`
+- **Functionality**: Shows how to use toJSONSafe and toJSONString utilities for manual conversion
+- **Features**: Manual conversion of TypedArrays, BigInt, and special values for JSON serialization
+- **Run Command**: `node subscriber/subscription-json-utilities-example.js`
+
 ## Validator Example
 
 The `validator/` directory contains validation utilities:
@@ -193,6 +213,7 @@ Several examples work together to demonstrate complete communication:
 - **Raw Messages**: Binary data transmission
 - **Service Events**: Monitoring service interactions
 - **Multi-dimensional Arrays**: Complex data structures with layout information
+- **Message Serialization**: TypedArray handling and JSON-safe conversion for web applications
 - **Validation**: Name and topic validation utilities
 
 ## Notes

--- a/example/topics/README.md
+++ b/example/topics/README.md
@@ -152,7 +152,7 @@ The `subscriber/` directory contains examples of nodes that subscribe to topics:
 
 - **Message Type**: `sensor_msgs/msg/LaserScan`
 - **Topic**: `scan`
-- **Functionality**: Shows how 'typed', 'plain', and 'json' modes affect message serialization
+- **Functionality**: Shows how 'default', 'plain', and 'json' modes affect message serialization
 - **Features**: Message serialization control for web applications and JSON compatibility
 - **Run Command**: `node subscriber/subscription-serialization-modes-example.js`
 

--- a/example/topics/subscriber/subscription-json-utilities-example.js
+++ b/example/topics/subscriber/subscription-json-utilities-example.js
@@ -1,0 +1,41 @@
+// Copyright (c) 2024 rclnodejs contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const rclnodejs = require('../../../index.js');
+
+/**
+ * This example demonstrates the JSON utility functions for manual message conversion.
+ * These utilities are useful when you need to convert messages on-demand
+ * rather than using the serializationMode subscription option.
+ */
+async function main() {
+  await rclnodejs.init();
+  const node = new rclnodejs.Node('json_utilities_example_node');
+
+  node.createSubscription('sensor_msgs/msg/LaserScan', '/laser_scan', (msg) => {
+    // Convert using utility functions
+    const jsonSafe = rclnodejs.toJSONSafe(msg);
+    const jsonString = rclnodejs.toJSONString(msg);
+
+    console.log(
+      `Original: ${msg.ranges ? msg.ranges.constructor.name : 'undefined'}, JSON-safe: ${jsonSafe.ranges ? jsonSafe.ranges.constructor.name : 'undefined'}, JSON length: ${jsonString.length}`
+    );
+  });
+
+  node.spin();
+}
+
+main().catch(console.error);

--- a/example/topics/subscriber/subscription-json-utilities-example.js
+++ b/example/topics/subscriber/subscription-json-utilities-example.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 rclnodejs contributors. All rights reserved.
+// Copyright (c) 2025 Mahmoud Alghalayini. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/topics/subscriber/subscription-serialization-modes-example.js
+++ b/example/topics/subscriber/subscription-serialization-modes-example.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 rclnodejs contributors. All rights reserved.
+// Copyright (c) 2025 Mahmoud Alghalayini. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ const rclnodejs = require('../../../index.js');
 /**
  * This example demonstrates the use of serialization modes for subscriptions.
  * Serialization modes allow you to control how TypedArrays are handled in messages:
- * - 'typed' (default): Keep TypedArrays for performance
+ * - 'default': Use native rclnodejs behavior (respects enableTypedArray setting)
  * - 'plain': Convert TypedArrays to regular arrays
  * - 'json': Fully JSON-safe (converts TypedArrays, BigInt, Infinity, etc.)
  */
@@ -27,11 +27,11 @@ async function main() {
   await rclnodejs.init();
   const node = new rclnodejs.Node('serialization_modes_example_node');
 
-  // Default mode: 'typed' - keeps TypedArrays
+  // Default mode: 'default' - uses native rclnodejs behavior
   node.createSubscription(
     'sensor_msgs/msg/LaserScan',
     '/laser_scan',
-    { serializationMode: 'typed' },
+    { serializationMode: 'default' },
     (msg) => {
       console.log(
         `[TYPED] ranges: ${msg.ranges ? msg.ranges.constructor.name : 'undefined'}`

--- a/example/topics/subscriber/subscription-serialization-modes-example.js
+++ b/example/topics/subscriber/subscription-serialization-modes-example.js
@@ -1,0 +1,78 @@
+// Copyright (c) 2024 rclnodejs contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const rclnodejs = require('../../../index.js');
+
+/**
+ * This example demonstrates the use of serialization modes for subscriptions.
+ * Serialization modes allow you to control how TypedArrays are handled in messages:
+ * - 'typed' (default): Keep TypedArrays for performance
+ * - 'plain': Convert TypedArrays to regular arrays
+ * - 'json': Fully JSON-safe (converts TypedArrays, BigInt, Infinity, etc.)
+ */
+async function main() {
+  await rclnodejs.init();
+  const node = new rclnodejs.Node('serialization_modes_example_node');
+
+  // Default mode: 'typed' - keeps TypedArrays
+  node.createSubscription(
+    'sensor_msgs/msg/LaserScan',
+    '/laser_scan',
+    { serializationMode: 'typed' },
+    (msg) => {
+      console.log(
+        `[TYPED] ranges: ${msg.ranges ? msg.ranges.constructor.name : 'undefined'}`
+      );
+    }
+  );
+
+  // Plain mode: converts TypedArrays to regular arrays
+  node.createSubscription(
+    'sensor_msgs/msg/LaserScan',
+    '/laser_scan',
+    { serializationMode: 'plain' },
+    (msg) => {
+      console.log(
+        `[PLAIN] ranges: ${msg.ranges ? msg.ranges.constructor.name : 'undefined'}`
+      );
+    }
+  );
+
+  // JSON mode: fully JSON-safe
+  node.createSubscription(
+    'sensor_msgs/msg/LaserScan',
+    '/laser_scan',
+    { serializationMode: 'json' },
+    (msg) => {
+      console.log(
+        `[JSON] ranges: ${msg.ranges ? msg.ranges.constructor.name : 'undefined'}, JSON-safe: ${canStringifyJSON(msg)}`
+      );
+    }
+  );
+
+  node.spin();
+}
+
+function canStringifyJSON(obj) {
+  try {
+    JSON.stringify(obj);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+main().catch(console.error);

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ const ActionUuid = require('./lib/action/uuid.js');
 const ClientGoalHandle = require('./lib/action/client_goal_handle.js');
 const { CancelResponse, GoalResponse } = require('./lib/action/response.js');
 const ServerGoalHandle = require('./lib/action/server_goal_handle.js');
+const { toJSONSafe, toJSONString } = require('./lib/message_serialization.js');
 const {
   getActionClientNamesAndTypesByNode,
   getActionServerNamesAndTypesByNode,
@@ -538,6 +539,23 @@ let rcl = {
    * @return {Promise<{process: ChildProcess}>} A Promise that resolves with the process.
    */
   ros2Launch: ros2Launch,
+
+  /**
+   * Convert a message object to be JSON-safe by converting TypedArrays to regular arrays
+   * and handling BigInt, Infinity, NaN, etc. for JSON serialization.
+   * @param {*} obj - The message object to convert
+   * @returns {*} A JSON-safe version of the object
+   */
+  toJSONSafe: toJSONSafe,
+
+  /**
+   * Convert a message object to a JSON string with proper handling of TypedArrays,
+   * BigInt, and other non-JSON-serializable values.
+   * @param {*} obj - The message object to convert
+   * @param {number} [space] - Space parameter for JSON.stringify formatting
+   * @returns {string} The JSON string representation
+   */
+  toJSONString: toJSONString,
 };
 
 const _sigHandler = () => {

--- a/lib/message_serialization.js
+++ b/lib/message_serialization.js
@@ -1,0 +1,171 @@
+// Copyright (c) 2024 rclnodejs contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+/**
+ * Check if a value is a TypedArray
+ * @param {*} value - The value to check
+ * @returns {boolean} True if the value is a TypedArray
+ */
+function isTypedArray(value) {
+  return ArrayBuffer.isView(value) && !(value instanceof DataView);
+}
+
+/**
+ * Check if a value needs JSON conversion (BigInt, functions, etc.)
+ * @param {*} value - The value to check
+ * @returns {boolean} True if the value needs special JSON handling
+ */
+function needsJSONConversion(value) {
+  return (
+    typeof value === 'bigint' ||
+    typeof value === 'function' ||
+    typeof value === 'undefined' ||
+    value === Infinity ||
+    value === -Infinity ||
+    (typeof value === 'number' && isNaN(value))
+  );
+}
+
+/**
+ * Convert a message to plain arrays (TypedArray -> regular Array)
+ * @param {*} obj - The object to convert
+ * @returns {*} The converted object with plain arrays
+ */
+function toPlainArrays(obj) {
+  if (obj === null || obj === undefined) {
+    return obj;
+  }
+
+  if (isTypedArray(obj)) {
+    return Array.from(obj);
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => toPlainArrays(item));
+  }
+
+  if (typeof obj === 'object' && obj !== null) {
+    const result = {};
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        result[key] = toPlainArrays(obj[key]);
+      }
+    }
+    return result;
+  }
+
+  return obj;
+}
+
+/**
+ * Convert a message to be fully JSON-safe
+ * @param {*} obj - The object to convert
+ * @returns {*} The JSON-safe converted object
+ */
+function toJSONSafe(obj) {
+  if (obj === null || obj === undefined) {
+    return obj;
+  }
+
+  if (isTypedArray(obj)) {
+    return Array.from(obj).map((item) => toJSONSafe(item));
+  }
+
+  if (needsJSONConversion(obj)) {
+    if (typeof obj === 'bigint') {
+      // Convert BigInt to string with 'n' suffix to indicate it was a BigInt
+      return obj.toString() + 'n';
+    }
+    if (obj === Infinity) return 'Infinity';
+    if (obj === -Infinity) return '-Infinity';
+    if (typeof obj === 'number' && isNaN(obj)) return 'NaN';
+    if (typeof obj === 'undefined') return null;
+    if (typeof obj === 'function') return '[Function]';
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => toJSONSafe(item));
+  }
+
+  if (typeof obj === 'object' && obj !== null) {
+    const result = {};
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        result[key] = toJSONSafe(obj[key]);
+      }
+    }
+    return result;
+  }
+
+  return obj;
+}
+
+/**
+ * Convert a message to a JSON string
+ * @param {*} obj - The object to convert
+ * @param {number} [space] - Space parameter for JSON.stringify formatting
+ * @returns {string} The JSON string representation
+ */
+function toJSONString(obj, space) {
+  const jsonSafeObj = toJSONSafe(obj);
+  return JSON.stringify(jsonSafeObj, null, space);
+}
+
+/**
+ * Apply serialization mode conversion to a message object
+ * @param {*} message - The message object to convert
+ * @param {string} serializationMode - The serialization mode ('typed', 'plain', 'json')
+ * @returns {*} The converted message
+ */
+function applySerializationMode(message, serializationMode) {
+  switch (serializationMode) {
+    case 'typed':
+      // No conversion needed - keep TypedArrays
+      return message;
+
+    case 'plain':
+      // Convert TypedArrays to regular arrays
+      return toPlainArrays(message);
+
+    case 'json':
+      // Convert to fully JSON-safe format
+      return toJSONSafe(message);
+
+    default:
+      throw new TypeError(
+        `Invalid serializationMode: ${serializationMode}. Valid modes are: 'typed', 'plain', 'json'`
+      );
+  }
+}
+
+/**
+ * Validate serialization mode
+ * @param {string} mode - The serialization mode to validate
+ * @returns {boolean} True if valid
+ */
+function isValidSerializationMode(mode) {
+  return ['typed', 'plain', 'json'].includes(mode);
+}
+
+module.exports = {
+  isTypedArray,
+  needsJSONConversion,
+  toPlainArrays,
+  toJSONSafe,
+  toJSONString,
+  applySerializationMode,
+  isValidSerializationMode,
+};

--- a/lib/message_serialization.js
+++ b/lib/message_serialization.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 rclnodejs contributors. All rights reserved.
+// Copyright (c) 2025 Mahmoud Alghalayini. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,13 +127,13 @@ function toJSONString(obj, space) {
 /**
  * Apply serialization mode conversion to a message object
  * @param {*} message - The message object to convert
- * @param {string} serializationMode - The serialization mode ('typed', 'plain', 'json')
+ * @param {string} serializationMode - The serialization mode ('default', 'plain', 'json')
  * @returns {*} The converted message
  */
 function applySerializationMode(message, serializationMode) {
   switch (serializationMode) {
-    case 'typed':
-      // No conversion needed - keep TypedArrays
+    case 'default':
+      // No conversion needed - use native rclnodejs behavior
       return message;
 
     case 'plain':
@@ -146,7 +146,7 @@ function applySerializationMode(message, serializationMode) {
 
     default:
       throw new TypeError(
-        `Invalid serializationMode: ${serializationMode}. Valid modes are: 'typed', 'plain', 'json'`
+        `Invalid serializationMode: ${serializationMode}. Valid modes are: 'default', 'plain', 'json'`
       );
   }
 }
@@ -157,7 +157,7 @@ function applySerializationMode(message, serializationMode) {
  * @returns {boolean} True if valid
  */
 function isValidSerializationMode(mode) {
-  return ['typed', 'plain', 'json'].includes(mode);
+  return ['default', 'plain', 'json'].includes(mode);
 }
 
 module.exports = {

--- a/lib/node.js
+++ b/lib/node.js
@@ -31,6 +31,7 @@ const {
   Parameter,
   ParameterDescriptor,
 } = require('./parameter.js');
+const { isValidSerializationMode } = require('./message_serialization.js');
 const ParameterService = require('./parameter_service.js');
 const Publisher = require('./publisher.js');
 const QoS = require('./qos.js');
@@ -532,6 +533,14 @@ class Node extends rclnodejs.ShadowNode {
       options = Object.assign(options, { isRaw: false });
     }
 
+    if (options.serializationMode === undefined) {
+      options = Object.assign(options, { serializationMode: 'typed' });
+    } else if (!isValidSerializationMode(options.serializationMode)) {
+      throw new TypeError(
+        `Invalid serializationMode: ${options.serializationMode}. Valid modes are: 'typed', 'plain', 'json'`
+      );
+    }
+
     return options;
   }
 
@@ -666,6 +675,10 @@ class Node extends rclnodejs.ShadowNode {
    * @param {boolean} options.enableTypedArray - The topic will use TypedArray if necessary, default: true.
    * @param {QoS} options.qos - ROS Middleware "quality of service" settings for the subscription, default: QoS.profileDefault.
    * @param {boolean} options.isRaw - The topic is serialized when true, default: false.
+   * @param {string} [options.serializationMode='typed'] - Controls message serialization format:
+   *  'typed' (default): Keep TypedArrays for performance,
+   *  'plain': Convert TypedArrays to regular arrays,
+   *  'json': Fully JSON-safe (handles TypedArrays, BigInt, etc.).
    * @param {object} [options.contentFilter=undefined] - The content-filter, default: undefined.
    *  Confirm that your RMW supports content-filtered topics before use. 
    * @param {string} options.contentFilter.expression - Specifies the criteria to select the data samples of
@@ -1920,6 +1933,7 @@ class Node extends rclnodejs.ShadowNode {
  *   isRaw: false,
  *   qos: QoS.profileDefault,
  *   contentFilter: undefined,
+ *   serializationMode: 'typed',
  * }
  */
 Node.getDefaultOptions = function () {
@@ -1928,6 +1942,7 @@ Node.getDefaultOptions = function () {
     isRaw: false,
     qos: QoS.profileDefault,
     contentFilter: undefined,
+    serializationMode: 'typed',
   };
 };
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -534,10 +534,10 @@ class Node extends rclnodejs.ShadowNode {
     }
 
     if (options.serializationMode === undefined) {
-      options = Object.assign(options, { serializationMode: 'typed' });
+      options = Object.assign(options, { serializationMode: 'default' });
     } else if (!isValidSerializationMode(options.serializationMode)) {
       throw new TypeError(
-        `Invalid serializationMode: ${options.serializationMode}. Valid modes are: 'typed', 'plain', 'json'`
+        `Invalid serializationMode: ${options.serializationMode}. Valid modes are: 'default', 'plain', 'json'`
       );
     }
 
@@ -675,8 +675,8 @@ class Node extends rclnodejs.ShadowNode {
    * @param {boolean} options.enableTypedArray - The topic will use TypedArray if necessary, default: true.
    * @param {QoS} options.qos - ROS Middleware "quality of service" settings for the subscription, default: QoS.profileDefault.
    * @param {boolean} options.isRaw - The topic is serialized when true, default: false.
-   * @param {string} [options.serializationMode='typed'] - Controls message serialization format:
-   *  'typed' (default): Keep TypedArrays for performance,
+   * @param {string} [options.serializationMode='default'] - Controls message serialization format:
+   *  'default': Use native rclnodejs behavior (respects enableTypedArray setting),
    *  'plain': Convert TypedArrays to regular arrays,
    *  'json': Fully JSON-safe (handles TypedArrays, BigInt, etc.).
    * @param {object} [options.contentFilter=undefined] - The content-filter, default: undefined.
@@ -1933,7 +1933,7 @@ class Node extends rclnodejs.ShadowNode {
  *   isRaw: false,
  *   qos: QoS.profileDefault,
  *   contentFilter: undefined,
- *   serializationMode: 'typed',
+ *   serializationMode: 'default',
  * }
  */
 Node.getDefaultOptions = function () {
@@ -1942,7 +1942,7 @@ Node.getDefaultOptions = function () {
     isRaw: false,
     qos: QoS.profileDefault,
     contentFilter: undefined,
-    serializationMode: 'typed',
+    serializationMode: 'default',
   };
 };
 

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -16,6 +16,7 @@
 
 const rclnodejs = require('./native_loader.js');
 const Entity = require('./entity.js');
+const { applySerializationMode } = require('./message_serialization.js');
 const debug = require('debug')('rclnodejs:subscription');
 
 /**
@@ -42,6 +43,7 @@ class Subscription extends Entity {
     this._topic = topic;
     this._callback = callback;
     this._isRaw = options.isRaw || false;
+    this._serializationMode = options.serializationMode || 'typed';
     this._node = node;
 
     if (node && eventCallbacks) {
@@ -55,7 +57,13 @@ class Subscription extends Entity {
     if (this._isRaw) {
       this._callback(msg);
     } else {
-      this._callback(msg.toPlainObject(this.typedArrayEnabled));
+      let message = msg.toPlainObject(this.typedArrayEnabled);
+
+      if (this._serializationMode !== 'typed') {
+        message = applySerializationMode(message, this._serializationMode);
+      }
+
+      this._callback(message);
     }
   }
 
@@ -107,6 +115,13 @@ class Subscription extends Entity {
    */
   get isRaw() {
     return this._isRaw;
+  }
+
+  /**
+   * @type {string}
+   */
+  get serializationMode() {
+    return this._serializationMode;
   }
 
   /**

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -43,7 +43,7 @@ class Subscription extends Entity {
     this._topic = topic;
     this._callback = callback;
     this._isRaw = options.isRaw || false;
-    this._serializationMode = options.serializationMode || 'typed';
+    this._serializationMode = options.serializationMode || 'default';
     this._node = node;
 
     if (node && eventCallbacks) {
@@ -59,7 +59,7 @@ class Subscription extends Entity {
     } else {
       let message = msg.toPlainObject(this.typedArrayEnabled);
 
-      if (this._serializationMode !== 'typed') {
+      if (this._serializationMode !== 'default') {
         message = applySerializationMode(message, this._serializationMode);
       }
 

--- a/test/test-serialization-modes.js
+++ b/test/test-serialization-modes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 rclnodejs contributors. All rights reserved.
+// Copyright (c) 2025 Mahmoud Alghalayini. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ describe('Serialization Modes Tests', function () {
 
   it('Test serializationMode option validation', function () {
     assert.doesNotThrow(() => {
-      node._validateOptions({ serializationMode: 'typed' });
+      node._validateOptions({ serializationMode: 'default' });
       node._validateOptions({ serializationMode: 'plain' });
       node._validateOptions({ serializationMode: 'json' });
     });
@@ -105,7 +105,7 @@ describe('Serialization Modes Tests', function () {
       typedSubscription = node.createSubscription(
         'std_msgs/msg/String',
         '/test_topic_typed',
-        { serializationMode: 'typed' },
+        { serializationMode: 'default' },
         () => {}
       );
 
@@ -123,7 +123,7 @@ describe('Serialization Modes Tests', function () {
         () => {}
       );
 
-      assert.strictEqual(typedSubscription.serializationMode, 'typed');
+      assert.strictEqual(typedSubscription.serializationMode, 'default');
       assert.strictEqual(plainSubscription.serializationMode, 'plain');
       assert.strictEqual(jsonSubscription.serializationMode, 'json');
 
@@ -141,6 +141,6 @@ describe('Serialization Modes Tests', function () {
       () => {}
     );
 
-    assert.strictEqual(subscription.serializationMode, 'typed');
+    assert.strictEqual(subscription.serializationMode, 'default');
   });
 });

--- a/test/test-serialization-modes.js
+++ b/test/test-serialization-modes.js
@@ -1,0 +1,146 @@
+// Copyright (c) 2024 rclnodejs contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const rclnodejs = require('../index.js');
+
+describe('Serialization Modes Tests', function () {
+  let node;
+
+  this.timeout(60 * 1000);
+
+  before(async function () {
+    await rclnodejs.init();
+    node = rclnodejs.createNode('test_serialization_modes');
+  });
+
+  after(function () {
+    rclnodejs.shutdown();
+  });
+
+  it('Test toJSONSafe utility function', function () {
+    const float64Array = new Float64Array([1.1, 2.2, 3.3]);
+    const jsonSafe = rclnodejs.toJSONSafe(float64Array);
+
+    assert.ok(Array.isArray(jsonSafe));
+    assert.strictEqual(jsonSafe.length, 3);
+    assert.strictEqual(jsonSafe[0], 1.1);
+    assert.strictEqual(jsonSafe[1], 2.2);
+    assert.strictEqual(jsonSafe[2], 3.3);
+  });
+
+  it('Test toJSONString utility function', function () {
+    const testObject = {
+      typedArray: new Float64Array([1.5, 2.5]),
+      bigIntValue: BigInt(123456789),
+      infinity: Infinity,
+      negInfinity: -Infinity,
+      nanValue: NaN,
+      regular: 'string',
+    };
+
+    const jsonString = rclnodejs.toJSONString(testObject);
+    const parsed = JSON.parse(jsonString);
+
+    assert.ok(Array.isArray(parsed.typedArray));
+    assert.strictEqual(parsed.typedArray[0], 1.5);
+
+    assert.strictEqual(parsed.bigIntValue, '123456789n');
+
+    assert.strictEqual(parsed.infinity, 'Infinity');
+    assert.strictEqual(parsed.negInfinity, '-Infinity');
+    assert.strictEqual(parsed.nanValue, 'NaN');
+
+    assert.strictEqual(parsed.regular, 'string');
+  });
+
+  it('Test nested object conversion', function () {
+    const nestedObject = {
+      level1: {
+        level2: {
+          typedArray: new Int32Array([10, 20, 30]),
+          regularArray: [1, 2, 3],
+        },
+      },
+    };
+
+    const jsonSafe = rclnodejs.toJSONSafe(nestedObject);
+
+    assert.ok(Array.isArray(jsonSafe.level1.level2.typedArray));
+    assert.strictEqual(jsonSafe.level1.level2.typedArray[0], 10);
+
+    assert.ok(Array.isArray(jsonSafe.level1.level2.regularArray));
+    assert.strictEqual(jsonSafe.level1.level2.regularArray[0], 1);
+  });
+
+  it('Test serializationMode option validation', function () {
+    assert.doesNotThrow(() => {
+      node._validateOptions({ serializationMode: 'typed' });
+      node._validateOptions({ serializationMode: 'plain' });
+      node._validateOptions({ serializationMode: 'json' });
+    });
+
+    assert.throws(() => {
+      node._validateOptions({ serializationMode: 'invalid' });
+    }, /Invalid serializationMode/);
+  });
+
+  it('Test subscription with different serialization modes', function (done) {
+    let typedSubscription, plainSubscription, jsonSubscription;
+
+    try {
+      typedSubscription = node.createSubscription(
+        'std_msgs/msg/String',
+        '/test_topic_typed',
+        { serializationMode: 'typed' },
+        () => {}
+      );
+
+      plainSubscription = node.createSubscription(
+        'std_msgs/msg/String',
+        '/test_topic_plain',
+        { serializationMode: 'plain' },
+        () => {}
+      );
+
+      jsonSubscription = node.createSubscription(
+        'std_msgs/msg/String',
+        '/test_topic_json',
+        { serializationMode: 'json' },
+        () => {}
+      );
+
+      assert.strictEqual(typedSubscription.serializationMode, 'typed');
+      assert.strictEqual(plainSubscription.serializationMode, 'plain');
+      assert.strictEqual(jsonSubscription.serializationMode, 'json');
+
+      done();
+    } catch (error) {
+      done(error);
+    }
+  });
+
+  it('Test default serializationMode', function () {
+    const subscription = node.createSubscription(
+      'std_msgs/msg/String',
+      '/test_topic_default',
+      {},
+      () => {}
+    );
+
+    assert.strictEqual(subscription.serializationMode, 'typed');
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -235,4 +235,21 @@ declare module 'rclnodejs' {
     launchFile: string,
     args: string[]
   ): Promise<{ process: ChildProcess }>;
+
+  /**
+   * Convert a message object to be JSON-safe by converting TypedArrays to regular arrays
+   * and handling BigInt, Infinity, NaN, etc. for JSON serialization.
+   * @param obj - The message object to convert
+   * @returns A JSON-safe version of the object
+   */
+  function toJSONSafe(obj: any): any;
+
+  /**
+   * Convert a message object to a JSON string with proper handling of TypedArrays,
+   * BigInt, and other non-JSON-serializable values.
+   * @param obj - The message object to convert
+   * @param space - Space parameter for JSON.stringify formatting
+   * @returns The JSON string representation
+   */
+  function toJSONString(obj: any, space?: number): string;
 }

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -13,6 +13,11 @@ declare module 'rclnodejs' {
       };
 
   /**
+   * Valid serialization modes for message conversion
+   */
+  type SerializationMode = 'typed' | 'plain' | 'json';
+
+  /**
    * A filter description similar to a SQL WHERE clause that limits
    * the data wanted by a Subscription.
    *
@@ -57,6 +62,15 @@ declare module 'rclnodejs' {
     isRaw?: boolean;
 
     /**
+     * Controls message serialization format, default: 'typed'.
+     *
+     * - 'typed': Keep TypedArrays for performance
+     * - 'plain': Convert TypedArrays to regular arrays
+     * - 'json': Fully JSON-safe (handles TypedArrays, BigInt, etc.)
+     */
+    serializationMode?: SerializationMode;
+
+    /**
      * ROS Middleware "quality of service" setting, default: QoS.profileDefault.
      */
     qos?: T;
@@ -76,7 +90,8 @@ declare module 'rclnodejs' {
    *   enableTypedArray: true,
    *   qos: QoS.profileDefault,
    *   isRaw: false,
-   *   contentFilter: undefined
+   *   contentFilter: undefined,
+   *   serializationMode: 'typed'
    * }
    * ```
    */

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -15,7 +15,7 @@ declare module 'rclnodejs' {
   /**
    * Valid serialization modes for message conversion
    */
-  type SerializationMode = 'typed' | 'plain' | 'json';
+  type SerializationMode = 'default' | 'plain' | 'json';
 
   /**
    * A filter description similar to a SQL WHERE clause that limits
@@ -62,9 +62,9 @@ declare module 'rclnodejs' {
     isRaw?: boolean;
 
     /**
-     * Controls message serialization format, default: 'typed'.
+     * Controls message serialization format, default: 'default'.
      *
-     * - 'typed': Keep TypedArrays for performance
+     * - 'default': Use native rclnodejs behavior (respects enableTypedArray setting)
      * - 'plain': Convert TypedArrays to regular arrays
      * - 'json': Fully JSON-safe (handles TypedArrays, BigInt, etc.)
      */
@@ -91,7 +91,7 @@ declare module 'rclnodejs' {
    *   qos: QoS.profileDefault,
    *   isRaw: false,
    *   contentFilter: undefined,
-   *   serializationMode: 'typed'
+   *   serializationMode: 'default'
    * }
    * ```
    */


### PR DESCRIPTION
## **Public API Changes**

**New subscription option:**
- `serializationMode: 'default' | 'plain' | 'json'` for `createSubscription()`

**New utility functions:**  
- `rclnodejs.toJSONSafe(obj)` - makes objects JSON-friendly
- `rclnodejs.toJSONString(obj)` - converts directly to JSON string

**Fully backward compatible** - existing code works unchanged.

## **Description**

This adds **message serialization modes** to fix a common headache: ROS sensor messages use `TypedArray`s which don't play nice with JSON.

**The Problem:**
If you try to `JSON.stringify()` a LaserScan message, you get `{}` instead of the actual data. This breaks web APIs, logging, and any workflow that needs JSON.

**The Solution:**
Three modes to handle messages differently:

- **`'default'`** Uses native rclnodejs behavior
- **`'plain'`**: Convert TypedArrays to regular arrays - JSON works!  
- **`'json'`**: Handle everything (TypedArrays, BigInt, NaN) - fully JSON-safe


[#1307](https://github.com/RobotWebTools/rclnodejs/issues/1307)
