### PR TITLE
Pump nodejs to v24 for actions on arm64

### DIFF
--- a/.github/workflows/linux-arm64-build-and-test.yml
+++ b/.github/workflows/linux-arm64-build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.X]
+        node-version: [24.X]
         architecture: [arm64]
         ros_distribution:
           - humble


### PR DESCRIPTION
This PR updates the Node.js version used in the Linux ARM64 build and test workflow from version 22.X to 24.X.

- Updated Node.js version in CI/CD matrix configuration

Fix: #1289