### PR TITLE
Pump checkout to v6.0.0

### DIFF
--- a/.github/workflows/linux-arm64-build-and-test.yml
+++ b/.github/workflows/linux-arm64-build-and-test.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         sudo apt install ros-${{ matrix.ros_distribution }}-test-msgs
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Fix permissions
       run: |

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         sudo apt install ros-${{ matrix.ros_distribution }}-test-msgs
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Build and test rclnodejs
       run: |

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Prebuild - Setup VS Dev Environment
       uses: seanmiddleditch/gha-setup-vsdevenv@v4
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Build rclnodejs
       shell: cmd


### PR DESCRIPTION
This PR upgrades the `actions/checkout` action from v5 to v6 across three GitHub workflow files for build and test automation.

- Consistent version bump of `actions/checkout` from v5 to v6 across all modified workflow files
- No other changes to workflow logic or configuration
- Ensures the CI/CD pipeline uses the latest version of the checkout action

Fix: #1327 