### PR TITLE
Add MessageIntrospector for message schema inspection

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -45,6 +45,8 @@
   - Add structured error handling with class error hierarchy
   - Add ParameterWatcher for real-time parameter monitoring
   - Enhance Message Validation
+  - Add TypeScript definitions and non-throwing variants for validator
+  - add MessageIntrospector for message schema inspection
 
 - **[Martins Mozeiko](https://github.com/martins-mozeiko)**
   - QoS new/delete fix

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,7 +46,7 @@
   - Add ParameterWatcher for real-time parameter monitoring
   - Enhance Message Validation
   - Add TypeScript definitions and non-throwing variants for validator
-  - add MessageIntrospector for message schema inspection
+  - Add MessageIntrospector for message schema inspection
 
 - **[Martins Mozeiko](https://github.com/martins-mozeiko)**
   - QoS new/delete fix

--- a/example/message-introspector/README.md
+++ b/example/message-introspector/README.md
@@ -19,20 +19,12 @@ node message-introspector-example.js
 ### Expected Output
 
 ```
-Type: geometry_msgs/msg/Twist
-Fields: [ 'linear', 'angular' ]
-Defaults: {
-  "linear": {
-    "x": 0,
-    "y": 0,
-    "z": 0
-  },
-  "angular": {
-    "x": 0,
-    "y": 0,
-    "z": 0
-  }
-}
+Twist fields: [ 'linear', 'angular' ]
+Twist defaults: { linear: { x: 0, y: 0, z: 0 }, angular: { x: 0, y: 0, z: 0 } }
+String fields: [ 'data' ]
+String defaults: { data: '' }
+JointState fields: [ 'header', 'name', 'position', 'velocity', 'effort' ]
+Twist schema msgName: Twist
 ```
 
 ## API

--- a/example/message-introspector/README.md
+++ b/example/message-introspector/README.md
@@ -1,0 +1,55 @@
+# ROS 2 MessageIntrospector Example
+
+This directory contains an example demonstrating the `MessageIntrospector` class for inspecting ROS 2 message structure.
+
+## Overview
+
+The `MessageIntrospector` class provides a simple way to understand the structure of ROS 2 messages without directly using `loader.loadInterface`. It's useful for debugging, generating documentation, and building dynamic UIs based on message structure.
+
+## MessageIntrospector Example (`message-introspector-example.js`)
+
+**Purpose**: Demonstrates how to inspect message structure, fields, and default values.
+
+### Run Command
+
+```bash
+node message-introspector-example.js
+```
+
+### Expected Output
+
+```
+Type: geometry_msgs/msg/Twist
+Fields: [ 'linear', 'angular' ]
+Defaults: {
+  "linear": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "angular": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  }
+}
+```
+
+## API
+
+```javascript
+const Twist = new rclnodejs.MessageIntrospector('geometry_msgs/msg/Twist');
+
+Twist.typeName; // 'geometry_msgs/msg/Twist'
+Twist.fields; // ['linear', 'angular']
+Twist.defaults; // { linear: { x: 0, y: 0, z: 0 }, angular: { x: 0, y: 0, z: 0 } }
+Twist.schema; // ROSMessageDef object
+Twist.typeClass; // The underlying constructor
+```
+
+## Notes
+
+- Works with any message type including custom packages
+- Default values are cached for performance after the first access
+- The `defaults` getter returns a new deep copy each time to prevent mutation
+- Service request/response types can also be inspected (e.g., `'my_pkg/srv/MyService_Request'`)

--- a/example/message-introspector/message-introspector-example.js
+++ b/example/message-introspector/message-introspector-example.js
@@ -1,0 +1,45 @@
+// Copyright (c) 2025 Mahmoud Alghalayini. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const rclnodejs = require('../../index.js');
+
+/**
+ * This example demonstrates the MessageIntrospector class for
+ * inspecting ROS 2 message structure without using loader.loadInterface.
+ */
+async function main() {
+  await rclnodejs.init();
+
+  const Twist = new rclnodejs.MessageIntrospector('geometry_msgs/msg/Twist');
+  const String = new rclnodejs.MessageIntrospector('std_msgs/msg/String');
+  const JointState = new rclnodejs.MessageIntrospector(
+    'sensor_msgs/msg/JointState'
+  );
+
+  console.log('Twist fields:', Twist.fields);
+  console.log('Twist defaults:', Twist.defaults);
+
+  console.log('String fields:', String.fields);
+  console.log('String defaults:', String.defaults);
+
+  console.log('JointState fields:', JointState.fields);
+
+  console.log('Twist schema msgName:', Twist.schema.msgName);
+
+  await rclnodejs.shutdown();
+}
+
+main();

--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ const {
 const ParameterClient = require('./lib/parameter_client.js');
 const errors = require('./lib/errors.js');
 const ParameterWatcher = require('./lib/parameter_watcher.js');
+const MessageIntrospector = require('./lib/message_introspector.js');
 const { spawn } = require('child_process');
 const {
   ValidationProblem,
@@ -721,3 +722,6 @@ const Lifecycle = require('./lib/lifecycle.js');
 
 /** Lifecycle namespace */
 rcl.lifecycle = Lifecycle;
+
+/** {@link MessageIntrospector} class */
+rcl.MessageIntrospector = MessageIntrospector;

--- a/lib/message_introspector.js
+++ b/lib/message_introspector.js
@@ -1,0 +1,123 @@
+// Copyright (c) 2025 Mahmoud Alghalayini. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const loader = require('./interface_loader.js');
+const { toPlainObject } = require('../rosidl_gen/message_translator.js');
+const { TypeValidationError } = require('./errors.js');
+
+/**
+ * A utility class for inspecting ROS 2 message structure without using loader.loadInterface directly.
+ * Provides access to message schema, field names, and default values.
+ */
+class MessageIntrospector {
+  #typeClass;
+  #typeName;
+  #defaultsCache;
+
+  /**
+   * Create a new MessageIntrospector for a ROS 2 message type.
+   * @param {string} typeName - The full message type name (e.g., 'geometry_msgs/msg/Twist')
+   * @throws {TypeValidationError} If typeName is not a non-empty string
+   * @throws {Error} If the message type cannot be loaded
+   */
+  constructor(typeName) {
+    if (!typeName || typeof typeName !== 'string') {
+      throw new TypeValidationError('typeName', typeName, 'non-empty string', {
+        entityType: 'MessageIntrospector',
+      });
+    }
+    this.#typeName = typeName;
+    this.#typeClass = loader.loadInterface(typeName);
+    this.#defaultsCache = null;
+  }
+
+  /**
+   * Get the full message type name.
+   * @returns {string} The message type name (e.g., 'geometry_msgs/msg/Twist')
+   */
+  get typeName() {
+    return this.#typeName;
+  }
+
+  /**
+   * Get the underlying ROS message class.
+   * @returns {Function} The message type class constructor
+   */
+  get typeClass() {
+    return this.#typeClass;
+  }
+
+  /**
+   * Get the field names of the message.
+   * @returns {string[]} Array of field names
+   */
+  get fields() {
+    const def = this.#typeClass.ROSMessageDef;
+    return def.fields.map((f) => f.name);
+  }
+
+  /**
+   * Get the ROSMessageDef schema for the message type.
+   * @returns {object} The message definition schema
+   */
+  get schema() {
+    return this.#typeClass.ROSMessageDef;
+  }
+
+  /**
+   * Get the default values for all fields.
+   * Creates a new instance of the message and converts it to a plain object.
+   * Result is cached for performance.
+   * @returns {object} A plain object with all default values
+   */
+  get defaults() {
+    if (this.#defaultsCache === null) {
+      const instance = new this.#typeClass();
+      this.#defaultsCache = toPlainObject(instance);
+    }
+    return this.#deepClone(this.#defaultsCache);
+  }
+
+  /**
+   * Deep clone an object.
+   * @param {any} obj - Object to clone
+   * @returns {any} Cloned object
+   * @private
+   */
+  #deepClone(obj) {
+    if (obj === null || typeof obj !== 'object') {
+      return obj;
+    }
+
+    if (Array.isArray(obj)) {
+      return obj.map((item) => this.#deepClone(item));
+    }
+
+    if (ArrayBuffer.isView(obj) && !(obj instanceof DataView)) {
+      return obj.slice();
+    }
+
+    const cloned = {};
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        cloned[key] = this.#deepClone(obj[key]);
+      }
+    }
+    return cloned;
+  }
+}
+
+module.exports = MessageIntrospector;

--- a/src/rcl_logging_bindings.cpp
+++ b/src/rcl_logging_bindings.cpp
@@ -41,7 +41,7 @@ Napi::Value InitRosoutPublisherForNode(const Napi::CallbackInfo& info) {
           .ThrowAsJavaScriptException();
       rcl_reset_error();
     }
-      }
+  }
   return env.Undefined();
 }
 

