### PR TITLE
Add getContentFilter for subscription

### DIFF
--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -152,6 +152,14 @@ class Subscription extends Entity {
   }
 
   /**
+   * Get the current content-filter.
+   * @returns {object} - The content-filter description {expression: string, parameters: string[]} or undefined if not set/supported.
+   */
+  getContentFilter() {
+    return rclnodejs.getContentFilter(this.handle);
+  }
+
+  /**
    * Clear the current content-filter. No filtering is to be applied.
    * @returns {boolean} - True if successful; false otherwise
    */

--- a/src/rcl_subscription_bindings.cpp
+++ b/src/rcl_subscription_bindings.cpp
@@ -303,9 +303,9 @@ Napi::Value GetContentFilter(const Napi::CallbackInfo& info) {
 
   rcl_ret_t ret = rcl_subscription_get_content_filter(subscription, &options);
   if (ret != RCL_RET_OK) {
-    rcl_reset_error();
     Napi::Error::New(env, rcl_get_error_string().str)
         .ThrowAsJavaScriptException();
+    rcl_reset_error();
     return env.Undefined();
   }
 
@@ -331,9 +331,9 @@ Napi::Value GetContentFilter(const Napi::CallbackInfo& info) {
   rcl_ret_t fini_ret =
       rcl_subscription_content_filter_options_fini(subscription, &options);
   if (fini_ret != RCL_RET_OK) {
-    rcl_reset_error();
     Napi::Error::New(env, rcl_get_error_string().str)
         .ThrowAsJavaScriptException();
+    rcl_reset_error();
     return env.Undefined();
   }
 

--- a/src/rcl_subscription_bindings.cpp
+++ b/src/rcl_subscription_bindings.cpp
@@ -76,7 +76,6 @@ Napi::Value CreateSubscription(const Napi::CallbackInfo& info) {
     subscription_ops.qos = *qos_profile;
   }
 
-#if ROS_VERSION >= 2205  // 2205 => Humble+
   if (options.Has("contentFilter")) {
     // configure content-filter
     Napi::Value contentFilterVal = options.Get("contentFilter");
@@ -123,7 +122,6 @@ Napi::Value CreateSubscription(const Napi::CallbackInfo& info) {
       }
     }
   }
-#endif
 
   const rosidl_message_type_support_t* ts =
       GetMessageTypeSupport(package_name, message_sub_folder, message_name);
@@ -201,9 +199,6 @@ Napi::Value GetSubscriptionTopic(const Napi::CallbackInfo& info) {
 }
 
 Napi::Value HasContentFilter(const Napi::CallbackInfo& info) {
-#if ROS_VERSION < 2205  // 2205 => Humble+
-  return Napi::Boolean::New(info.Env(), false);
-#else
   Napi::Env env = info.Env();
 
   RclHandle* subscription_handle =
@@ -213,13 +208,9 @@ Napi::Value HasContentFilter(const Napi::CallbackInfo& info) {
 
   bool is_valid = rcl_subscription_is_cft_enabled(subscription);
   return Napi::Boolean::New(env, is_valid);
-#endif
 }
 
 Napi::Value SetContentFilter(const Napi::CallbackInfo& info) {
-#if ROS_VERSION < 2205  // 2205 => Humble+
-  return Napi::Boolean::New(info.Env(), false);
-#else
   Napi::Env env = info.Env();
 
   RclHandle* subscription_handle =
@@ -272,13 +263,9 @@ Napi::Value SetContentFilter(const Napi::CallbackInfo& info) {
   }
 
   return Napi::Boolean::New(env, true);
-#endif
 }
 
 Napi::Value ClearContentFilter(const Napi::CallbackInfo& info) {
-#if ROS_VERSION < 2205  // 2205 => Humble+
-  return Napi::Boolean::New(info.Env(), false);
-#else
   Napi::Env env = info.Env();
 
   RclHandle* subscription_handle =
@@ -301,7 +288,56 @@ Napi::Value ClearContentFilter(const Napi::CallbackInfo& info) {
       rcl_get_error_string().str);
 
   return Napi::Boolean::New(env, true);
-#endif
+}
+
+Napi::Value GetContentFilter(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* subscription_handle =
+      RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_subscription_t* subscription =
+      reinterpret_cast<rcl_subscription_t*>(subscription_handle->ptr());
+
+  rcl_subscription_content_filter_options_t options =
+      rcl_get_zero_initialized_subscription_content_filter_options();
+
+  rcl_ret_t ret = rcl_subscription_get_content_filter(subscription, &options);
+  if (ret != RCL_RET_OK) {
+    rcl_reset_error();
+    Napi::Error::New(env, rcl_get_error_string().str)
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  // Create result object
+  Napi::Object result = Napi::Object::New(env);
+  result.Set(
+      "expression",
+      Napi::String::New(
+          env,
+          options.rmw_subscription_content_filter_options.filter_expression));
+
+  size_t param_count = options.rmw_subscription_content_filter_options
+                           .expression_parameters.size;
+  Napi::Array parameters = Napi::Array::New(env, param_count);
+  for (size_t i = 0; i < param_count; ++i) {
+    parameters[i] =
+        Napi::String::New(env, options.rmw_subscription_content_filter_options
+                                   .expression_parameters.data[i]);
+  }
+  result.Set("parameters", parameters);
+
+  // Cleanup
+  rcl_ret_t fini_ret =
+      rcl_subscription_content_filter_options_fini(subscription, &options);
+  if (fini_ret != RCL_RET_OK) {
+    rcl_reset_error();
+    Napi::Error::New(env, rcl_get_error_string().str)
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  return result;
 }
 
 Napi::Value GetPublisherCount(const Napi::CallbackInfo& info) {
@@ -327,6 +363,7 @@ Napi::Object InitSubscriptionBindings(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, GetSubscriptionTopic));
   exports.Set("hasContentFilter", Napi::Function::New(env, HasContentFilter));
   exports.Set("setContentFilter", Napi::Function::New(env, SetContentFilter));
+  exports.Set("getContentFilter", Napi::Function::New(env, GetContentFilter));
   exports.Set("clearContentFilter",
               Napi::Function::New(env, ClearContentFilter));
   exports.Set("getPublisherCount", Napi::Function::New(env, GetPublisherCount));

--- a/test/test-subscription-content-filter.js
+++ b/test/test-subscription-content-filter.js
@@ -403,6 +403,30 @@ describe('subscription content-filtering', function () {
     done();
   });
 
+  it('getContentFilter', function (done) {
+    const typeclass = 'std_msgs/msg/Int32';
+    let options = Node.getDefaultOptions();
+    options.contentFilter = {
+      expression: 'data = %0',
+      parameters: [5],
+    };
+
+    const subscription = this.subscriberNode.createSubscription(
+      typeclass,
+      TOPIC,
+      options,
+      (msg) => {}
+    );
+
+    assert.ok(subscription.hasContentFilter());
+    const filter = subscription.getContentFilter();
+    assert.strictEqual(filter.expression, 'data = %0');
+    assert.strictEqual(filter.parameters.length, 1);
+    assert.strictEqual(filter.parameters[0], '5');
+
+    done();
+  });
+
   it('multiple clearContentFilter', function (done) {
     const typeclass = 'std_msgs/msg/Int32';
     let options = Node.getDefaultOptions();

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -220,6 +220,9 @@ expectType<rclnodejs.SubscriptionWithRawMessageCallback>(rawMessageCallback);
 expectType<string>(subscription.topic);
 expectType<boolean>(subscription.isDestroyed());
 expectType<boolean>(subscription.setContentFilter(contentFilter));
+expectType<rclnodejs.SubscriptionContentFilter | undefined>(
+  subscription.getContentFilter()
+);
 expectType<boolean>(subscription.clearContentFilter());
 expectType<boolean>(subscription.hasContentFilter());
 expectType<string>(subscription.loggerName);

--- a/types/subscription.d.ts
+++ b/types/subscription.d.ts
@@ -62,6 +62,12 @@ declare module 'rclnodejs' {
     setContentFilter(filter: SubscriptionContentFilter): boolean;
 
     /**
+     * Get the current content-filter.
+     * @returns The content-filter description {expression: string, parameters: string[]} or undefined if not set/supported.
+     */
+    getContentFilter(): SubscriptionContentFilter | undefined;
+
+    /**
      * Clear the current content-filter. No filtering is to be applied.
      * @returns True if successful; false otherwise
      */


### PR DESCRIPTION
This PR adds a `getContentFilter()` method to subscriptions, enabling retrieval of the current content filter configuration. The implementation mirrors the existing content filter API with getter functionality alongside the existing setter and clear operations.

Key changes:
- Added `getContentFilter()` method to retrieve current content filter expression and parameters
- Removed version guards (`#if ROS_VERSION >= 2205`) from content filtering code, assuming universal Humble+ support
- Added corresponding TypeScript type definitions and test coverage

Fix: #1330