### PR TITLE
Add assertLiveliness() method for publisher

### DIFF
--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -113,6 +113,14 @@ class Publisher extends Entity {
   }
 
   /**
+   * Manually assert that this Publisher is alive (for RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC).
+   * @return {undefined}
+   */
+  assertLiveliness() {
+    rclnodejs.assertLiveliness(this._handle);
+  }
+
+  /**
    * Get the event handlers for this publisher.
    * @returns {Array} The array of event handlers for this publisher.
    */

--- a/lib/qos.js
+++ b/lib/qos.js
@@ -58,6 +58,24 @@ let DurabilityPolicy = {
   RMW_QOS_POLICY_DURABILITY_VOLATILE: 2,
 };
 
+/**
+ * Enum for LivelinessPolicy
+ * @readonly
+ * @enum {number}
+ */
+let LivelinessPolicy = {
+  /** @member {number} */
+  RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT: 0,
+  /** @member {number} */
+  RMW_QOS_POLICY_LIVELINESS_AUTOMATIC: 1,
+  /** @member {number} */
+  RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC: 3,
+  /** @member {number} */
+  RMW_QOS_POLICY_LIVELINESS_UNKNOWN: 4,
+  /** @member {number} */
+  RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE: 5,
+};
+
 /** Class representing middleware quality of service */
 class QoS {
   /**
@@ -73,12 +91,14 @@ class QoS {
     depth = 0,
     reliability = ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT,
     durability = DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT,
+    liveliness = LivelinessPolicy.RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT,
     avoidRosNameSpaceConventions = false
   ) {
     this._history = history;
     this._depth = depth;
     this._reliability = reliability;
     this._durability = durability;
+    this._liveliness = liveliness;
     this._avoidRosNameSpaceConventions = avoidRosNameSpaceConventions;
   }
 
@@ -110,6 +130,16 @@ class QoS {
    */
   static get DurabilityPolicy() {
     return DurabilityPolicy;
+  }
+
+  /**
+   * Get LivelinessPolicy enum.
+   * @name QoS#static get:LivelinessPolicy
+   * @function
+   * @return {LivelinessPolicy}
+   */
+  static get LivelinessPolicy() {
+    return LivelinessPolicy;
   }
 
   /**
@@ -218,6 +248,33 @@ class QoS {
     }
 
     this._durability = durability;
+  }
+
+  /**
+   * Get the liveliness value.
+   * @name QoS#get:liveliness
+   * @function
+   * @return {number}
+   */
+  get liveliness() {
+    return this._liveliness;
+  }
+
+  /**
+   * Set the liveliness value.
+   * @param {number} liveliness - value to be set.
+   * @name QoS#set:liveliness
+   * @function
+   * @return {undefined}
+   */
+  set liveliness(liveliness) {
+    if (typeof liveliness !== 'number') {
+      throw new TypeValidationError('liveliness', liveliness, 'number', {
+        entityType: 'qos',
+      });
+    }
+
+    this._liveliness = liveliness;
   }
 
   /**

--- a/src/rcl_publisher_bindings.cpp
+++ b/src/rcl_publisher_bindings.cpp
@@ -147,6 +147,17 @@ Napi::Value WaitForAllAcked(const Napi::CallbackInfo& info) {
   return env.Undefined();
 }
 
+Napi::Value AssertLiveliness(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  rcl_publisher_t* publisher = reinterpret_cast<rcl_publisher_t*>(
+      RclHandle::Unwrap(info[0].As<Napi::Object>())->ptr());
+
+  THROW_ERROR_IF_NOT_EQUAL(rcl_publisher_assert_liveliness(publisher),
+                           RCL_RET_OK, rcl_get_error_string().str);
+
+  return env.Undefined();
+}
+
 Napi::Object InitPublisherBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("createPublisher", Napi::Function::New(env, CreatePublisher));
   exports.Set("publish", Napi::Function::New(env, Publish));
@@ -155,6 +166,7 @@ Napi::Object InitPublisherBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("getSubscriptionCount",
               Napi::Function::New(env, GetSubscriptionCount));
   exports.Set("waitForAllAcked", Napi::Function::New(env, WaitForAllAcked));
+  exports.Set("assertLiveliness", Napi::Function::New(env, AssertLiveliness));
   return exports;
 }
 

--- a/src/rcl_utilities.cpp
+++ b/src/rcl_utilities.cpp
@@ -55,6 +55,7 @@ std::unique_ptr<rmw_qos_profile_t> GetQosProfileFromObject(
   auto depth = object.Get("depth");
   auto reliability = object.Get("reliability");
   auto durability = object.Get("durability");
+  auto liveliness = object.Get("liveliness");
   auto avoid_ros_namespace_conventions =
       object.Get("avoidRosNameSpaceConventions");
 
@@ -65,6 +66,8 @@ std::unique_ptr<rmw_qos_profile_t> GetQosProfileFromObject(
       reliability.As<Napi::Number>().Uint32Value());
   qos_profile->durability = static_cast<rmw_qos_durability_policy_t>(
       durability.As<Napi::Number>().Uint32Value());
+  qos_profile->liveliness = static_cast<rmw_qos_liveliness_policy_t>(
+      liveliness.As<Napi::Number>().Uint32Value());
   qos_profile->avoid_ros_namespace_conventions =
       avoid_ros_namespace_conventions.As<Napi::Boolean>();
 

--- a/test/test-publisher.js
+++ b/test/test-publisher.js
@@ -69,4 +69,21 @@ describe('rclnodejs publisher test suite', function () {
     publisher.publish('Hello World');
     assert.strictEqual(publisher.waitForAllAcked(BigInt(1000000000)), true);
   });
+
+  it('Test assertLiveliness', function () {
+    const node = rclnodejs.createNode('publisher_node');
+    const String = 'std_msgs/msg/String';
+    const qos = new rclnodejs.QoS(
+      rclnodejs.QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT,
+      0,
+      rclnodejs.QoS.ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT,
+      rclnodejs.QoS.DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT,
+      rclnodejs.QoS.LivelinessPolicy.RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC
+    );
+    const publisher = node.createPublisher(String, 'topic', { qos: qos });
+    assert.doesNotThrow(() => {
+      publisher.assertLiveliness();
+    });
+    rclnodejs.spin(node);
+  });
 });

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -163,6 +163,7 @@ expectType<boolean>(publisher.waitForAllAcked(BigInt(1000)));
 node.createPublisher(TYPE_CLASS, TOPIC, publisher.options, (event: object) => {
   const receivedEvent = event;
 });
+expectType<void>(publisher.assertLiveliness());
 expectType<string>(publisher.loggerName);
 
 // ---- LifecyclePublisher ----

--- a/types/publisher.d.ts
+++ b/types/publisher.d.ts
@@ -39,6 +39,11 @@ declare module 'rclnodejs' {
     waitForAllAcked(timeout: bigint): boolean;
 
     /**
+     * Manually assert that this Publisher is alive (for RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC).
+     */
+    assertLiveliness(): void;
+
+    /**
      * Get the logger name for this publisher.
      */
     readonly loggerName: string;

--- a/types/qos.d.ts
+++ b/types/qos.d.ts
@@ -11,6 +11,7 @@ declare module 'rclnodejs' {
      * @param depth - The depth value, default = 0.
      * @param reliability - The reliability value, default = RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT
      * @param durability - The durability value, default = RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT
+     * @param liveliness - The liveliness value, default = RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT
      * @param avoidRosNameSpaceConventions - The avoidRosNameSpaceConventions value, default = false.
      */
     constructor(
@@ -18,6 +19,7 @@ declare module 'rclnodejs' {
       depth?: number,
       reliability?: QoS.ReliabilityPolicy,
       durability?: QoS.DurabilityPolicy,
+      liveliness?: QoS.LivelinessPolicy,
       avoidRosNameSpaceConventions?: boolean
     );
 
@@ -40,6 +42,11 @@ declare module 'rclnodejs' {
      * Get the durability value.
      */
     durability: QoS.DurabilityPolicy;
+
+    /**
+     * Get the liveliness value.
+     */
+    liveliness: QoS.LivelinessPolicy;
 
     /**
      * Get the avoidRosNameSpaceConventions value.
@@ -114,6 +121,17 @@ declare module 'rclnodejs' {
       RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT = 0,
       RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL = 1,
       RMW_QOS_POLICY_DURABILITY_VOLATILE = 2,
+    }
+
+    /**
+     * LivelinessPolicy
+     */
+    enum LivelinessPolicy {
+      RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT = 0,
+      RMW_QOS_POLICY_LIVELINESS_AUTOMATIC = 1,
+      RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC = 3,
+      RMW_QOS_POLICY_LIVELINESS_UNKNOWN = 4,
+      RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE = 5,
     }
   }
 }


### PR DESCRIPTION
This PR adds support for liveliness assertions in publishers by introducing the `assertLiveliness()` method and extending the QoS configuration with liveliness policy options.

- Adds `LivelinessPolicy` enum with five policy options (SYSTEM_DEFAULT, AUTOMATIC, MANUAL_BY_TOPIC, UNKNOWN, BEST_AVAILABLE)
- Adds `assertLiveliness()` method to Publisher class for manual liveliness assertions
- Extends QoS class to support liveliness configuration as a constructor parameter and property

Fix: #1330 