### PR TITLE
Add node-gyp into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
-    "@types/node": "^24.5.2",
+    "@types/node": "^25.0.2",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",
     "clang-format": "^1.8.0",
@@ -64,6 +64,7 @@
     "jsdoc": "^4.0.4",
     "lint-staged": "^16.2.0",
     "mocha": "^11.0.2",
+    "node-gyp": "^12.1.0",
     "nyc": "^17.1.0",
     "prebuildify": "^6.0.1",
     "rimraf": "^6.0.1",


### PR DESCRIPTION
This PR adds `node-gyp` as an explicit devDependency and updates the `@types/node` package to a newer version. The addition of node-gyp makes sense as it's already used extensively in the project's build scripts but was not previously declared as a dependency.

- Adds `node-gyp` ^12.1.0 to devDependencies
- Updates `@types/node` from ^24.5.2 to ^25.0.2

Fix: #1350