### PR TITLE
Leverage rcl_arguments_get_unparsed_ros() to get unsupported args

### DIFF
--- a/src/rcl_context_bindings.cpp
+++ b/src/rcl_context_bindings.cpp
@@ -73,6 +73,11 @@ Napi::Value Init(const Napi::CallbackInfo& info) {
       rcl_init(argc, argc > 0 ? argv : nullptr, &init_options, context),
       rcl_get_error_string().str);
 
+  ThrowIfUnparsedROSArgs(env, jsArgv, context->global_arguments);
+  if (env.IsExceptionPending()) {
+    return env.Undefined();
+  }
+
   THROW_ERROR_IF_NOT_EQUAL(
       RCL_RET_OK, rcl_logging_configure(&context->global_arguments, &allocator),
       rcl_get_error_string().str);

--- a/src/rcl_node_bindings.cpp
+++ b/src/rcl_node_bindings.cpp
@@ -193,9 +193,14 @@ Napi::Value CreateNode(const Napi::CallbackInfo& info) {
   rcl_arguments_t arguments = rcl_get_zero_initialized_arguments();
   rcl_ret_t ret =
       rcl_parse_arguments(argc, argv, rcl_get_default_allocator(), &arguments);
-  if ((ret != RCL_RET_OK) || HasUnparsedROSArgs(arguments)) {
+  if (ret != RCL_RET_OK) {
     Napi::Error::New(env, "failed to parse arguments")
         .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  ThrowIfUnparsedROSArgs(env, jsArgv, arguments);
+  if (env.IsExceptionPending()) {
     return env.Undefined();
   }
 

--- a/src/rcl_utilities.cpp
+++ b/src/rcl_utilities.cpp
@@ -369,8 +369,9 @@ void ThrowIfUnparsedROSArgs(Napi::Env env, const Napi::Array& jsArgv,
     return;
   }
 
-  RCPPUTILS_SCOPE_EXIT(
-      { allocator.deallocate(unparsed_indices_c, allocator.state); });
+  RCPPUTILS_SCOPE_EXIT({
+    allocator.deallocate(unparsed_indices_c, allocator.state);
+  });
 
   std::string unparsed_args_str = "[";
   for (int i = 0; i < unparsed_ros_args_count; ++i) {

--- a/src/rcl_utilities.cpp
+++ b/src/rcl_utilities.cpp
@@ -21,6 +21,7 @@
 
 #include <cstdio>
 #include <memory>
+#include <rcpputils/scope_exit.hpp>
 #include <string>
 
 namespace {
@@ -344,9 +345,50 @@ void FreeArgs(char** argv, size_t argc) {
   }
 }
 
-bool HasUnparsedROSArgs(const rcl_arguments_t& rcl_args) {
+void ThrowIfUnparsedROSArgs(Napi::Env env, const Napi::Array& jsArgv,
+                            const rcl_arguments_t& rcl_args) {
   int unparsed_ros_args_count = rcl_arguments_get_count_unparsed_ros(&rcl_args);
-  return unparsed_ros_args_count != 0;
+
+  if (unparsed_ros_args_count < 0) {
+    Napi::Error::New(env, "Failed to count unparsed arguments")
+        .ThrowAsJavaScriptException();
+    return;
+  }
+  if (0 == unparsed_ros_args_count) {
+    return;
+  }
+
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  int* unparsed_indices_c = nullptr;
+  rcl_ret_t ret =
+      rcl_arguments_get_unparsed_ros(&rcl_args, allocator, &unparsed_indices_c);
+  if (RCL_RET_OK != ret) {
+    Napi::Error::New(env, "Failed to get unparsed arguments")
+        .ThrowAsJavaScriptException();
+    return;
+  }
+
+  RCPPUTILS_SCOPE_EXIT(
+      { allocator.deallocate(unparsed_indices_c, allocator.state); });
+
+  std::string unparsed_args_str = "[";
+  for (int i = 0; i < unparsed_ros_args_count; ++i) {
+    int index = unparsed_indices_c[i];
+    if (index < 0 || static_cast<size_t>(index) >= jsArgv.Length()) {
+      Napi::Error::New(env, "Got invalid unparsed ROS arg index")
+          .ThrowAsJavaScriptException();
+      return;
+    }
+    std::string arg = jsArgv.Get(index).As<Napi::String>().Utf8Value();
+    unparsed_args_str += "'" + arg + "'";
+    if (i < unparsed_ros_args_count - 1) {
+      unparsed_args_str += ", ";
+    }
+  }
+  unparsed_args_str += "]";
+
+  Napi::Error::New(env, "Unknown ROS arguments: " + unparsed_args_str)
+      .ThrowAsJavaScriptException();
 }
 
 }  // namespace rclnodejs

--- a/src/rcl_utilities.cpp
+++ b/src/rcl_utilities.cpp
@@ -22,6 +22,7 @@
 #include <cstdio>
 #include <memory>
 #include <rcpputils/scope_exit.hpp>
+// NOLINTNEXTLINE
 #include <string>
 
 namespace {

--- a/src/rcl_utilities.h
+++ b/src/rcl_utilities.h
@@ -63,7 +63,8 @@ char** AbstractArgsFromNapiArray(const Napi::Array& jsArgv);
 // `AbstractArgsFromNapiArray` and `FreeArgs` must be called in pairs.
 void FreeArgs(char** argv, size_t argc);
 
-bool HasUnparsedROSArgs(const rcl_arguments_t& rcl_args);
+void ThrowIfUnparsedROSArgs(Napi::Env env, const Napi::Array& jsArgv,
+                            const rcl_arguments_t& rcl_args);
 
 }  // namespace rclnodejs
 

--- a/test/test-unparsed-args.js
+++ b/test/test-unparsed-args.js
@@ -1,0 +1,59 @@
+// Copyright (c) 2025, The Robot Web Tools Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const rclnodejs = require('../index.js');
+
+describe('rclnodejs unparsed ROS args', function () {
+  this.timeout(10 * 1000);
+
+  beforeEach(function () {
+    rclnodejs.shutdown();
+  });
+
+  afterEach(function () {
+    rclnodejs.shutdown();
+  });
+
+  it('should throw error when initializing context with unknown ROS args', async function () {
+    const args = ['--ros-args', '--unknown-arg'];
+    try {
+      await rclnodejs.init(rclnodejs.Context.defaultContext(), args);
+      assert.fail('Should have thrown an error');
+    } catch (e) {
+      assert.ok(e.message.includes('Unknown ROS arguments'));
+      assert.ok(e.message.includes('--unknown-arg'));
+    }
+  });
+
+  it('should throw error when creating node with unknown ROS args', async function () {
+    await rclnodejs.init();
+    const args = ['--ros-args', '--unknown-arg'];
+    try {
+      rclnodejs.createNode(
+        'test_node',
+        '',
+        rclnodejs.Context.defaultContext(),
+        rclnodejs.NodeOptions.defaultOptions,
+        args
+      );
+      assert.fail('Should have thrown an error');
+    } catch (e) {
+      assert.ok(e.message.includes('Unknown ROS arguments'));
+      assert.ok(e.message.includes('--unknown-arg'));
+    }
+  });
+});


### PR DESCRIPTION
This PR enhances ROS argument validation by leveraging the RCL API function `rcl_arguments_get_unparsed_ros()` to detect and report unknown ROS arguments. The implementation replaces the simple boolean check `HasUnparsedROSArgs()` with a more comprehensive `ThrowIfUnparsedROSArgs()` function that provides detailed error messages listing the specific unknown arguments.

Key changes:
- Implemented `ThrowIfUnparsedROSArgs()` to detect and report unparsed ROS arguments with detailed error messages
- Added test coverage for unknown ROS argument detection during both context initialization and node creation
- Integrated the new validation into both `rcl_init()` and `rcl_node_init()` code paths

Fix: #1330