### PR TITLE
Support logging mutex functions

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -17,6 +17,7 @@
 const path = require('path');
 const rclnodejs = require('./native_loader.js');
 const { TypeValidationError } = require('./errors.js');
+const Context = require('./context.js');
 
 /**
  * Enum for LoggingSeverity
@@ -262,6 +263,28 @@ class Logging {
       });
     }
     return new Logging(name);
+  }
+
+  /**
+   * Configure the logging system with the given context.
+   * @param {Context} context - The context to configure logging for.
+   * @function
+   * @return {undefined}
+   */
+  static configure(context) {
+    if (!(context instanceof Context)) {
+      throw new TypeValidationError('context', context, 'Context');
+    }
+    rclnodejs.loggingConfigure(context.handle);
+  }
+
+  /**
+   * Shutdown the logging system.
+   * @function
+   * @return {undefined}
+   */
+  static shutdown() {
+    rclnodejs.loggingFini();
   }
 
   /**

--- a/src/rcl_logging_bindings.cpp
+++ b/src/rcl_logging_bindings.cpp
@@ -20,6 +20,7 @@
 #include <rcl/rcl.h>
 #include <rcl_logging_interface/rcl_logging_interface.h>
 
+#include <mutex>
 #include <string>
 
 #include "macros.h"
@@ -40,6 +41,47 @@ Napi::Value InitRosoutPublisherForNode(const Napi::CallbackInfo& info) {
           .ThrowAsJavaScriptException();
       rcl_reset_error();
     }
+      }
+  return env.Undefined();
+}
+
+static std::recursive_mutex logging_mutex;
+
+static void rclnodejs_thread_safe_logging_output_handler(
+    const rcutils_log_location_t* location, int severity, const char* name,
+    rcutils_time_point_value_t timestamp, const char* format, va_list* args) {
+  try {
+    std::lock_guard<std::recursive_mutex> lock(logging_mutex);
+    rcl_logging_multiple_output_handler(location, severity, name, timestamp,
+                                        format, args);
+  } catch (const std::exception& ex) {
+    RCUTILS_SAFE_FWRITE_TO_STDERR(
+        "rclnodejs failed to get the global logging mutex: ");
+    RCUTILS_SAFE_FWRITE_TO_STDERR(ex.what());
+    RCUTILS_SAFE_FWRITE_TO_STDERR("\n");
+  } catch (...) {
+    RCUTILS_SAFE_FWRITE_TO_STDERR(
+        "rclnodejs failed to get the global logging mutex\n");
+  }
+}
+
+Napi::Value LoggingConfigure(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  RclHandle* context_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_context_t* context =
+      reinterpret_cast<rcl_context_t*>(context_handle->ptr());
+
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+
+  std::lock_guard<std::recursive_mutex> lock(logging_mutex);
+  rcl_ret_t ret = rcl_logging_configure_with_output_handler(
+      &context->global_arguments, &allocator,
+      rclnodejs_thread_safe_logging_output_handler);
+
+  if (ret != RCL_RET_OK) {
+    Napi::Error::New(env, rcl_get_error_string().str)
+        .ThrowAsJavaScriptException();
+    rcl_reset_error();
   }
   return env.Undefined();
 }
@@ -56,6 +98,18 @@ Napi::Value FiniRosoutPublisherForNode(const Napi::CallbackInfo& info) {
           .ThrowAsJavaScriptException();
       rcl_reset_error();
     }
+  }
+  return env.Undefined();
+}
+
+Napi::Value LoggingFini(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  std::lock_guard<std::recursive_mutex> lock(logging_mutex);
+  rcl_ret_t ret = rcl_logging_fini();
+  if (ret != RCL_RET_OK) {
+    Napi::Error::New(env, rcl_get_error_string().str)
+        .ThrowAsJavaScriptException();
+    rcl_reset_error();
   }
   return env.Undefined();
 }
@@ -192,6 +246,8 @@ Napi::Object InitLoggingBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("removeRosoutSublogger",
               Napi::Function::New(env, RemoveRosoutSublogger));
 #endif
+  exports.Set("loggingConfigure", Napi::Function::New(env, LoggingConfigure));
+  exports.Set("loggingFini", Napi::Function::New(env, LoggingFini));
   return exports;
 }
 

--- a/test/test-logging.js
+++ b/test/test-logging.js
@@ -64,6 +64,7 @@ describe('Test logging util', function () {
 
   for (const level of ['debug', 'info', 'warn', 'error', 'fatal']) {
     it(`Test commandline parameter configuration of log level '${level}'`, async function () {
+      this.timeout(10000);
       // test the specific log level
       await testLoglevel(level);
     });
@@ -193,5 +194,37 @@ describe('Test logging util', function () {
     const childLogger = logger.getChild('child_logger');
     assert.strictEqual(childLogger.name, 'parent_logger.child_logger');
     childLogger.destroy();
+  });
+
+  it('Test logging configure and shutdown', async function () {
+    await rclnodejs.init();
+    const logger = rclnodejs.logging.getLogger('config_logger');
+
+    // Verify logging works initially
+    assert.doesNotThrow(() => {
+      logger.info('Initial message');
+    });
+
+    // Shutdown logging
+    assert.doesNotThrow(() => {
+      rclnodejs.logging.shutdown();
+    });
+
+    // Re-configure logging with thread-safe handler
+    assert.doesNotThrow(() => {
+      rclnodejs.logging.configure(rclnodejs.Context.defaultContext());
+    });
+
+    // Verify logging works after reconfiguration
+    assert.doesNotThrow(() => {
+      logger.info('Message after reconfiguration');
+    });
+
+    // Test invalid context
+    assert.throws(() => {
+      rclnodejs.logging.configure({});
+    }, /context/);
+
+    rclnodejs.shutdown();
   });
 });

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -355,6 +355,10 @@ expectType<boolean>(logger.debug('test msg'));
 expectType<boolean>(logger.warn('test msg'));
 expectType<boolean>(logger.error('test msg'));
 expectType<boolean>(logger.fatal('test msg'));
+expectType<void>(
+  rclnodejs.Logging.configure(rclnodejs.Context.defaultContext())
+);
+expectType<void>(rclnodejs.Logging.shutdown());
 expectType<string>(rclnodejs.Logging.getLoggingDirectory());
 expectType<rclnodejs.Logging>(logger.getChild('child'));
 expectType<void>(logger.destroy());

--- a/types/logging.d.ts
+++ b/types/logging.d.ts
@@ -99,6 +99,18 @@ declare module 'rclnodejs' {
     static getLogger(name: string): Logging;
 
     /**
+     * Configure the logging system with the given context.
+     *
+     * @param context - The context to configure logging for.
+     */
+    static configure(context: Context): void;
+
+    /**
+     * Shutdown the logging system.
+     */
+    static shutdown(): void;
+
+    /**
      * Get the logging directory.
      *
      * @returns The logging directory.


### PR DESCRIPTION
This PR adds support for logging mutex functions to enable thread-safe logging configuration and shutdown. The changes introduce new `configure()` and `shutdown()` methods to the logging system with proper mutex protection.

- Implements thread-safe logging output handler with recursive mutex
- Adds static methods `configure()` and `shutdown()` to the `Logging` class
- Includes TypeScript type definitions and comprehensive tests

Fix: #1330