### PR TITLE
Add nodejs v25 for actions

### DIFF
--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.X, 24.X]
+        node-version: [24.X, 25.X]
         architecture: [x64]
         ros_distribution:
           - humble

--- a/.github/workflows/prebuild-linux-arm64.yml
+++ b/.github/workflows/prebuild-linux-arm64.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.X]
+        node-version: [24.X]
         architecture: [arm64]
         ros_distribution:
           - humble

--- a/.github/workflows/prebuild-linux-x64.yml
+++ b/.github/workflows/prebuild-linux-x64.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.X]
+        node-version: [24.X]
         architecture: [x64]
         ros_distribution:
           - humble

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.X]
+        node-version: [24.X]
         ros_distribution:
           - humble
           - jazzy


### PR DESCRIPTION
This PR updates the Node.js versions used in GitHub Actions workflows. The primary change is updating from Node.js v22 to v24 across multiple workflow files, and adding v25 to the linux-x64 build and test workflow.

**Key Changes:**
- Node.js v22 replaced with v24 in Windows and Linux prebuild workflows
- Node.js test matrix expanded to include v25 alongside v24 in the linux-x64 build and test workflow

Fix: #1289 