### PR TITLE
Remove rolling from Windows action

### DIFF
--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -19,7 +19,6 @@ jobs:
           - humble
           - jazzy
           - kilted
-          - rolling
     steps:
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6


### PR DESCRIPTION
We are going to remove `rolling` build from Windows action becaue recently downloading package from https://ci.ros2.org/view/packaging/ needs authentication.

Fix: ##1353