### PR TITLE
feat: add ParameterWatcher for real time parameter monitoring

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -43,6 +43,7 @@
   - Promise-based service calls implementation
   - Add ParameterClient for external parameter access
   - Add structured error handling with class error hierarchy
+  - Add ParameterWatcher for real-time parameter monitoring
 
 - **[Martins Mozeiko](https://github.com/martins-mozeiko)**
   - QoS new/delete fix

--- a/example/parameter/README.md
+++ b/example/parameter/README.md
@@ -110,6 +110,25 @@ Parameters are ideal for:
   - Lifecycle management
 - **Run Command**: `node parameter-client-advanced-example.js`
 
+#### 5. ParameterWatcher (`parameter-watcher-example.js`)
+
+**Purpose**: Demonstrates watching parameter changes on a remote node in real-time.
+
+- **Functionality**:
+  - Creates a watcher for turtlesim's background color parameters
+  - Listens for parameter change events
+  - Displays current parameter values
+  - Shows real-time updates when parameters change
+- **Features**:
+  - Event-driven parameter monitoring
+  - Automatic filtering by node and parameter names
+  - Real-time change notifications
+  - Built on top of ParameterClient
+  - Simple EventEmitter API
+- **Target Node**: `turtlesim` (run: `ros2 run turtlesim turtlesim_node`)
+- **Run Command**: `node parameter-watcher-example.js`
+- **Test Changes**: In another terminal, run `ros2 param set /turtlesim background_r 200`
+
 **ParameterClient Key Features**:
 
 - **Remote Access**: Query/modify parameters on any node
@@ -119,7 +138,7 @@ Parameters are ideal for:
 - **Cancellation**: AbortController integration for request cancellation
 - **Lifecycle Management**: Automatic cleanup when parent node is destroyed
 
-**Public API**:
+**ParameterClient Public API**:
 
 - `remoteNodeName` (getter) - Get the target node name
 - `waitForService(timeout?)` - Wait for remote services to be available
@@ -132,6 +151,27 @@ Parameters are ideal for:
 - `getParameterTypes(names, options?)` - Get parameter types
 - `isDestroyed()` - Check if client has been destroyed
 - `destroy()` - Clean up and destroy the client
+
+**ParameterWatcher Key Features**:
+
+- **Real-Time Monitoring**: Automatically notified when watched parameters change
+- **Event-Driven**: Uses EventEmitter pattern for clean async code
+- **Filtered**: Only notifies about relevant parameter changes
+- **Flexible**: Add/remove parameters from watch list dynamically
+- **Built on ParameterClient**: Can query current values at any time
+- **Lifecycle Management**: Automatic cleanup when parent node is destroyed
+
+**ParameterWatcher Public API**:
+
+- `remoteNodeName` (getter) - Get the target node name
+- `watchedParameters` (getter) - Get list of watched parameter names
+- `start(timeout?)` - Start watching for parameter changes
+- `getCurrentValues(options?)` - Get current values of all watched parameters
+- `addParameter(name)` - Add a parameter to the watch list
+- `removeParameter(name)` - Remove a parameter from the watch list
+- `on('change', callback)` - Listen for parameter change events
+- `isDestroyed()` - Check if watcher has been destroyed
+- `destroy()` - Clean up and destroy the watcher
 
 ## How to Run the Examples
 
@@ -244,6 +284,46 @@ max_speed descriptor: {
   integer_range: []
 }
 ```
+
+### Running ParameterWatcher Example
+
+First, in one terminal, run turtlesim:
+
+```bash
+ros2 run turtlesim turtlesim_node
+```
+
+Then in another terminal:
+
+```bash
+cd example/parameter
+node parameter-watcher-example.js
+```
+
+**Expected Output**:
+
+```
+Watching: [ 'background_r', 'background_g' ]
+Added background_b. Now watching: [ 'background_r', 'background_g', 'background_b' ]
+Removed background_g. Now watching: [ 'background_r', 'background_b' ]
+```
+
+Now in a third terminal, change a parameter to see real-time updates:
+
+```bash
+ros2 param set /turtlesim background_r 200
+ros2 param set /turtlesim background_b 100
+ros2 param set /turtlesim background_g 50  # This won't trigger (removed from watch list)
+```
+
+You'll see output like:
+
+```
+background_r changed to 200
+background_b changed to 100
+```
+
+Note: `background_g` changes won't be displayed since it was removed from the watch list.
 
 ## Using ROS 2 Parameter Tools
 

--- a/example/parameter/parameter-watcher-example.js
+++ b/example/parameter/parameter-watcher-example.js
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 Mahmoud Alghalayini. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const rclnodejs = require('../../index.js');
+
+async function main() {
+  await rclnodejs.init();
+
+  const node = rclnodejs.createNode('watcher_node');
+
+  const watcher = node.createParameterWatcher('turtlesim', [
+    'background_r',
+    'background_g',
+  ]);
+
+  watcher.on('change', (params) => {
+    params.forEach((p) => {
+      console.log(`${p.name} changed to ${p.value.integer_value}`);
+    });
+  });
+
+  try {
+    const available = await watcher.start(10000);
+
+    if (!available) {
+      console.log('Turtlesim node not available. Please run:');
+      console.log('  ros2 run turtlesim turtlesim_node');
+      return;
+    }
+
+    console.log('Watching:', watcher.watchedParameters);
+
+    watcher.addParameter('background_b');
+    console.log('Added background_b. Now watching:', watcher.watchedParameters);
+
+    watcher.removeParameter('background_g');
+    console.log(
+      'Removed background_g. Now watching:',
+      watcher.watchedParameters
+    );
+
+    rclnodejs.spin(node);
+  } catch (error) {
+    console.error('Error:', error.message);
+    node.destroy();
+    rclnodejs.shutdown();
+  }
+}
+
+main();

--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ const {
 } = require('./lib/serialization.js');
 const ParameterClient = require('./lib/parameter_client.js');
 const errors = require('./lib/errors.js');
+const ParameterWatcher = require('./lib/parameter_watcher.js');
 const { spawn } = require('child_process');
 
 /**
@@ -221,6 +222,9 @@ let rcl = {
 
   /** {@link ParameterClient} class */
   ParameterClient: ParameterClient,
+
+  /** {@link ParameterWatcher} class */
+  ParameterWatcher: ParameterWatcher,
 
   /** {@link QoS} class */
   QoS: QoS,

--- a/lib/node.js
+++ b/lib/node.js
@@ -39,6 +39,7 @@ const {
 } = require('./errors.js');
 const ParameterService = require('./parameter_service.js');
 const ParameterClient = require('./parameter_client.js');
+const ParameterWatcher = require('./parameter_watcher.js');
 const Publisher = require('./publisher.js');
 const QoS = require('./qos.js');
 const Rates = require('./rate.js');
@@ -121,6 +122,7 @@ class Node extends rclnodejs.ShadowNode {
     this._actionClients = [];
     this._actionServers = [];
     this._parameterClients = [];
+    this._parameterWatchers = [];
     this._rateTimerServer = null;
     this._parameterDescriptors = new Map();
     this._parameters = new Map();
@@ -950,6 +952,30 @@ class Node extends rclnodejs.ShadowNode {
   }
 
   /**
+   * Create a ParameterWatcher for watching parameter changes on a remote node.
+   * @param {string} remoteNodeName - The name of the remote node whose parameters to watch.
+   * @param {string[]} parameterNames - Array of parameter names to watch.
+   * @param {object} [options] - Options for parameter watcher.
+   * @param {number} [options.timeout=5000] - Default timeout in milliseconds for service calls.
+   * @return {ParameterWatcher} - An instance of ParameterWatcher.
+   */
+  createParameterWatcher(remoteNodeName, parameterNames, options = {}) {
+    const watcher = new ParameterWatcher(
+      this,
+      remoteNodeName,
+      parameterNames,
+      options
+    );
+    debug(
+      'Finish creating parameter watcher for remote node = %s.',
+      remoteNodeName
+    );
+    this._parameterWatchers.push(watcher);
+
+    return watcher;
+  }
+
+  /**
    * Create a guard condition.
    * @param {Function} callback - The callback to be called when the guard condition is triggered.
    * @return {GuardCondition} - An instance of GuardCondition.
@@ -986,6 +1012,7 @@ class Node extends rclnodejs.ShadowNode {
     this._actionServers.forEach((actionServer) => actionServer.destroy());
 
     this._parameterClients.forEach((paramClient) => paramClient.destroy());
+    this._parameterWatchers.forEach((watcher) => watcher.destroy());
 
     this.context.onNodeDestroyed(this);
 
@@ -1000,6 +1027,7 @@ class Node extends rclnodejs.ShadowNode {
     this._actionClients = [];
     this._actionServers = [];
     this._parameterClients = [];
+    this._parameterWatchers = [];
 
     if (this._rateTimerServer) {
       this._rateTimerServer.shutdown();
@@ -1097,6 +1125,19 @@ class Node extends rclnodejs.ShadowNode {
     }
     this._removeEntityFromArray(parameterClient, this._parameterClients);
     parameterClient.destroy();
+  }
+
+  /**
+   * Destroy a ParameterWatcher.
+   * @param {ParameterWatcher} watcher - The ParameterWatcher to be destroyed.
+   * @return {undefined}
+   */
+  destroyParameterWatcher(watcher) {
+    if (!(watcher instanceof ParameterWatcher)) {
+      throw new TypeError('Invalid argument');
+    }
+    this._removeEntityFromArray(watcher, this._parameterWatchers);
+    watcher.destroy();
   }
 
   /**

--- a/lib/parameter_client.js
+++ b/lib/parameter_client.js
@@ -25,6 +25,7 @@ const {
   OperationError,
 } = require('./errors.js');
 const validator = require('./validator.js');
+const { normalizeNodeName } = require('./utils.js');
 const debug = require('debug')('rclnodejs:parameter_client');
 
 /**
@@ -58,7 +59,7 @@ class ParameterClient {
     }
 
     this.#node = node;
-    this.#remoteNodeName = this.#normalizeNodeName(remoteNodeName);
+    this.#remoteNodeName = normalizeNodeName(remoteNodeName);
     validator.validateNodeName(this.#remoteNodeName);
 
     this.#timeout = options.timeout || 5000;
@@ -472,16 +473,6 @@ class ParameterClient {
       default:
         return null;
     }
-  }
-
-  /**
-   * Normalize a node name by removing leading slash if present.
-   * @private
-   * @param {string} nodeName - The node name to normalize.
-   * @return {string} - The normalized node name.
-   */
-  #normalizeNodeName(nodeName) {
-    return nodeName.startsWith('/') ? nodeName.substring(1) : nodeName;
   }
 
   /**

--- a/lib/parameter_watcher.js
+++ b/lib/parameter_watcher.js
@@ -1,0 +1,309 @@
+// Copyright (c) 2025 Mahmoud Alghalayini. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const EventEmitter = require('events');
+const { TypeValidationError, OperationError } = require('./errors');
+const { normalizeNodeName } = require('./utils');
+const debug = require('debug')('rclnodejs:parameter_watcher');
+
+/**
+ * @class ParameterWatcher - Watches parameter changes on a remote node
+ *
+ * Subscribes to /parameter_events and emits 'change' events when
+ * watched parameters on the target node are modified.
+ *
+ * @extends EventEmitter
+ */
+class ParameterWatcher extends EventEmitter {
+  #node;
+  #paramClient;
+  #subscription;
+  #watchedParams;
+  #remoteNodeName;
+  #destroyed;
+
+  /**
+   * Create a ParameterWatcher instance.
+   * Note: Use node.createParameterWatcher() instead of calling this directly.
+   *
+   * @param {object} node - The local rclnodejs Node instance
+   * @param {string} remoteNodeName - Name of the remote node to watch
+   * @param {string[]} parameterNames - Array of parameter names to watch
+   * @param {object} [options] - Options for the parameter client
+   * @param {number} [options.timeout=5000] - Default timeout for parameter operations
+   * @hideconstructor
+   */
+  constructor(node, remoteNodeName, parameterNames, options = {}) {
+    super();
+
+    if (!node || typeof node.createParameterClient !== 'function') {
+      throw new TypeValidationError('node', node, 'Node instance', {
+        entityType: 'parameter watcher',
+      });
+    }
+
+    if (typeof remoteNodeName !== 'string' || remoteNodeName.trim() === '') {
+      throw new TypeValidationError(
+        'remoteNodeName',
+        remoteNodeName,
+        'non-empty string',
+        {
+          entityType: 'parameter watcher',
+        }
+      );
+    }
+
+    if (!Array.isArray(parameterNames) || parameterNames.length === 0) {
+      throw new TypeValidationError(
+        'parameterNames',
+        parameterNames,
+        'non-empty array',
+        {
+          entityType: 'parameter watcher',
+        }
+      );
+    }
+
+    this.#node = node;
+    this.#watchedParams = new Set(parameterNames);
+    this.#paramClient = node.createParameterClient(remoteNodeName, options);
+    // Cache the remote node name for error messages (in case paramClient is destroyed)
+    this.#remoteNodeName = this.#paramClient.remoteNodeName;
+    this.#subscription = null;
+    this.#destroyed = false;
+
+    debug(
+      'Created ParameterWatcher for node=%s, params=%o',
+      remoteNodeName,
+      parameterNames
+    );
+  }
+
+  /**
+   * Get the remote node name being watched.
+   * @type {string}
+   * @readonly
+   */
+  get remoteNodeName() {
+    return this.#remoteNodeName;
+  }
+
+  /**
+   * Get the list of watched parameter names.
+   * @type {string[]}
+   * @readonly
+   */
+  get watchedParameters() {
+    return Array.from(this.#watchedParams);
+  }
+
+  /**
+   * Start watching for parameter changes.
+   * Waits for the remote node's parameter services and subscribes to parameter events.
+   *
+   * @param {number} [timeout=5000] - Timeout in milliseconds to wait for services
+   * @returns {Promise<boolean>} Resolves to true when watching has started
+   * @throws {Error} If the watcher has been destroyed
+   */
+  async start(timeout = 5000) {
+    this.#checkNotDestroyed();
+
+    debug('Starting ParameterWatcher for node=%s', this.remoteNodeName);
+
+    const available = await this.#paramClient.waitForService(timeout);
+
+    if (!available) {
+      debug(
+        'Parameter services not available for node=%s',
+        this.remoteNodeName
+      );
+      return false;
+    }
+
+    if (!this.#subscription) {
+      this.#subscription = this.#node.createSubscription(
+        'rcl_interfaces/msg/ParameterEvent',
+        '/parameter_events',
+        (event) => this.#handleParameterEvent(event)
+      );
+
+      debug('Subscribed to /parameter_events');
+    }
+
+    return true;
+  }
+
+  /**
+   * Get current values of all watched parameters.
+   *
+   * @param {object} [options] - Options for the parameter client
+   * @param {number} [options.timeout] - Timeout in milliseconds
+   * @param {AbortSignal} [options.signal] - AbortSignal for cancellation
+   * @returns {Promise<Parameter[]>} Array of Parameter objects
+   * @throws {Error} If the watcher has been destroyed
+   */
+  async getCurrentValues(options) {
+    this.#checkNotDestroyed();
+    return await this.#paramClient.getParameters(
+      Array.from(this.#watchedParams),
+      options
+    );
+  }
+
+  /**
+   * Add a parameter name to the watch list.
+   *
+   * @param {string} name - Parameter name to watch
+   * @throws {TypeError} If name is not a string
+   * @throws {Error} If the watcher has been destroyed
+   */
+  addParameter(name) {
+    this.#checkNotDestroyed();
+
+    if (typeof name !== 'string' || name.trim() === '') {
+      throw new TypeValidationError('name', name, 'non-empty string', {
+        entityType: 'parameter watcher',
+        entityName: this.remoteNodeName,
+      });
+    }
+
+    const wasAdded = !this.#watchedParams.has(name);
+    this.#watchedParams.add(name);
+
+    if (wasAdded) {
+      debug('Added parameter to watch list: %s', name);
+    }
+  }
+
+  /**
+   * Remove a parameter name from the watch list.
+   *
+   * @param {string} name - Parameter name to stop watching
+   * @returns {boolean} True if the parameter was in the watch list
+   * @throws {Error} If the watcher has been destroyed
+   */
+  removeParameter(name) {
+    this.#checkNotDestroyed();
+
+    const wasRemoved = this.#watchedParams.delete(name);
+
+    if (wasRemoved) {
+      debug('Removed parameter from watch list: %s', name);
+    }
+
+    return wasRemoved;
+  }
+
+  /**
+   * Check if the watcher has been destroyed.
+   *
+   * @returns {boolean} True if destroyed
+   */
+  isDestroyed() {
+    return this.#destroyed;
+  }
+
+  /**
+   * Destroy the watcher and clean up resources.
+   * Unsubscribes from parameter events and destroys the parameter client.
+   */
+  destroy() {
+    if (this.#destroyed) {
+      return;
+    }
+
+    debug('Destroying ParameterWatcher for node=%s', this.remoteNodeName);
+
+    if (this.#subscription) {
+      try {
+        this.#node.destroySubscription(this.#subscription);
+      } catch (error) {
+        debug('Error destroying subscription: %s', error.message);
+      }
+      this.#subscription = null;
+    }
+
+    if (this.#paramClient) {
+      try {
+        this.#node.destroyParameterClient(this.#paramClient);
+      } catch (error) {
+        debug('Error destroying parameter client: %s', error.message);
+      }
+      this.#paramClient = null;
+    }
+
+    this.removeAllListeners();
+
+    this.#destroyed = true;
+  }
+
+  /**
+   * Handle parameter event from /parameter_events topic.
+   * @private
+   */
+  #handleParameterEvent(event) {
+    if (normalizeNodeName(event.node) !== this.remoteNodeName) {
+      return;
+    }
+
+    const relevantChanges = [];
+
+    if (event.new_parameters) {
+      const newParams = event.new_parameters.filter((p) =>
+        this.#watchedParams.has(p.name)
+      );
+      relevantChanges.push(...newParams);
+    }
+
+    if (event.changed_parameters) {
+      const changedParams = event.changed_parameters.filter((p) =>
+        this.#watchedParams.has(p.name)
+      );
+      relevantChanges.push(...changedParams);
+    }
+
+    if (event.deleted_parameters) {
+      const deletedParams = event.deleted_parameters.filter((p) =>
+        this.#watchedParams.has(p.name)
+      );
+      relevantChanges.push(...deletedParams);
+    }
+
+    if (relevantChanges.length > 0) {
+      debug(
+        'Parameter change detected: %o',
+        relevantChanges.map((p) => p.name)
+      );
+      this.emit('change', relevantChanges);
+    }
+  }
+
+  /**
+   * Check if the watcher has been destroyed and throw if so.
+   * @private
+   */
+  #checkNotDestroyed() {
+    if (this.#destroyed) {
+      throw new OperationError('ParameterWatcher has been destroyed', {
+        code: 'WATCHER_DESTROYED',
+        entityType: 'parameter watcher',
+        entityName: this.remoteNodeName,
+      });
+    }
+  }
+}
+
+module.exports = ParameterWatcher;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -184,6 +184,25 @@ function detectUbuntuCodename() {
 }
 
 /**
+ * Normalize a ROS 2 node name by removing the leading slash if present.
+ *
+ * ROS 2 node names may be specified with or without a leading slash depending
+ * on the context. This utility ensures consistent representation without the
+ * leading slash, which is the standard format for most ROS 2 APIs.
+ *
+ * @param {string} nodeName - The node name to normalize
+ * @returns {string} The normalized node name without leading slash
+ *
+ * @example
+ * normalizeNodeName('my_node')    // 'my_node'
+ * normalizeNodeName('/my_node')   // 'my_node'
+ * normalizeNodeName('/ns/my_node') // 'ns/my_node'
+ */
+function normalizeNodeName(nodeName) {
+  return nodeName.startsWith('/') ? nodeName.substring(1) : nodeName;
+}
+
+/**
  * Check if two numbers are equal within a given tolerance.
  *
  * This function compares two numbers using both relative and absolute tolerance,
@@ -308,6 +327,7 @@ module.exports = {
   // General utilities
   detectUbuntuCodename,
   isClose,
+  normalizeNodeName,
 
   // File system utilities (async)
   ensureDir,

--- a/test/test-parameter-watcher.js
+++ b/test/test-parameter-watcher.js
@@ -1,0 +1,606 @@
+// Copyright (c) 2025 Mahmoud Alghalayini. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const rclnodejs = require('../index.js');
+
+describe('ParameterWatcher tests', function () {
+  this.timeout(60 * 1000);
+
+  let targetNode;
+  let clientNode;
+  let watcher;
+
+  before(function () {
+    return rclnodejs.init();
+  });
+
+  after(function () {
+    rclnodejs.shutdown();
+  });
+
+  beforeEach(async function () {
+    targetNode = rclnodejs.createNode('target_node');
+    clientNode = rclnodejs.createNode('client_node');
+
+    targetNode.declareParameter(
+      new rclnodejs.Parameter(
+        'test_int',
+        rclnodejs.ParameterType.PARAMETER_INTEGER,
+        BigInt(42)
+      )
+    );
+    targetNode.declareParameter(
+      new rclnodejs.Parameter(
+        'test_double',
+        rclnodejs.ParameterType.PARAMETER_DOUBLE,
+        3.14
+      )
+    );
+    targetNode.declareParameter(
+      new rclnodejs.Parameter(
+        'test_string',
+        rclnodejs.ParameterType.PARAMETER_STRING,
+        'hello'
+      )
+    );
+
+    watcher = clientNode.createParameterWatcher('target_node', [
+      'test_int',
+      'test_double',
+    ]);
+
+    rclnodejs.spin(targetNode);
+    rclnodejs.spin(clientNode);
+
+    await watcher.start(5000);
+  });
+
+  afterEach(function () {
+    try {
+      if (watcher && !watcher.isDestroyed()) {
+        watcher.destroy();
+      }
+    } catch (e) {
+      // Ignore cleanup errors
+    }
+
+    try {
+      if (clientNode) {
+        clientNode.stop();
+        clientNode.destroy();
+      }
+    } catch (e) {
+      // Ignore cleanup errors
+    }
+
+    try {
+      if (targetNode) {
+        targetNode.stop();
+        targetNode.destroy();
+      }
+    } catch (e) {
+      // Ignore cleanup errors
+    }
+
+    watcher = null;
+    clientNode = null;
+    targetNode = null;
+  });
+
+  describe('Constructor and properties', function () {
+    it('should create ParameterWatcher with valid arguments', function () {
+      const w = clientNode.createParameterWatcher('target_node', [
+        'param1',
+        'param2',
+      ]);
+      assert.strictEqual(w.remoteNodeName, 'target_node');
+      assert.deepStrictEqual(w.watchedParameters, ['param1', 'param2']);
+      w.destroy();
+    });
+
+    it('should throw error if remote node name is null', function () {
+      assert.throws(() => {
+        clientNode.createParameterWatcher(null, ['param1']);
+      }, rclnodejs.TypeValidationError);
+    });
+
+    it('should throw error if remote node name is empty', function () {
+      assert.throws(() => {
+        clientNode.createParameterWatcher('', ['param1']);
+      }, rclnodejs.TypeValidationError);
+    });
+
+    it('should throw error if parameter names is not an array', function () {
+      assert.throws(() => {
+        clientNode.createParameterWatcher('target_node', 'not_array');
+      }, rclnodejs.TypeValidationError);
+    });
+
+    it('should throw error if parameter names is empty array', function () {
+      assert.throws(() => {
+        clientNode.createParameterWatcher('target_node', []);
+      }, rclnodejs.TypeValidationError);
+    });
+
+    it('should normalize node name by removing leading slash', function () {
+      const w = clientNode.createParameterWatcher('/target_node', ['param1']);
+      assert.strictEqual(w.remoteNodeName, 'target_node');
+      w.destroy();
+    });
+  });
+
+  describe('start', function () {
+    it('should start watching and return true when services available', async function () {
+      const w = clientNode.createParameterWatcher('target_node', ['test_int']);
+      const started = await w.start(5000);
+      assert.strictEqual(started, true);
+      w.destroy();
+    });
+
+    it('should return false when services not available', async function () {
+      const w = clientNode.createParameterWatcher('nonexistent_node', [
+        'param1',
+      ]);
+      const started = await w.start(1000);
+      assert.strictEqual(started, false);
+      w.destroy();
+    });
+
+    it('should throw error if watcher is destroyed', async function () {
+      const w = clientNode.createParameterWatcher('target_node', ['test_int']);
+      w.destroy();
+
+      try {
+        await w.start();
+        assert.fail('Should have thrown error');
+      } catch (error) {
+        assert.ok(error.message.includes('destroyed'));
+      }
+    });
+  });
+
+  describe('change event', function () {
+    it('should emit change event when watched parameter changes', function (done) {
+      this.timeout(10000);
+
+      watcher.on('change', (params) => {
+        assert.ok(Array.isArray(params));
+        assert.ok(params.length > 0);
+        const changedParam = params.find((p) => p.name === 'test_int');
+        assert.ok(changedParam);
+        done();
+      });
+
+      setTimeout(() => {
+        targetNode.setParameter(
+          new rclnodejs.Parameter(
+            'test_int',
+            rclnodejs.ParameterType.PARAMETER_INTEGER,
+            BigInt(100)
+          )
+        );
+      }, 100);
+    });
+
+    it('should not emit change event for unwatched parameters', function (done) {
+      this.timeout(10000);
+      let changeCount = 0;
+
+      watcher.on('change', (params) => {
+        changeCount++;
+        const hasUnwatched = params.some((p) => p.name === 'test_string');
+        assert.strictEqual(hasUnwatched, false);
+      });
+
+      targetNode.setParameter(
+        new rclnodejs.Parameter(
+          'test_int',
+          rclnodejs.ParameterType.PARAMETER_INTEGER,
+          BigInt(200)
+        )
+      );
+
+      setTimeout(() => {
+        targetNode.setParameter(
+          new rclnodejs.Parameter(
+            'test_string',
+            rclnodejs.ParameterType.PARAMETER_STRING,
+            'changed'
+          )
+        );
+      }, 100);
+
+      setTimeout(() => {
+        assert.strictEqual(changeCount, 1);
+        done();
+      }, 500);
+    });
+
+    it('should emit change event for multiple parameter changes', function (done) {
+      this.timeout(10000);
+
+      // Use once() to ensure done() is only called once
+      watcher.once('change', (params) => {
+        assert.ok(params.length >= 1);
+        done();
+      });
+
+      setTimeout(() => {
+        targetNode.setParameters([
+          new rclnodejs.Parameter(
+            'test_int',
+            rclnodejs.ParameterType.PARAMETER_INTEGER,
+            BigInt(111)
+          ),
+          new rclnodejs.Parameter(
+            'test_double',
+            rclnodejs.ParameterType.PARAMETER_DOUBLE,
+            2.71
+          ),
+        ]);
+      }, 100);
+    });
+  });
+
+  describe('getCurrentValues', function () {
+    it('should get current values of watched parameters', async function () {
+      const values = await watcher.getCurrentValues();
+      assert.ok(Array.isArray(values));
+      assert.strictEqual(values.length, 2);
+
+      const intParam = values.find((p) => p.name === 'test_int');
+      const doubleParam = values.find((p) => p.name === 'test_double');
+
+      assert.ok(intParam);
+      assert.strictEqual(intParam.value, BigInt(42));
+      assert.ok(doubleParam);
+      assert.strictEqual(doubleParam.value, 3.14);
+    });
+
+    it('should throw error if watcher is destroyed', async function () {
+      watcher.destroy();
+
+      try {
+        await watcher.getCurrentValues();
+        assert.fail('Should have thrown error');
+      } catch (error) {
+        assert.ok(error.message.includes('destroyed'));
+      }
+    });
+
+    it('should support timeout option', async function () {
+      // Create watcher for non-existent node to ensure timeout occurs
+      const slowWatcher = clientNode.createParameterWatcher(
+        'nonexistent_slow_node',
+        ['param1']
+      );
+      await slowWatcher.start(1000).catch(() => {}); // Services won't be available
+
+      try {
+        await slowWatcher.getCurrentValues({ timeout: 1 });
+        assert.fail('Should have timed out');
+      } catch (error) {
+        assert.strictEqual(error.name, 'TimeoutError');
+      } finally {
+        slowWatcher.destroy();
+      }
+    });
+
+    it('should support AbortSignal', async function () {
+      // Create watcher for non-existent node to ensure abort can occur
+      const slowWatcher = clientNode.createParameterWatcher(
+        'nonexistent_slow_node',
+        ['param1']
+      );
+      await slowWatcher.start(1000).catch(() => {}); // Services won't be available
+
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), 1);
+
+      try {
+        await slowWatcher.getCurrentValues({ signal: controller.signal });
+        assert.fail('Should have been aborted');
+      } catch (error) {
+        assert.strictEqual(error.name, 'AbortError');
+      } finally {
+        slowWatcher.destroy();
+      }
+    });
+  });
+
+  describe('addParameter', function () {
+    it('should add parameter to watch list', function () {
+      const initialLength = watcher.watchedParameters.length;
+      watcher.addParameter('test_string');
+
+      assert.strictEqual(watcher.watchedParameters.length, initialLength + 1);
+      assert.ok(watcher.watchedParameters.includes('test_string'));
+    });
+
+    it('should not duplicate parameters', function () {
+      watcher.addParameter('test_int');
+      const length = watcher.watchedParameters.length;
+      watcher.addParameter('test_int');
+
+      assert.strictEqual(watcher.watchedParameters.length, length);
+    });
+
+    it('should throw error if name is not a string', function () {
+      assert.throws(() => {
+        watcher.addParameter(123);
+      }, rclnodejs.TypeValidationError);
+    });
+
+    it('should throw error if name is empty string', function () {
+      assert.throws(() => {
+        watcher.addParameter('');
+      }, rclnodejs.TypeValidationError);
+    });
+
+    it('should throw error if watcher is destroyed', function () {
+      watcher.destroy();
+
+      assert.throws(() => {
+        watcher.addParameter('test_string');
+      }, /destroyed/);
+    });
+
+    it('should trigger change event after adding parameter', function (done) {
+      this.timeout(10000);
+
+      watcher.addParameter('test_string');
+
+      watcher.on('change', (params) => {
+        const hasNewParam = params.some((p) => p.name === 'test_string');
+        if (hasNewParam) {
+          done();
+        }
+      });
+
+      setTimeout(() => {
+        targetNode.setParameter(
+          new rclnodejs.Parameter(
+            'test_string',
+            rclnodejs.ParameterType.PARAMETER_STRING,
+            'updated'
+          )
+        );
+      }, 100);
+    });
+  });
+
+  describe('removeParameter', function () {
+    it('should remove parameter from watch list', function () {
+      const initialLength = watcher.watchedParameters.length;
+      const removed = watcher.removeParameter('test_int');
+
+      assert.strictEqual(removed, true);
+      assert.strictEqual(watcher.watchedParameters.length, initialLength - 1);
+      assert.ok(!watcher.watchedParameters.includes('test_int'));
+    });
+
+    it('should return false if parameter not in watch list', function () {
+      const removed = watcher.removeParameter('nonexistent');
+      assert.strictEqual(removed, false);
+    });
+
+    it('should throw error if watcher is destroyed', function () {
+      watcher.destroy();
+
+      assert.throws(() => {
+        watcher.removeParameter('test_int');
+      }, /destroyed/);
+    });
+
+    it('should not trigger change event after removing parameter', function (done) {
+      this.timeout(10000);
+      let changeCount = 0;
+
+      watcher.removeParameter('test_int');
+
+      watcher.on('change', (params) => {
+        changeCount++;
+        const hasRemoved = params.some((p) => p.name === 'test_int');
+        assert.strictEqual(hasRemoved, false);
+      });
+
+      setTimeout(() => {
+        targetNode.setParameter(
+          new rclnodejs.Parameter(
+            'test_int',
+            rclnodejs.ParameterType.PARAMETER_INTEGER,
+            BigInt(999)
+          )
+        );
+      }, 100);
+
+      setTimeout(() => {
+        assert.strictEqual(changeCount, 0);
+        done();
+      }, 500);
+    });
+  });
+
+  describe('Lifecycle management', function () {
+    it('should destroy watcher', function () {
+      const w = clientNode.createParameterWatcher('target_node', ['test_int']);
+      w.destroy();
+      assert.strictEqual(w.isDestroyed(), true);
+    });
+
+    it('should allow multiple destroy calls', function () {
+      const w = clientNode.createParameterWatcher('target_node', ['test_int']);
+      w.destroy();
+      w.destroy();
+      assert.strictEqual(w.isDestroyed(), true);
+    });
+
+    it('should auto-destroy when parent node is destroyed', function () {
+      const node = rclnodejs.createNode('temp_node');
+      const w = node.createParameterWatcher('target_node', ['test_int']);
+
+      assert.strictEqual(w.isDestroyed(), false);
+      node.destroy();
+      assert.strictEqual(w.isDestroyed(), true);
+    });
+
+    it('should destroy via node.destroyParameterWatcher', function () {
+      const node = rclnodejs.createNode('temp_node');
+      const w = node.createParameterWatcher('target_node', ['test_int']);
+
+      assert.strictEqual(w.isDestroyed(), false);
+      node.destroyParameterWatcher(w);
+      assert.strictEqual(w.isDestroyed(), true);
+
+      node.destroy();
+    });
+
+    it('should throw error when calling methods on destroyed watcher', function () {
+      watcher.destroy();
+
+      assert.throws(() => {
+        watcher.addParameter('param1');
+      }, /destroyed/);
+
+      assert.throws(() => {
+        watcher.removeParameter('param1');
+      }, /destroyed/);
+    });
+
+    it('should remove all event listeners on destroy', function () {
+      const w = clientNode.createParameterWatcher('target_node', ['test_int']);
+      w.on('change', () => {});
+      w.on('change', () => {});
+
+      assert.ok(w.listenerCount('change') > 0);
+      w.destroy();
+      assert.strictEqual(w.listenerCount('change'), 0);
+    });
+  });
+
+  describe('watchedParameters getter', function () {
+    it('should return array of watched parameter names', function () {
+      const params = watcher.watchedParameters;
+      assert.ok(Array.isArray(params));
+      assert.strictEqual(params.length, 2);
+      assert.ok(params.includes('test_int'));
+      assert.ok(params.includes('test_double'));
+    });
+
+    it('should return a copy, not the original set', function () {
+      const params1 = watcher.watchedParameters;
+      const params2 = watcher.watchedParameters;
+
+      assert.notStrictEqual(params1, params2);
+      assert.deepStrictEqual(params1, params2);
+    });
+
+    it('should reflect changes after add/remove', function () {
+      watcher.addParameter('new_param');
+      assert.ok(watcher.watchedParameters.includes('new_param'));
+
+      watcher.removeParameter('test_int');
+      assert.ok(!watcher.watchedParameters.includes('test_int'));
+    });
+  });
+
+  describe('remoteNodeName getter', function () {
+    it('should return the remote node name', function () {
+      assert.strictEqual(watcher.remoteNodeName, 'target_node');
+    });
+  });
+
+  describe('Error cases', function () {
+    it('should handle parameter events from other nodes', function (done) {
+      this.timeout(10000);
+      let changeCount = 0;
+
+      watcher.on('change', () => {
+        changeCount++;
+      });
+
+      const otherNode = rclnodejs.createNode('other_node');
+      otherNode.declareParameter(
+        new rclnodejs.Parameter(
+          'test_int',
+          rclnodejs.ParameterType.PARAMETER_INTEGER,
+          BigInt(1)
+        )
+      );
+      rclnodejs.spin(otherNode);
+
+      setTimeout(() => {
+        otherNode.setParameter(
+          new rclnodejs.Parameter(
+            'test_int',
+            rclnodejs.ParameterType.PARAMETER_INTEGER,
+            BigInt(2)
+          )
+        );
+      }, 100);
+
+      setTimeout(() => {
+        assert.strictEqual(changeCount, 0);
+        otherNode.destroy();
+        done();
+      }, 500);
+    });
+
+    it('should handle empty parameter event', function (done) {
+      this.timeout(10000);
+      let eventReceived = false;
+
+      watcher.on('change', () => {
+        eventReceived = true;
+      });
+
+      setTimeout(() => {
+        assert.strictEqual(eventReceived, false);
+        done();
+      }, 500);
+    });
+  });
+
+  describe('Integration with ParameterClient', function () {
+    it('should use underlying ParameterClient correctly', async function () {
+      const values = await watcher.getCurrentValues();
+      assert.ok(Array.isArray(values));
+      assert.strictEqual(values.length, 2);
+    });
+
+    it('should share timeout option with ParameterClient', async function () {
+      // Use non-existent node to ensure timeout occurs
+      const w = clientNode.createParameterWatcher(
+        'nonexistent_timeout_node',
+        ['test_int'],
+        {
+          timeout: 100,
+        }
+      );
+      await w.start(1000).catch(() => {}); // Services won't be available
+
+      try {
+        await w.getCurrentValues({ timeout: 1 });
+        assert.fail('Should have timed out');
+      } catch (error) {
+        assert.strictEqual(error.name, 'TimeoutError');
+      } finally {
+        w.destroy();
+      }
+    });
+  });
+});

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -18,6 +18,7 @@
 /// <reference path="./node_options.d.ts" />
 /// <reference path="./parameter.d.ts" />
 /// <reference path="./parameter_client.d.ts" />
+/// <reference path="./parameter_watcher.d.ts" />
 /// <reference path="./publisher.d.ts" />
 /// <reference path="./qos.d.ts" />
 /// <reference path="./rate.d.ts" />

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -420,6 +420,20 @@ declare module 'rclnodejs' {
     ): ParameterClient;
 
     /**
+     * Create a ParameterWatcher for watching parameter changes on a remote node.
+     *
+     * @param remoteNodeName - The name of the remote node whose parameters to watch.
+     * @param parameterNames - Array of parameter names to watch.
+     * @param options - Options for parameter watcher.
+     * @returns An instance of ParameterWatcher.
+     */
+    createParameterWatcher(
+      remoteNodeName: string,
+      parameterNames: string[],
+      options?: { timeout?: number }
+    ): ParameterWatcher;
+
+    /**
      * Create a guard condition.
      *
      * @param callback - The callback to be called when the guard condition is triggered.
@@ -472,6 +486,13 @@ declare module 'rclnodejs' {
      * @param parameterClient - ParameterClient to be destroyed.
      */
     destroyParameterClient(parameterClient: ParameterClient): void;
+
+    /**
+     * Destroy a ParameterWatcher.
+     *
+     * @param watcher - ParameterWatcher to be destroyed.
+     */
+    destroyParameterWatcher(watcher: ParameterWatcher): void;
 
     /**
      * Destroy a Timer.

--- a/types/parameter_watcher.d.ts
+++ b/types/parameter_watcher.d.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2025 Mahmoud Alghalayini. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+declare module 'rclnodejs' {
+  import { EventEmitter } from 'events';
+
+  /**
+   * Options for ParameterWatcher constructor.
+   */
+  export interface ParameterWatcherOptions {
+    /**
+     * Default timeout in milliseconds for service calls.
+     * @default 5000
+     */
+    timeout?: number;
+  }
+
+  /**
+   * ParameterWatcher - Watches parameter changes on a remote node.
+   *
+   * Subscribes to /parameter_events and emits 'change' events when
+   * watched parameters on the target node are modified.
+   */
+  class ParameterWatcher extends EventEmitter {
+    /**
+     * Get the remote node name being watched.
+     */
+    readonly remoteNodeName: string;
+
+    /**
+     * Get the list of watched parameter names.
+     */
+    readonly watchedParameters: string[];
+
+    /**
+     * Start watching for parameter changes.
+     * Waits for the remote node's parameter services and subscribes to parameter events.
+     *
+     * @param timeout - Timeout in milliseconds to wait for services.
+     * @returns Promise that resolves to true when watching has started.
+     */
+    start(timeout?: number): Promise<boolean>;
+
+    /**
+     * Get current values of all watched parameters.
+     *
+     * @param options - Optional request options (timeout, signal).
+     * @returns Promise that resolves to an array of Parameter objects.
+     */
+    getCurrentValues(options?: {
+      timeout?: number;
+      signal?: AbortSignal;
+    }): Promise<Parameter[]>;
+
+    /**
+     * Add a parameter name to the watch list.
+     *
+     * @param name - Parameter name to watch.
+     */
+    addParameter(name: string): void;
+
+    /**
+     * Remove a parameter name from the watch list.
+     *
+     * @param name - Parameter name to stop watching.
+     * @returns True if the parameter was in the watch list.
+     */
+    removeParameter(name: string): boolean;
+
+    /**
+     * Check if the watcher has been destroyed.
+     *
+     * @returns True if destroyed.
+     */
+    isDestroyed(): boolean;
+
+    /**
+     * Destroy the watcher and clean up resources.
+     * Unsubscribes from parameter events and destroys the parameter client.
+     */
+    destroy(): void;
+
+    /**
+     * Event emitted when watched parameters change.
+     *
+     * @event change
+     * @param params - Array of changed parameters (ParameterValue messages).
+     */
+    on(event: 'change', listener: (params: any[]) => void): this;
+    once(event: 'change', listener: (params: any[]) => void): this;
+    emit(event: 'change', params: any[]): boolean;
+  }
+}


### PR DESCRIPTION
**Public API Changes**:
- `remoteNodeName` (getter)
- `watchedParameters` (getter)
- `start(timeout?)` - Start watching
- `getCurrentValues(options?)` - Get current values
- `addParameter(name)` - Add to watch list
- `removeParameter(name)` - Remove from watch list
- `on('change', callback)` - Listen for changes
- `isDestroyed()` / `destroy()`


### Implementation Details

**Core Class**: `lib/parameter_watcher.js`
- Subscribes to `/parameter_events` topic
- Filters events by node name and parameter names
- Emits `'change'` event when watched parameters change
- Provides `addParameter()` / `removeParameter()` for dynamic management
- Integrates with Node lifecycle for automatic cleanup

**Node Integration**:
- `node.createParameterWatcher(remoteNodeName, parameterNames, options)`
- `node.destroyParameterWatcher(watcher)`
- Auto-destroy when parent node is destroyed


[1325](https://github.com/RobotWebTools/rclnodejs/issues/1325)
