### PR TITLE
Support logging rosout

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -89,6 +89,8 @@ class Caller {
 class Logging {
   constructor(name) {
     this._name = name;
+    this._parentName = null;
+    this._subName = null;
   }
 
   /**
@@ -201,6 +203,50 @@ class Logging {
    */
   get name() {
     return this._name;
+  }
+
+  /**
+   * Create a child logger.
+   * @param {string} name - name of the child logger.
+   * @function
+   * @return {Logging} Return the child logger object.
+   */
+  getChild(name) {
+    if (typeof name !== 'string' || !name) {
+      throw new Error('Child logger name must be a non-empty string.');
+    }
+
+    let fullname = name;
+    if (this._name) {
+      fullname = this._name + '.' + name;
+    }
+
+    const logger = new Logging(fullname);
+    if (this._name) {
+      if (
+        rclnodejs.addRosoutSublogger &&
+        rclnodejs.addRosoutSublogger(this._name, name)
+      ) {
+        logger._parentName = this._name;
+        logger._subName = name;
+      }
+    }
+    return logger;
+  }
+
+  /**
+   * Destroy the logger and remove it from the parent logger if it is a child logger.
+   * @function
+   * @return {undefined}
+   */
+  destroy() {
+    if (this._parentName && this._subName) {
+      if (rclnodejs.removeRosoutSublogger) {
+        rclnodejs.removeRosoutSublogger(this._parentName, this._subName);
+      }
+      this._parentName = null;
+      this._subName = null;
+    }
   }
 
   /**

--- a/lib/node.js
+++ b/lib/node.js
@@ -1024,6 +1024,7 @@ class Node extends rclnodejs.ShadowNode {
 
     if (this._enableRosout) {
       rclnodejs.finiRosoutPublisherForNode(this.handle);
+      this._enableRosout = false;
     }
 
     this.handle.release();

--- a/lib/node.js
+++ b/lib/node.js
@@ -102,7 +102,8 @@ class Node extends rclnodejs.ShadowNode {
       namespace,
       context.handle,
       args,
-      useGlobalArguments
+      useGlobalArguments,
+      options.rosoutQos
     );
     Object.defineProperty(this, 'handle', {
       configurable: false,
@@ -132,6 +133,11 @@ class Node extends rclnodejs.ShadowNode {
     this._setParametersCallbacks = [];
     this._logger = new Logging(rclnodejs.getNodeLoggerName(this.handle));
     this._spinning = false;
+    this._enableRosout = options.enableRosout;
+
+    if (this._enableRosout) {
+      rclnodejs.initRosoutPublisherForNode(this.handle);
+    }
 
     this._parameterEventPublisher = this.createPublisher(
       PARAMETER_EVENT_MSG_TYPE,
@@ -1015,6 +1021,10 @@ class Node extends rclnodejs.ShadowNode {
     this._parameterWatchers.forEach((watcher) => watcher.destroy());
 
     this.context.onNodeDestroyed(this);
+
+    if (this._enableRosout) {
+      rclnodejs.finiRosoutPublisherForNode(this.handle);
+    }
 
     this.handle.release();
     this._clock = null;

--- a/lib/node_options.js
+++ b/lib/node_options.js
@@ -27,18 +27,24 @@ class NodeOptions {
    * @param {array} [parameterOverrides=[]]
    * @param {boolean} [automaticallyDeclareParametersFromOverrides=false]
    * @param {boolean} [startTypeDescriptionService=true]
+   * @param {boolean} [enableRosout=true]
+   * @param {QoS} [rosoutQos=QoS.profileDefault]
    */
   constructor(
     startParameterServices = true,
     parameterOverrides = [],
     automaticallyDeclareParametersFromOverrides = false,
-    startTypeDescriptionService = true
+    startTypeDescriptionService = true,
+    enableRosout = true,
+    rosoutQos = null
   ) {
     this._startParameterServices = startParameterServices;
     this._parameterOverrides = parameterOverrides;
     this._automaticallyDeclareParametersFromOverrides =
       automaticallyDeclareParametersFromOverrides;
     this._startTypeDescriptionService = startTypeDescriptionService;
+    this._enableRosout = enableRosout;
+    this._rosoutQos = rosoutQos;
   }
 
   /**
@@ -123,6 +129,39 @@ class NodeOptions {
    */
   set startTypeDescriptionService(willStartTypeDescriptionService) {
     this._startTypeDescriptionService = willStartTypeDescriptionService;
+  }
+
+  /**
+   * Get the enableRosout option.
+   * Default value = true;
+   * @returns {boolean} - true if the rosout logging is enabled.
+   */
+  get enableRosout() {
+    return this._enableRosout;
+  }
+
+  /**
+   * Set enableRosout.
+   * @param {boolean} enableRosout
+   */
+  set enableRosout(enableRosout) {
+    this._enableRosout = enableRosout;
+  }
+
+  /**
+   * Get the rosoutQos option.
+   * @returns {QoS} - The QoS profile for rosout.
+   */
+  get rosoutQos() {
+    return this._rosoutQos;
+  }
+
+  /**
+   * Set rosoutQos.
+   * @param {QoS} rosoutQos
+   */
+  set rosoutQos(rosoutQos) {
+    this._rosoutQos = rosoutQos;
   }
 
   /**

--- a/src/rcl_logging_bindings.cpp
+++ b/src/rcl_logging_bindings.cpp
@@ -15,15 +15,50 @@
 #include "rcl_logging_bindings.h"
 
 #include <rcl/error_handling.h>
+#include <rcl/logging.h>
+#include <rcl/logging_rosout.h>
 #include <rcl/rcl.h>
 #include <rcl_logging_interface/rcl_logging_interface.h>
 
 #include <string>
 
 #include "macros.h"
+#include "rcl_handle.h"
 #include "rcl_utilities.h"
 
 namespace rclnodejs {
+
+Napi::Value InitRosoutPublisherForNode(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+
+  if (rcl_logging_rosout_enabled()) {
+    rcl_ret_t ret = rcl_logging_rosout_init_publisher_for_node(node);
+    if (ret != RCL_RET_OK) {
+      Napi::Error::New(env, rcl_get_error_string().str)
+          .ThrowAsJavaScriptException();
+      rcl_reset_error();
+    }
+  }
+  return env.Undefined();
+}
+
+Napi::Value FiniRosoutPublisherForNode(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+
+  if (rcl_logging_rosout_enabled()) {
+    rcl_ret_t ret = rcl_logging_rosout_fini_publisher_for_node(node);
+    if (ret != RCL_RET_OK) {
+      Napi::Error::New(env, rcl_get_error_string().str)
+          .ThrowAsJavaScriptException();
+      rcl_reset_error();
+    }
+  }
+  return env.Undefined();
+}
 
 Napi::Value setLoggerLevel(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
@@ -104,6 +139,41 @@ Napi::Value GetLoggingDirectory(const Napi::CallbackInfo& info) {
   return result;
 }
 
+#if ROS_VERSION > 2205
+Napi::Value AddRosoutSublogger(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  std::string logger_name = info[0].As<Napi::String>().Utf8Value();
+  std::string sublogger_name = info[1].As<Napi::String>().Utf8Value();
+
+  rcl_ret_t ret = rcl_logging_rosout_add_sublogger(logger_name.c_str(),
+                                                   sublogger_name.c_str());
+  if (ret == RCL_RET_OK) {
+    return Napi::Boolean::New(env, true);
+  } else if (ret == RCL_RET_NOT_FOUND) {
+    rcl_reset_error();
+    return Napi::Boolean::New(env, false);
+  } else {
+    Napi::Error::New(env, rcl_get_error_string().str)
+        .ThrowAsJavaScriptException();
+    rcl_reset_error();
+    return env.Undefined();
+  }
+}
+
+Napi::Value RemoveRosoutSublogger(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  std::string logger_name = info[0].As<Napi::String>().Utf8Value();
+  std::string sublogger_name = info[1].As<Napi::String>().Utf8Value();
+
+  rcl_ret_t ret = rcl_logging_rosout_remove_sublogger(logger_name.c_str(),
+                                                      sublogger_name.c_str());
+  if (ret != RCL_RET_OK) {
+    rcl_reset_error();
+  }
+  return env.Undefined();
+}
+#endif
+
 Napi::Object InitLoggingBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("setLoggerLevel", Napi::Function::New(env, setLoggerLevel));
   exports.Set("getLoggerEffectiveLevel",
@@ -112,6 +182,16 @@ Napi::Object InitLoggingBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("isEnableFor", Napi::Function::New(env, IsEnableFor));
   exports.Set("getLoggingDirectory",
               Napi::Function::New(env, GetLoggingDirectory));
+  exports.Set("initRosoutPublisherForNode",
+              Napi::Function::New(env, InitRosoutPublisherForNode));
+  exports.Set("finiRosoutPublisherForNode",
+              Napi::Function::New(env, FiniRosoutPublisherForNode));
+#if ROS_VERSION > 2205
+  exports.Set("addRosoutSublogger",
+              Napi::Function::New(env, AddRosoutSublogger));
+  exports.Set("removeRosoutSublogger",
+              Napi::Function::New(env, RemoveRosoutSublogger));
+#endif
   return exports;
 }
 

--- a/src/rcl_node_bindings.cpp
+++ b/src/rcl_node_bindings.cpp
@@ -26,8 +26,10 @@
 #include <rcl_yaml_param_parser/types.h>
 
 #include <rcpputils/scope_exit.hpp>
-// NOLINTNEXTLINE
+// NOLINTBEGIN
+#include <memory>
 #include <string>
+// NOLINTEND
 
 #include "macros.h"
 #include "rcl_handle.h"

--- a/src/rcl_node_bindings.cpp
+++ b/src/rcl_node_bindings.cpp
@@ -212,6 +212,11 @@ Napi::Value CreateNode(const Napi::CallbackInfo& info) {
   options.use_global_arguments = use_global_arguments;
   options.arguments = arguments;
 
+  if (info.Length() > 5 && !info[5].IsUndefined() && !info[5].IsNull()) {
+    std::unique_ptr<rmw_qos_profile_t> qos_profile = GetQoSProfile(info[5]);
+    options.rosout_qos = *qos_profile;
+  }
+
   THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK,
                            rcl_node_init(node, node_name.c_str(),
                                          name_space.c_str(), context, &options),

--- a/test/test-logging.js
+++ b/test/test-logging.js
@@ -114,6 +114,7 @@ describe('Test logging util', function () {
       pub.name.includes('rosout')
     );
     assert.notStrictEqual(rosoutPublisher, undefined);
+    node.destroy();
     rclnodejs.shutdown();
   });
 
@@ -165,6 +166,7 @@ describe('Test logging util', function () {
       rclnodejs.QoS.ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT
     );
 
+    node.destroy();
     rclnodejs.shutdown();
   });
 

--- a/test/test-logging.js
+++ b/test/test-logging.js
@@ -91,6 +91,12 @@ describe('Test logging util', function () {
   });
 
   it('Test enableRosout option true', async function () {
+    if (
+      rclnodejs.DistroUtils.getDistroId() <
+      rclnodejs.DistroUtils.getDistroId('jazzy')
+    ) {
+      this.skip();
+    }
     await rclnodejs.init();
     const options = new rclnodejs.NodeOptions();
     options.enableRosout = true;

--- a/test/test-logging.js
+++ b/test/test-logging.js
@@ -119,6 +119,12 @@ describe('Test logging util', function () {
   });
 
   it('Test enableRosout option false', async function () {
+    if (
+      rclnodejs.DistroUtils.getDistroId() <
+      rclnodejs.DistroUtils.getDistroId('jazzy')
+    ) {
+      this.skip();
+    }
     await rclnodejs.init();
     const options = new rclnodejs.NodeOptions();
     options.enableRosout = false;

--- a/test/test-logging.js
+++ b/test/test-logging.js
@@ -146,6 +146,12 @@ describe('Test logging util', function () {
   });
 
   it('Test rosoutQos option', async function () {
+    if (
+      rclnodejs.DistroUtils.getDistroId() <
+      rclnodejs.DistroUtils.getDistroId('jazzy')
+    ) {
+      this.skip();
+    }
     await rclnodejs.init();
     const options = new rclnodejs.NodeOptions();
     options.enableRosout = true;

--- a/test/test-logging.js
+++ b/test/test-logging.js
@@ -89,4 +89,89 @@ describe('Test logging util', function () {
     assert.strictEqual(typeof logDir, 'string');
     assert.ok(logDir.length > 0);
   });
+
+  it('Test enableRosout option true', async function () {
+    await rclnodejs.init();
+    const options = new rclnodejs.NodeOptions();
+    options.enableRosout = true;
+    const node = rclnodejs.createNode(
+      'node_with_rosout',
+      '',
+      rclnodejs.Context.defaultContext(),
+      options
+    );
+    const publishers = node.getPublisherNamesAndTypesByNode(
+      node.name(),
+      node.namespace()
+    );
+    const rosoutPublisher = publishers.find((pub) =>
+      pub.name.includes('rosout')
+    );
+    assert.notStrictEqual(rosoutPublisher, undefined);
+    rclnodejs.shutdown();
+  });
+
+  it('Test enableRosout option false', async function () {
+    await rclnodejs.init();
+    const options = new rclnodejs.NodeOptions();
+    options.enableRosout = false;
+    const node = rclnodejs.createNode(
+      'node_without_rosout',
+      '',
+      rclnodejs.Context.defaultContext(),
+      options
+    );
+    const publishers = node.getPublisherNamesAndTypesByNode(
+      node.name(),
+      node.namespace()
+    );
+    const rosoutPublisher = publishers.find((pub) =>
+      pub.name.includes('rosout')
+    );
+    assert.strictEqual(rosoutPublisher, undefined);
+    rclnodejs.shutdown();
+  });
+
+  it('Test rosoutQos option', async function () {
+    await rclnodejs.init();
+    const options = new rclnodejs.NodeOptions();
+    options.enableRosout = true;
+    options.rosoutQos = rclnodejs.QoS.profileSensorData;
+    const node = rclnodejs.createNode(
+      'node_with_rosout_qos',
+      '',
+      rclnodejs.Context.defaultContext(),
+      options
+    );
+
+    const publishers = node.getPublishersInfoByTopic('/rosout');
+    const myPub = publishers.find(
+      (p) => p.node_name === 'node_with_rosout_qos'
+    );
+
+    assert.notStrictEqual(myPub, undefined);
+    // SensorData profile: Reliability = BEST_EFFORT (2), Durability = VOLATILE (2)
+    // Default rosout profile: Reliability = RELIABLE (1), Durability = TRANSIENT_LOCAL (1)
+
+    // Check reliability
+    assert.strictEqual(
+      myPub.qos_profile.reliability,
+      rclnodejs.QoS.ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT
+    );
+
+    rclnodejs.shutdown();
+  });
+
+  it('Test child logger', function () {
+    if (
+      rclnodejs.DistroUtils.getDistroId() <=
+      rclnodejs.DistroUtils.getDistroId('humble')
+    ) {
+      this.skip();
+    }
+    const logger = rclnodejs.logging.getLogger('parent_logger');
+    const childLogger = logger.getChild('child_logger');
+    assert.strictEqual(childLogger.name, 'parent_logger.child_logger');
+    childLogger.destroy();
+  });
 });

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -44,6 +44,8 @@ expectType<rclnodejs.NodeOptions>(nodeOptions);
 expectType<boolean>(nodeOptions.startParameterServices);
 expectType<boolean>(nodeOptions.automaticallyDeclareParametersFromOverrides);
 expectType<rclnodejs.Parameter[]>(nodeOptions.parameterOverrides);
+expectType<boolean>(nodeOptions.enableRosout);
+expectType<rclnodejs.QoS | rclnodejs.QoS.ProfileRef>(nodeOptions.rosoutQos);
 
 // ---- Node -----
 const node = rclnodejs.createNode(NODE_NAME);

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -356,6 +356,8 @@ expectType<boolean>(logger.warn('test msg'));
 expectType<boolean>(logger.error('test msg'));
 expectType<boolean>(logger.fatal('test msg'));
 expectType<string>(rclnodejs.Logging.getLoggingDirectory());
+expectType<rclnodejs.Logging>(logger.getChild('child'));
+expectType<void>(logger.destroy());
 
 // ---- ActionClient -----
 const Fibonacci = rclnodejs.require('example_interfaces/action/Fibonacci');

--- a/types/logging.d.ts
+++ b/types/logging.d.ts
@@ -78,6 +78,19 @@ declare module 'rclnodejs' {
     readonly name: string;
 
     /**
+     * Create a child logger.
+     *
+     * @param name - name of the child logger.
+     * @returns The child logger object.
+     */
+    getChild(name: string): Logging;
+
+    /**
+     * Destroy the logger and remove it from the parent logger if it is a child logger.
+     */
+    destroy(): void;
+
+    /**
      * Create a logger by name.
      *
      * @param  name - name of the logger.

--- a/types/node_options.d.ts
+++ b/types/node_options.d.ts
@@ -33,6 +33,19 @@ declare module 'rclnodejs' {
     automaticallyDeclareParametersFromOverrides: boolean;
 
     /**
+     * A flag controlling the startup of the rosout logging.
+     * When true a node will start the rosout logging.
+     * Default value = true;
+     * @returns {boolean} -
+     */
+    enableRosout: boolean;
+
+    /**
+     * The QoS profile for the rosout publisher.
+     */
+    rosoutQos: QoS | QoS.ProfileRef;
+
+    /**
      * An instance configured with default values.
      */
     static defaultOptions: NodeOptions;


### PR DESCRIPTION
This PR adds support for ROS2 rosout logging by introducing `enableRosout` and `rosoutQos` configuration options to control rosout publisher behavior in nodes. The changes include TypeScript type definitions, C++ bindings, JavaScript implementation, and comprehensive test coverage.

- Adds `enableRosout` boolean flag to control rosout logging startup (default: true)
- Adds `rosoutQos` option to configure QoS profile for rosout publisher
- Implements child logger support with rosout sublogger management for ROS2 distributions newer than Humble

Fix: #1330