### PR TITLE
Add removeROSArgs() function

### DIFF
--- a/index.js
+++ b/index.js
@@ -387,6 +387,21 @@ let rcl = {
   },
 
   /**
+   * Remove ROS-specific arguments from the given argument list.
+   * @param {string[]} argv - The argument list to process.
+   * @return {string[]} The argument list with ROS arguments removed.
+   */
+  removeROSArgs(argv) {
+    if (!Array.isArray(argv)) {
+      throw new TypeError('argv must be an array.');
+    }
+    if (!argv.every((argument) => typeof argument === 'string')) {
+      throw new TypeError('argv elements must be strings (and not null).');
+    }
+    return rclnodejs.removeROSArgs(argv);
+  },
+
+  /**
    * Start detection and processing of units of work.
    * @param {Node} node - The node to be spun up.
    * @param {number} [timeout=10] - Timeout to wait in milliseconds. Block forever if negative. Don't wait if 0.

--- a/src/rcl_bindings.cpp
+++ b/src/rcl_bindings.cpp
@@ -15,6 +15,11 @@
 #include "rcl_bindings.h"
 
 #include <node.h>
+#include <rcl/arguments.h>
+#include <rcl/rcl.h>
+
+#include <rcpputils/scope_exit.hpp>
+
 #if ROS_VERSION >= 2006
 #include <rosidl_runtime_c/string_functions.h>
 #else
@@ -23,10 +28,63 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "rcl_handle.h"
+#include "rcl_utilities.h"
 
 namespace rclnodejs {
+
+Napi::Value RemoveROSArgs(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::Array jsArgv = info[0].As<Napi::Array>();
+  size_t argc = jsArgv.Length();
+  char** argv = AbstractArgsFromNapiArray(jsArgv);
+
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
+
+  rcl_ret_t ret = rcl_parse_arguments(argc, const_cast<const char**>(argv),
+                                      allocator, &parsed_args);
+
+  if (RCL_RET_OK != ret) {
+    FreeArgs(argv, argc);
+    Napi::Error::New(env, "Failed to parse arguments")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  RCPPUTILS_SCOPE_EXIT({
+    rcl_ret_t fini_ret = rcl_arguments_fini(&parsed_args);
+    if (RCL_RET_OK != fini_ret) {
+      // Log error but don't throw since we might be already throwing
+    }
+  });
+
+  int nonros_argc = 0;
+  const char** nonros_argv = nullptr;
+
+  ret = rcl_remove_ros_arguments(const_cast<const char**>(argv), &parsed_args,
+                                 allocator, &nonros_argc, &nonros_argv);
+
+  if (RCL_RET_OK != ret) {
+    FreeArgs(argv, argc);
+    Napi::Error::New(env, "Failed to remove ROS arguments")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  RCPPUTILS_SCOPE_EXIT({ allocator.deallocate(nonros_argv, allocator.state); });
+
+  Napi::Array result = Napi::Array::New(env, nonros_argc);
+  for (int i = 0; i < nonros_argc; ++i) {
+    result.Set(i, Napi::String::New(env, nonros_argv[i]));
+  }
+
+  FreeArgs(argv, argc);
+
+  return result;
+}
 
 Napi::Value InitString(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
@@ -110,6 +168,7 @@ Napi::Object InitBindings(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, CreateArrayBufferFromAddress));
   exports.Set("createArrayBufferCleaner",
               Napi::Function::New(env, CreateArrayBufferCleaner));
+  exports.Set("removeROSArgs", Napi::Function::New(env, RemoveROSArgs));
   return exports;
 }
 

--- a/test/test-remove-ros-args.js
+++ b/test/test-remove-ros-args.js
@@ -1,0 +1,63 @@
+// Copyright (c) 2025, The Robot Web Tools Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const rclnodejs = require('../index.js');
+
+describe('rclnodejs removeROSArgs', function () {
+  it('should remove ROS arguments', function () {
+    const args = ['node', 'script.js', '--ros-args', '-r', '__node:=my_node'];
+    const nonRosArgs = rclnodejs.removeROSArgs(args);
+    assert.deepStrictEqual(nonRosArgs, ['node', 'script.js']);
+  });
+
+  it('should keep non-ROS arguments', function () {
+    const args = ['node', 'script.js', 'arg1', 'arg2'];
+    const nonRosArgs = rclnodejs.removeROSArgs(args);
+    assert.deepStrictEqual(nonRosArgs, ['node', 'script.js', 'arg1', 'arg2']);
+  });
+
+  it('should handle mixed arguments', function () {
+    const args = [
+      'node',
+      'script.js',
+      'arg1',
+      '--ros-args',
+      '-r',
+      '__node:=my_node',
+      '--',
+      'arg2',
+    ];
+    const nonRosArgs = rclnodejs.removeROSArgs(args);
+
+    assert.ok(nonRosArgs.includes('arg1'));
+    assert.ok(nonRosArgs.includes('arg2'));
+    assert.ok(!nonRosArgs.includes('--ros-args'));
+    assert.ok(!nonRosArgs.includes('__node:=my_node'));
+  });
+
+  it('should throw if argv is not an array', function () {
+    assert.throws(() => {
+      rclnodejs.removeROSArgs('not an array');
+    }, TypeError);
+  });
+
+  it('should throw if argv elements are not strings', function () {
+    assert.throws(() => {
+      rclnodejs.removeROSArgs(['string', 123]);
+    }, TypeError);
+  });
+});

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -14,6 +14,9 @@ MSG.data = '';
 
 // ---- rclnodejs -----
 expectType<Promise<void>>(rclnodejs.init());
+expectType<string[]>(
+  rclnodejs.removeROSArgs(['--ros-args', '-r', '__node:=my_node'])
+);
 expectType<string | undefined>(rclnodejs.DistroUtils.getDistroName());
 expectType<boolean>(rclnodejs.isShutdown());
 expectType<void>(rclnodejs.shutdown());

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -59,6 +59,13 @@ declare module 'rclnodejs' {
   function init(context?: Context, argv?: string[]): Promise<void>;
 
   /**
+   * Remove ROS-specific arguments from the given argument list.
+   * @param argv - The argument list to process.
+   * @returns The argument list with ROS arguments removed.
+   */
+  function removeROSArgs(argv: string[]): string[];
+
+  /**
    * Start detection and processing of units of work.
    *
    * @param node - The node to be spun.


### PR DESCRIPTION
This PR adds a new `removeROSArgs()` function to rclnodejs that filters out ROS-specific command-line arguments from a given argument list, returning only the non-ROS arguments.

- Implements `removeROSArgs()` function with complete TypeScript type definitions
- Adds comprehensive test coverage including edge cases for invalid inputs
- Uses native RCL functions (`rcl_parse_arguments` and `rcl_remove_ros_arguments`) for correct ROS argument parsing

Fix: #1330