### PR TITLE
Add getLoggingDirectory()

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -67,6 +67,7 @@
         '-lrcl_action',
         '-lrcl_lifecycle',
         '-lrcutils',
+        '-lrcl_logging_interface',
         '-lrcl_yaml_param_parser',
         '-lrcpputils',
         '-lrmw',

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -217,6 +217,15 @@ class Logging {
     }
     return new Logging(name);
   }
+
+  /**
+   * Get the logging directory.
+   * @function
+   * @return {string} - The logging directory.
+   */
+  static getLoggingDirectory() {
+    return rclnodejs.getLoggingDirectory();
+  }
 }
 
 module.exports = Logging;

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -33,6 +33,7 @@ const dependencies = [
   'rosidl_runtime_c',
   'rosidl_dynamic_typesupport',
   'type_description_interfaces',
+  'rcl_logging_interface',
 ];
 
 const command = os.type() === 'Windows_NT' ? 'where ros2' : 'which ros2';

--- a/src/rcl_logging_bindings.cpp
+++ b/src/rcl_logging_bindings.cpp
@@ -93,9 +93,9 @@ Napi::Value GetLoggingDirectory(const Napi::CallbackInfo& info) {
       rcl_logging_get_logging_directory(allocator, &directory_path);
 
   if (ret != RCL_LOGGING_RET_OK) {
-    Napi::Error::New(env, rcl_get_error_string().str)
+    Napi::Error::New(env, rcutils_get_error_string().str)
         .ThrowAsJavaScriptException();
-    rcl_reset_error();
+    rcutils_reset_error();
     return env.Undefined();
   }
 

--- a/src/rcl_logging_bindings.cpp
+++ b/src/rcl_logging_bindings.cpp
@@ -16,6 +16,7 @@
 
 #include <rcl/error_handling.h>
 #include <rcl/rcl.h>
+#include <rcl_logging_interface/rcl_logging_interface.h>
 
 #include <string>
 
@@ -84,12 +85,33 @@ Napi::Value IsEnableFor(const Napi::CallbackInfo& info) {
   return Napi::Boolean::New(env, enabled);
 }
 
+Napi::Value GetLoggingDirectory(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  char* directory_path = nullptr;
+  rcl_logging_ret_t ret =
+      rcl_logging_get_logging_directory(allocator, &directory_path);
+
+  if (ret != RCL_LOGGING_RET_OK) {
+    Napi::Error::New(env, rcl_get_error_string().str)
+        .ThrowAsJavaScriptException();
+    rcl_reset_error();
+    return env.Undefined();
+  }
+
+  Napi::String result = Napi::String::New(env, directory_path);
+  allocator.deallocate(directory_path, allocator.state);
+  return result;
+}
+
 Napi::Object InitLoggingBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("setLoggerLevel", Napi::Function::New(env, setLoggerLevel));
   exports.Set("getLoggerEffectiveLevel",
               Napi::Function::New(env, GetLoggerEffectiveLevel));
   exports.Set("log", Napi::Function::New(env, Log));
   exports.Set("isEnableFor", Napi::Function::New(env, IsEnableFor));
+  exports.Set("getLoggingDirectory",
+              Napi::Function::New(env, GetLoggingDirectory));
   return exports;
 }
 

--- a/test/test-logging.js
+++ b/test/test-logging.js
@@ -83,4 +83,10 @@ describe('Test logging util', function () {
     );
     rclnodejs.shutdown();
   });
+
+  it('Test getLoggingDirectory', function () {
+    const logDir = rclnodejs.logging.getLoggingDirectory();
+    assert.strictEqual(typeof logDir, 'string');
+    assert.ok(logDir.length > 0);
+  });
 });

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -347,6 +347,7 @@ expectType<boolean>(logger.debug('test msg'));
 expectType<boolean>(logger.warn('test msg'));
 expectType<boolean>(logger.error('test msg'));
 expectType<boolean>(logger.fatal('test msg'));
+expectType<string>(rclnodejs.Logging.getLoggingDirectory());
 
 // ---- ActionClient -----
 const Fibonacci = rclnodejs.require('example_interfaces/action/Fibonacci');

--- a/types/logging.d.ts
+++ b/types/logging.d.ts
@@ -84,6 +84,13 @@ declare module 'rclnodejs' {
      * @returns New logger.
      */
     static getLogger(name: string): Logging;
+
+    /**
+     * Get the logging directory.
+     *
+     * @returns The logging directory.
+     */
+    static getLoggingDirectory(): string;
   }
 
   namespace Logging {


### PR DESCRIPTION
This PR adds a new `getLoggingDirectory()` static method to the Logging class that retrieves the directory path where ROS 2 logging files are stored.

- Adds C++ binding for `rcl_logging_get_logging_directory` from the rcl_logging_interface library
- Exposes the functionality through JavaScript and TypeScript APIs
- Includes test coverage for both runtime behavior and type checking

Fix: #1330 