--- a/src/rcl_utilities.cpp
+++ b/src/rcl_utilities.cpp
@@ -369,9 +369,8 @@ void ThrowIfUnparsedROSArgs(Napi::Env env, const Napi::Array& jsArgv,
     return;
   }
 
-  RCPPUTILS_SCOPE_EXIT({
-    allocator.deallocate(unparsed_indices_c, allocator.state);
-  });
+  RCPPUTILS_SCOPE_EXIT(
+      { allocator.deallocate(unparsed_indices_c, allocator.state); });
 
   std::string unparsed_args_str = "[";
   for (int i = 0; i < unparsed_ros_args_count; ++i) {

--- a/test/test-message-introspector.js
+++ b/test/test-message-introspector.js
@@ -1,0 +1,140 @@
+// Copyright (c) 2025 Mahmoud Alghalayini. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const rclnodejs = require('../index.js');
+const MessageIntrospector = require('../lib/message_introspector.js');
+const { TypeValidationError } = require('../lib/errors.js');
+
+describe('MessageIntrospector Tests', function () {
+  before(async function () {
+    try {
+      await rclnodejs.init();
+    } catch {}
+  });
+
+  after(function () {
+    try {
+      rclnodejs.shutdown();
+    } catch {}
+  });
+
+  describe('Constructor', function () {
+    it('should create an introspector for std_msgs/msg/String', function () {
+      const introspector = new MessageIntrospector('std_msgs/msg/String');
+      assert.strictEqual(introspector.typeName, 'std_msgs/msg/String');
+    });
+
+    it('should create an introspector for geometry_msgs/msg/Twist', function () {
+      const introspector = new MessageIntrospector('geometry_msgs/msg/Twist');
+      assert.strictEqual(introspector.typeName, 'geometry_msgs/msg/Twist');
+    });
+
+    it('should throw TypeValidationError for invalid typeName', function () {
+      assert.throws(() => new MessageIntrospector(null), TypeValidationError);
+      assert.throws(() => new MessageIntrospector(''), TypeValidationError);
+      assert.throws(() => new MessageIntrospector(123), TypeValidationError);
+    });
+
+    it('should throw for unknown message type', function () {
+      assert.throws(() => new MessageIntrospector('unknown/msg/Type'));
+    });
+  });
+
+  describe('Properties', function () {
+    it('should return correct fields for std_msgs/msg/String', function () {
+      const introspector = new MessageIntrospector('std_msgs/msg/String');
+      assert.deepStrictEqual(introspector.fields, ['data']);
+    });
+
+    it('should return correct fields for geometry_msgs/msg/Twist', function () {
+      const introspector = new MessageIntrospector('geometry_msgs/msg/Twist');
+      assert.deepStrictEqual(introspector.fields, ['linear', 'angular']);
+    });
+
+    it('should return correct fields for sensor_msgs/msg/JointState', function () {
+      const introspector = new MessageIntrospector(
+        'sensor_msgs/msg/JointState'
+      );
+      assert.deepStrictEqual(introspector.fields, [
+        'header',
+        'name',
+        'position',
+        'velocity',
+        'effort',
+      ]);
+    });
+
+    it('should have a valid schema', function () {
+      const introspector = new MessageIntrospector('geometry_msgs/msg/Twist');
+      assert.ok(introspector.schema);
+      assert.ok(introspector.schema.fields);
+      assert.strictEqual(introspector.schema.msgName, 'Twist');
+    });
+
+    it('should have a valid typeClass', function () {
+      const introspector = new MessageIntrospector('geometry_msgs/msg/Twist');
+      assert.ok(introspector.typeClass);
+      assert.strictEqual(typeof introspector.typeClass, 'function');
+    });
+  });
+
+  describe('defaults', function () {
+    it('should return correct defaults for std_msgs/msg/String', function () {
+      const introspector = new MessageIntrospector('std_msgs/msg/String');
+      const defaults = introspector.defaults;
+      assert.deepStrictEqual(defaults, { data: '' });
+    });
+
+    it('should return correct defaults for geometry_msgs/msg/Twist', function () {
+      const introspector = new MessageIntrospector('geometry_msgs/msg/Twist');
+      const defaults = introspector.defaults;
+      assert.deepStrictEqual(defaults, {
+        linear: { x: 0, y: 0, z: 0 },
+        angular: { x: 0, y: 0, z: 0 },
+      });
+    });
+
+    it('should return a new object each time (no mutation)', function () {
+      const introspector = new MessageIntrospector('geometry_msgs/msg/Twist');
+      const defaults1 = introspector.defaults;
+      const defaults2 = introspector.defaults;
+      assert.notStrictEqual(defaults1, defaults2);
+
+      defaults1.linear.x = 999;
+      assert.strictEqual(defaults2.linear.x, 0);
+    });
+  });
+
+  describe('Integration with rclnodejs', function () {
+    it('should be accessible via rclnodejs.MessageIntrospector', function () {
+      assert.strictEqual(rclnodejs.MessageIntrospector, MessageIntrospector);
+    });
+
+    it('should work for inspecting message structure', function () {
+      const Twist = new rclnodejs.MessageIntrospector(
+        'geometry_msgs/msg/Twist'
+      );
+
+      assert.deepStrictEqual(Twist.fields, ['linear', 'angular']);
+      assert.deepStrictEqual(Twist.defaults, {
+        linear: { x: 0, y: 0, z: 0 },
+        angular: { x: 0, y: 0, z: 0 },
+      });
+      assert.strictEqual(Twist.schema.msgName, 'Twist');
+    });
+  });
+});

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -14,6 +14,7 @@
 /// <reference path="./lifecycle.d.ts" />
 /// <reference path="./lifecycle_publisher.d.ts" />
 /// <reference path="./logging.d.ts" />
+/// <reference path="./message_introspector.d.ts" />
 /// <reference path="./node.d.ts" />
 /// <reference path="./node_options.d.ts" />
 /// <reference path="./parameter.d.ts" />

--- a/types/message_introspector.d.ts
+++ b/types/message_introspector.d.ts
@@ -1,0 +1,75 @@
+declare module 'rclnodejs' {
+  /**
+   * A utility class for inspecting ROS 2 message structure without using loader.loadInterface directly.
+   * Provides access to message schema, field names, and default values.
+   */
+  export class MessageIntrospector<T = any> {
+    /**
+     * Create a new MessageIntrospector for a ROS 2 message type.
+     * @param typeName - The full message type name (e.g., 'geometry_msgs/msg/Twist')
+     * @throws {TypeValidationError} If typeName is not a non-empty string
+     * @throws {Error} If the message type cannot be loaded
+     */
+    constructor(typeName: string);
+
+    /**
+     * Get the full message type name.
+     */
+    readonly typeName: string;
+
+    /**
+     * Get the underlying ROS message class.
+     */
+    readonly typeClass: new () => T;
+
+    /**
+     * Get the field names of the message.
+     */
+    readonly fields: string[];
+
+    /**
+     * Get the ROSMessageDef schema for the message type.
+     */
+    readonly schema: ROSMessageDef;
+
+    /**
+     * Get the default values for all fields.
+     * Creates a new instance of the message and converts it to a plain object.
+     * Result is cached for performance.
+     */
+    readonly defaults: T;
+  }
+
+  /**
+   * ROSMessageDef schema structure.
+   */
+  interface ROSMessageDef {
+    constants: Array<{
+      name: string;
+      type: string;
+      value: any;
+    }>;
+    fields: Array<{
+      name: string;
+      type: {
+        isPrimitiveType: boolean;
+        type: string;
+        pkgName: string | null;
+        isArray: boolean;
+        isDynamicArray: boolean;
+        isFixedSizeArray: boolean | null;
+        arraySize: number | null;
+        stringUpperBound: number | null;
+        isUpperBound: boolean;
+      };
+      default_value: any;
+    }>;
+    msgName: string;
+    baseType: {
+      pkgName: string;
+      type: string;
+      stringUpperBound: number | null;
+      isPrimitiveType: boolean;
+    };
+  }
+}


### PR DESCRIPTION
**Public API Changes**

Added `MessageIntrospector` class to inspect ROS 2 message structure without using `loader.loadInterface` directly. Useful for debugging, documentation, and building dynamic UIs based on message structure.

**Constructor:**

- `new MessageIntrospector(typeName)` - Create an introspector for any message type

**Properties:**

- `introspector.typeName` - Get the full message type name
- `introspector.typeClass` - Get the underlying message class constructor
- `introspector.fields` - Get array of field names
- `introspector.schema` - Get ROSMessageDef schema object
- `introspector.defaults` - Get default values for all fields (cached, returns deep copy)

**TypeScript:**

- Added `MessageIntrospector<T>` class
- Added `ROSMessageDef` interface

[#1343](https://github.com/RobotWebTools/rclnodejs/issues/1343)