### PR TITLE
Add TypeScript definitions and non-throwing variants for validator

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -28,8 +28,10 @@ let validator = {
 
   /**
    * Validate a given topic or service name, and throw an error if invalid.
-   * @param {string} topic - The name of topic/service. and it must be fully-qualified and already expanded.
-   * @return {boolean} - True if it is valid.
+   * @param {string} topic - The name of topic/service. Must be fully-qualified and already expanded.
+   * @returns {true} Always returns true if valid.
+   * @throws {TypeValidationError} If topic is not a string.
+   * @throws {NameValidationError} If the topic name is invalid.
    */
   validateFullTopicName(topic) {
     if (typeof topic !== 'string') {
@@ -44,9 +46,23 @@ let validator = {
   },
 
   /**
+   * Check if a fully-qualified topic name is valid without throwing.
+   * @param {string} topic - The name of topic/service. Must be fully-qualified and already expanded.
+   * @returns {boolean} True if valid, false otherwise.
+   */
+  isValidFullTopicName(topic) {
+    if (typeof topic !== 'string') {
+      return false;
+    }
+    return rclnodejs.validateFullTopicName(topic) === null;
+  },
+
+  /**
    * Validate a given node name, and throw an error if invalid.
    * @param {string} name - The name of node.
-   * @return {boolean} - True if it is valid.
+   * @returns {true} Always returns true if valid.
+   * @throws {TypeValidationError} If name is not a string.
+   * @throws {NameValidationError} If the node name is invalid.
    */
   validateNodeName(name) {
     if (typeof name !== 'string') {
@@ -61,9 +77,23 @@ let validator = {
   },
 
   /**
+   * Check if a node name is valid without throwing.
+   * @param {string} name - The name of node.
+   * @returns {boolean} True if valid, false otherwise.
+   */
+  isValidNodeName(name) {
+    if (typeof name !== 'string') {
+      return false;
+    }
+    return rclnodejs.validateNodeName(name) === null;
+  },
+
+  /**
    * Validate a given topic or service name, and throw an error if invalid.
-   * @param {string} topic - The name of topic/service and does not have to be fully-qualified and is not expanded.
-   * @return {boolean} - True if it is valid.
+   * @param {string} topic - The name of topic/service. Does not have to be fully-qualified.
+   * @returns {true} Always returns true if valid.
+   * @throws {TypeValidationError} If topic is not a string.
+   * @throws {NameValidationError} If the topic name is invalid.
    */
   validateTopicName(topic) {
     if (typeof topic !== 'string') {
@@ -78,9 +108,23 @@ let validator = {
   },
 
   /**
+   * Check if a topic name is valid without throwing.
+   * @param {string} topic - The name of topic/service. Does not have to be fully-qualified.
+   * @returns {boolean} True if valid, false otherwise.
+   */
+  isValidTopicName(topic) {
+    if (typeof topic !== 'string') {
+      return false;
+    }
+    return rclnodejs.validateTopicName(topic) === null;
+  },
+
+  /**
    * Validate a given namespace, and throw an error if invalid.
-   * @param {string} namespace - The namespace to be validated
-   * @return {boolean} - True if it is valid.
+   * @param {string} namespace - The namespace to be validated.
+   * @returns {true} Always returns true if valid.
+   * @throws {TypeValidationError} If namespace is not a string.
+   * @throws {NameValidationError} If the namespace is invalid.
    */
   validateNamespace(namespace) {
     if (typeof namespace !== 'string') {
@@ -92,6 +136,18 @@ let validator = {
       return true;
     }
     throw this._createErrorFromValidation(result, namespace, 'namespace');
+  },
+
+  /**
+   * Check if a namespace is valid without throwing.
+   * @param {string} namespace - The namespace to be validated.
+   * @returns {boolean} True if valid, false otherwise.
+   */
+  isValidNamespace(namespace) {
+    if (typeof namespace !== 'string') {
+      return false;
+    }
+    return rclnodejs.validateNamespace(namespace) === null;
   },
 };
 

--- a/test/test-validator.js
+++ b/test/test-validator.js
@@ -178,4 +178,127 @@ describe('rclnodejs validator testing', function () {
       'invalid namespace!'
     );
   });
+
+  describe('isValidFullTopicName', function () {
+    it('should return true for valid fully-qualified topics', function () {
+      assert.strictEqual(
+        rclnodejs.validator.isValidFullTopicName('/chatter'),
+        true
+      );
+      assert.strictEqual(
+        rclnodejs.validator.isValidFullTopicName('/node_name/chatter'),
+        true
+      );
+      assert.strictEqual(
+        rclnodejs.validator.isValidFullTopicName('/ns/node_name/chatter'),
+        true
+      );
+    });
+
+    it('should return false for invalid topics', function () {
+      assert.strictEqual(
+        rclnodejs.validator.isValidFullTopicName('/invalid_topic?'),
+        false
+      );
+      assert.strictEqual(
+        rclnodejs.validator.isValidFullTopicName('relative_topic'),
+        false
+      );
+    });
+
+    it('should return false for non-string input', function () {
+      assert.strictEqual(rclnodejs.validator.isValidFullTopicName(123), false);
+      assert.strictEqual(rclnodejs.validator.isValidFullTopicName(null), false);
+      assert.strictEqual(
+        rclnodejs.validator.isValidFullTopicName(undefined),
+        false
+      );
+    });
+  });
+
+  describe('isValidNodeName', function () {
+    it('should return true for valid node names', function () {
+      assert.strictEqual(rclnodejs.validator.isValidNodeName('my_node'), true);
+      assert.strictEqual(rclnodejs.validator.isValidNodeName('node123'), true);
+    });
+
+    it('should return false for invalid node names', function () {
+      assert.strictEqual(rclnodejs.validator.isValidNodeName(''), false);
+      assert.strictEqual(
+        rclnodejs.validator.isValidNodeName('invalid_node?'),
+        false
+      );
+      assert.strictEqual(
+        rclnodejs.validator.isValidNodeName('/invalid_node'),
+        false
+      );
+    });
+
+    it('should return false for non-string input', function () {
+      assert.strictEqual(rclnodejs.validator.isValidNodeName(123), false);
+      assert.strictEqual(rclnodejs.validator.isValidNodeName(null), false);
+    });
+  });
+
+  describe('isValidTopicName', function () {
+    it('should return true for valid topic names', function () {
+      assert.strictEqual(rclnodejs.validator.isValidTopicName('chatter'), true);
+      assert.strictEqual(
+        rclnodejs.validator.isValidTopicName('{node}/chatter'),
+        true
+      );
+      assert.strictEqual(
+        rclnodejs.validator.isValidTopicName('~/chatter'),
+        true
+      );
+      assert.strictEqual(
+        rclnodejs.validator.isValidTopicName('/my/topic'),
+        true
+      );
+    });
+
+    it('should return false for invalid topic names', function () {
+      assert.strictEqual(rclnodejs.validator.isValidTopicName(''), false);
+      assert.strictEqual(
+        rclnodejs.validator.isValidTopicName('/invalid_topic?'),
+        false
+      );
+      assert.strictEqual(
+        rclnodejs.validator.isValidTopicName('invalid/42topic'),
+        false
+      );
+    });
+
+    it('should return false for non-string input', function () {
+      assert.strictEqual(rclnodejs.validator.isValidTopicName(123), false);
+    });
+  });
+
+  describe('isValidNamespace', function () {
+    it('should return true for valid namespaces', function () {
+      assert.strictEqual(rclnodejs.validator.isValidNamespace('/my_ns'), true);
+      assert.strictEqual(rclnodejs.validator.isValidNamespace('/'), true);
+      assert.strictEqual(
+        rclnodejs.validator.isValidNamespace('/deep/namespace'),
+        true
+      );
+    });
+
+    it('should return false for invalid namespaces', function () {
+      assert.strictEqual(rclnodejs.validator.isValidNamespace(''), false);
+      assert.strictEqual(
+        rclnodejs.validator.isValidNamespace('invalid_namespace'),
+        false
+      );
+      assert.strictEqual(
+        rclnodejs.validator.isValidNamespace('invalid namespace'),
+        false
+      );
+    });
+
+    it('should return false for non-string input', function () {
+      assert.strictEqual(rclnodejs.validator.isValidNamespace(123), false);
+      assert.strictEqual(rclnodejs.validator.isValidNamespace(null), false);
+    });
+  });
 });

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -28,3 +28,4 @@
 /// <reference path="./time_source.d.ts" />
 /// <reference path="./time.d.ts" />
 /// <reference path="./timer.d.ts" />
+/// <reference path="./validator.d.ts" />

--- a/types/validator.d.ts
+++ b/types/validator.d.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 Mahmoud Alghalayini. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+declare module 'rclnodejs' {
+  /**
+   * Validator for ROS 2 names (topics, services, nodes, namespaces).
+   */
+  namespace validator {
+    /**
+     * Validate a fully-qualified topic or service name.
+     * The name must be fully-qualified and already expanded.
+     * @param topic - The topic/service name to validate.
+     * @returns Always returns true if valid.
+     * @throws TypeValidationError if topic is not a string.
+     * @throws NameValidationError if the name is invalid.
+     */
+    function validateFullTopicName(topic: string): true;
+
+    /**
+     * Check if a fully-qualified topic name is valid without throwing.
+     * @param topic - The topic/service name to check.
+     * @returns True if valid, false otherwise.
+     */
+    function isValidFullTopicName(topic: string): boolean;
+
+    /**
+     * Validate a node name.
+     * @param name - The node name to validate.
+     * @returns Always returns true if valid.
+     * @throws TypeValidationError if name is not a string.
+     * @throws NameValidationError if the name is invalid.
+     */
+    function validateNodeName(name: string): true;
+
+    /**
+     * Check if a node name is valid without throwing.
+     * @param name - The node name to check.
+     * @returns True if valid, false otherwise.
+     */
+    function isValidNodeName(name: string): boolean;
+
+    /**
+     * Validate a topic or service name.
+     * The name does not have to be fully-qualified and is not expanded.
+     * @param topic - The topic/service name to validate.
+     * @returns Always returns true if valid.
+     * @throws TypeValidationError if topic is not a string.
+     * @throws NameValidationError if the name is invalid.
+     */
+    function validateTopicName(topic: string): true;
+
+    /**
+     * Check if a topic name is valid without throwing.
+     * @param topic - The topic/service name to check.
+     * @returns True if valid, false otherwise.
+     */
+    function isValidTopicName(topic: string): boolean;
+
+    /**
+     * Validate a namespace.
+     * @param namespace - The namespace to validate.
+     * @returns Always returns true if valid.
+     * @throws TypeValidationError if namespace is not a string.
+     * @throws NameValidationError if the namespace is invalid.
+     */
+    function validateNamespace(namespace: string): true;
+
+    /**
+     * Check if a namespace is valid without throwing.
+     * @param namespace - The namespace to check.
+     * @returns True if valid, false otherwise.
+     */
+    function isValidNamespace(namespace: string): boolean;
+  }
+}


### PR DESCRIPTION
**Public API Changes**

Added non-throwing validator variants to `rclnodejs.validator`:
- `isValidFullTopicName(topic: string): boolean`
- `isValidNodeName(name: string): boolean`
- `isValidTopicName(topic: string): boolean`
- `isValidNamespace(namespace: string): boolean`

Added TypeScript definitions for all validator methods in `types/validator.d.ts`.

[#1344](https://github.com/RobotWebTools/rclnodejs/issues/1344)