### PR TITLE
Add Clock callback support

### DIFF
--- a/lib/clock.js
+++ b/lib/clock.js
@@ -56,6 +56,31 @@ class Clock {
    * @param {bigint} minBackward - Minimum backward jump to trigger the callback.
    */
   addClockCallback(callbackObject, onClockChange, minForward, minBackward) {
+    if (typeof callbackObject !== 'object' || callbackObject === null) {
+      throw new TypeValidationError(
+        'callbackObject',
+        callbackObject,
+        'object',
+        {
+          entityType: 'clock',
+        }
+      );
+    }
+    if (typeof onClockChange !== 'boolean') {
+      throw new TypeValidationError('onClockChange', onClockChange, 'boolean', {
+        entityType: 'clock',
+      });
+    }
+    if (typeof minForward !== 'bigint') {
+      throw new TypeValidationError('minForward', minForward, 'bigint', {
+        entityType: 'clock',
+      });
+    }
+    if (typeof minBackward !== 'bigint') {
+      throw new TypeValidationError('minBackward', minBackward, 'bigint', {
+        entityType: 'clock',
+      });
+    }
     rclnodejs.clockAddJumpCallback(
       this._handle,
       callbackObject,
@@ -70,6 +95,16 @@ class Clock {
    * @param {object} callbackObject - The object containing _pre_callback and _post_callback methods.
    */
   removeClockCallback(callbackObject) {
+    if (typeof callbackObject !== 'object' || callbackObject === null) {
+      throw new TypeValidationError(
+        'callbackObject',
+        callbackObject,
+        'object',
+        {
+          entityType: 'clock',
+        }
+      );
+    }
     rclnodejs.clockRemoveJumpCallback(this._handle, callbackObject);
   }
 

--- a/lib/clock.js
+++ b/lib/clock.js
@@ -49,6 +49,31 @@ class Clock {
   }
 
   /**
+   * Add a clock callback.
+   * @param {object} callbackObject - The object containing _pre_callback and _post_callback methods.
+   * @param {boolean} onClockChange - Whether to call the callback on clock change.
+   * @param {bigint} minForward - Minimum forward jump to trigger the callback.
+   * @param {bigint} minBackward - Minimum backward jump to trigger the callback.
+   */
+  addClockCallback(callbackObject, onClockChange, minForward, minBackward) {
+    rclnodejs.clockAddJumpCallback(
+      this._handle,
+      callbackObject,
+      onClockChange,
+      minForward,
+      minBackward
+    );
+  }
+
+  /**
+   * Remove a clock callback.
+   * @param {object} callbackObject - The object containing _pre_callback and _post_callback methods.
+   */
+  removeClockCallback(callbackObject) {
+    rclnodejs.clockRemoveJumpCallback(this._handle, callbackObject);
+  }
+
+  /**
    * Return the current time.
    * @return {Time} Return the current time.
    */

--- a/src/rcl_time_point_bindings.cpp
+++ b/src/rcl_time_point_bindings.cpp
@@ -175,9 +175,111 @@ Napi::Value ClockGetNow(const Napi::CallbackInfo& info) {
   return Napi::BigInt::New(env, time_point.nanoseconds);
 }
 
+struct JumpCallbackData {
+  Napi::ObjectReference ref;
+};
+
+void _rclnodejs_on_time_jump(const rcl_time_jump_t* time_jump, bool before_jump,
+                             void* user_data) {
+  JumpCallbackData* data = static_cast<JumpCallbackData*>(user_data);
+  Napi::Env env = data->ref.Env();
+  Napi::HandleScope scope(env);
+
+  Napi::Object callback_obj = data->ref.Value();
+
+  if (before_jump) {
+    Napi::Value pre_callback = callback_obj.Get("_pre_callback");
+    if (pre_callback.IsFunction()) {
+      pre_callback.As<Napi::Function>().Call(callback_obj, {});
+    }
+  } else {
+    Napi::Value post_callback = callback_obj.Get("_post_callback");
+    if (post_callback.IsFunction()) {
+      Napi::Object jump_info = Napi::Object::New(env);
+      jump_info.Set("clock_change",
+                    static_cast<int32_t>(time_jump->clock_change));
+      jump_info.Set("delta",
+                    Napi::BigInt::New(env, time_jump->delta.nanoseconds));
+      post_callback.As<Napi::Function>().Call(callback_obj, {jump_info});
+    }
+  }
+}
+
+Napi::Value ClockAddJumpCallback(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* clock_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_clock_t* clock = reinterpret_cast<rcl_clock_t*>(clock_handle->ptr());
+
+  Napi::Object callback_obj = info[1].As<Napi::Object>();
+  bool on_clock_change = info[2].As<Napi::Boolean>();
+
+  bool lossless;
+  int64_t min_forward = info[3].As<Napi::BigInt>().Int64Value(&lossless);
+  int64_t min_backward = info[4].As<Napi::BigInt>().Int64Value(&lossless);
+
+  rcl_jump_threshold_t threshold;
+  threshold.on_clock_change = on_clock_change;
+  threshold.min_forward.nanoseconds = min_forward;
+  threshold.min_backward.nanoseconds = min_backward;
+
+  JumpCallbackData* data = new JumpCallbackData{Napi::Persistent(callback_obj)};
+  callback_obj.Set("_cpp_handle",
+                   Napi::External<JumpCallbackData>::New(env, data));
+
+  rcl_ret_t ret = rcl_clock_add_jump_callback(clock, threshold,
+                                              _rclnodejs_on_time_jump, data);
+
+  if (ret != RCL_RET_OK) {
+    data->ref.Reset();
+    delete data;
+    callback_obj.Set("_cpp_handle", env.Undefined());
+    THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
+  }
+
+  return env.Undefined();
+}
+
+Napi::Value ClockRemoveJumpCallback(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* clock_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_clock_t* clock = reinterpret_cast<rcl_clock_t*>(clock_handle->ptr());
+
+  Napi::Object callback_obj = info[1].As<Napi::Object>();
+  Napi::Value cpp_handle = callback_obj.Get("_cpp_handle");
+
+  if (cpp_handle.IsUndefined() || !cpp_handle.IsExternal()) {
+    Napi::Error::New(env,
+                     "Callback object was not registered or already removed")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  JumpCallbackData* data =
+      cpp_handle.As<Napi::External<JumpCallbackData>>().Data();
+
+  rcl_ret_t ret =
+      rcl_clock_remove_jump_callback(clock, _rclnodejs_on_time_jump, data);
+
+  if (ret == RCL_RET_OK) {
+    data->ref.Reset();
+    delete data;
+    callback_obj.Set("_cpp_handle", env.Undefined());
+  } else {
+    THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
+  }
+
+  return env.Undefined();
+}
+
 Napi::Object InitTimePointBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("createClock", Napi::Function::New(env, CreateClock));
   exports.Set("clockGetNow", Napi::Function::New(env, ClockGetNow));
+  exports.Set("clockAddJumpCallback",
+              Napi::Function::New(env, ClockAddJumpCallback));
+  exports.Set("clockRemoveJumpCallback",
+              Napi::Function::New(env, ClockRemoveJumpCallback));
   exports.Set("createTimePoint", Napi::Function::New(env, CreateTimePoint));
   exports.Set("getNanoseconds", Napi::Function::New(env, GetNanoseconds));
   exports.Set("createDuration", Napi::Function::New(env, CreateDuration));

--- a/src/rcl_time_point_bindings.cpp
+++ b/src/rcl_time_point_bindings.cpp
@@ -176,32 +176,40 @@ Napi::Value ClockGetNow(const Napi::CallbackInfo& info) {
 }
 
 struct JumpCallbackData {
-  Napi::ObjectReference ref;
+  Napi::ThreadSafeFunction tsfn_pre;
+  Napi::ThreadSafeFunction tsfn_post;
+};
+
+struct JumpCallbackContext {
+  rcl_time_jump_t time_jump;
+  bool before_jump;
 };
 
 void _rclnodejs_on_time_jump(const rcl_time_jump_t* time_jump, bool before_jump,
                              void* user_data) {
   JumpCallbackData* data = static_cast<JumpCallbackData*>(user_data);
-  Napi::Env env = data->ref.Env();
-  Napi::HandleScope scope(env);
 
-  Napi::Object callback_obj = data->ref.Value();
+  auto context = new JumpCallbackContext{*time_jump, before_jump};
 
   if (before_jump) {
-    Napi::Value pre_callback = callback_obj.Get("_pre_callback");
-    if (pre_callback.IsFunction()) {
-      pre_callback.As<Napi::Function>().Call(callback_obj, {});
-    }
+    auto callback = [](Napi::Env env, Napi::Function js_callback,
+                       JumpCallbackContext* context) {
+      js_callback.Call({});
+      delete context;
+    };
+    data->tsfn_pre.NonBlockingCall(context, callback);
   } else {
-    Napi::Value post_callback = callback_obj.Get("_post_callback");
-    if (post_callback.IsFunction()) {
+    auto callback = [](Napi::Env env, Napi::Function js_callback,
+                       JumpCallbackContext* context) {
       Napi::Object jump_info = Napi::Object::New(env);
       jump_info.Set("clock_change",
-                    static_cast<int32_t>(time_jump->clock_change));
-      jump_info.Set("delta",
-                    Napi::BigInt::New(env, time_jump->delta.nanoseconds));
-      post_callback.As<Napi::Function>().Call(callback_obj, {jump_info});
-    }
+                    static_cast<int32_t>(context->time_jump.clock_change));
+      jump_info.Set("delta", Napi::BigInt::New(
+                                 env, context->time_jump.delta.nanoseconds));
+      js_callback.Call({jump_info});
+      delete context;
+    };
+    data->tsfn_post.NonBlockingCall(context, callback);
   }
 }
 
@@ -212,30 +220,55 @@ Napi::Value ClockAddJumpCallback(const Napi::CallbackInfo& info) {
   rcl_clock_t* clock = reinterpret_cast<rcl_clock_t*>(clock_handle->ptr());
 
   Napi::Object callback_obj = info[1].As<Napi::Object>();
+  Napi::Function pre_callback =
+      callback_obj.Get("_pre_callback").As<Napi::Function>();
+  Napi::Function post_callback =
+      callback_obj.Get("_post_callback").As<Napi::Function>();
+
   bool on_clock_change = info[2].As<Napi::Boolean>();
 
   bool lossless;
   int64_t min_forward = info[3].As<Napi::BigInt>().Int64Value(&lossless);
+  if (!lossless) {
+    Napi::TypeError::New(
+        env, "min_forward BigInt value cannot be represented as int64_t")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
   int64_t min_backward = info[4].As<Napi::BigInt>().Int64Value(&lossless);
+  if (!lossless) {
+    Napi::TypeError::New(
+        env, "min_backward BigInt value cannot be represented as int64_t")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
 
   rcl_jump_threshold_t threshold;
   threshold.on_clock_change = on_clock_change;
   threshold.min_forward.nanoseconds = min_forward;
   threshold.min_backward.nanoseconds = min_backward;
 
-  JumpCallbackData* data = new JumpCallbackData{Napi::Persistent(callback_obj)};
-  callback_obj.Set("_cpp_handle",
-                   Napi::External<JumpCallbackData>::New(env, data));
+  JumpCallbackData* data = new JumpCallbackData();
+  data->tsfn_pre = Napi::ThreadSafeFunction::New(
+      env, pre_callback, "ClockJumpPreCallback", 10, 1, [](Napi::Env) {});
+  data->tsfn_post =
+      Napi::ThreadSafeFunction::New(env, post_callback, "ClockJumpPostCallback",
+                                    10, 1, [data](Napi::Env) { delete data; });
+
+  Napi::Object handle_obj = Napi::Object::New(env);
+  handle_obj.Set("_cpp_handle",
+                 Napi::External<JumpCallbackData>::New(env, data));
 
   rcl_ret_t ret = rcl_clock_add_jump_callback(clock, threshold,
                                               _rclnodejs_on_time_jump, data);
 
   if (ret != RCL_RET_OK) {
-    data->ref.Reset();
-    delete data;
-    callback_obj.Set("_cpp_handle", env.Undefined());
+    data->tsfn_pre.Release();
+    data->tsfn_post.Release();
     THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
   }
+
+  callback_obj.Set("_cpp_handle", handle_obj.Get("_cpp_handle"));
 
   return env.Undefined();
 }
@@ -246,8 +279,8 @@ Napi::Value ClockRemoveJumpCallback(const Napi::CallbackInfo& info) {
   RclHandle* clock_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
   rcl_clock_t* clock = reinterpret_cast<rcl_clock_t*>(clock_handle->ptr());
 
-  Napi::Object callback_obj = info[1].As<Napi::Object>();
-  Napi::Value cpp_handle = callback_obj.Get("_cpp_handle");
+  Napi::Object handle_obj = info[1].As<Napi::Object>();
+  Napi::Value cpp_handle = handle_obj.Get("_cpp_handle");
 
   if (cpp_handle.IsUndefined() || !cpp_handle.IsExternal()) {
     Napi::Error::New(env,
@@ -263,9 +296,9 @@ Napi::Value ClockRemoveJumpCallback(const Napi::CallbackInfo& info) {
       rcl_clock_remove_jump_callback(clock, _rclnodejs_on_time_jump, data);
 
   if (ret == RCL_RET_OK) {
-    data->ref.Reset();
-    delete data;
-    callback_obj.Set("_cpp_handle", env.Undefined());
+    data->tsfn_pre.Release();
+    data->tsfn_post.Release();
+    handle_obj.Set("_cpp_handle", env.Undefined());
   } else {
     THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
   }

--- a/test/test-clock-callback.js
+++ b/test/test-clock-callback.js
@@ -1,3 +1,17 @@
+// Copyright (c) 2025, The Robot Web Tools Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 
 const assert = require('assert');

--- a/test/test-clock-callback.js
+++ b/test/test-clock-callback.js
@@ -17,8 +17,27 @@ describe('rclnodejs Clock Callback testing', function () {
     rclnodejs.shutdown();
   });
 
-  it('Test add and remove clock callback', function () {
+  let testClock = null;
+  let testCallbacks = [];
+
+  afterEach(function () {
+    // Clean up all registered callbacks
+    if (testClock && testCallbacks.length > 0) {
+      testCallbacks.forEach((callback) => {
+        try {
+          testClock.removeClockCallback(callback);
+        } catch (e) {
+          // Callback may already be removed
+        }
+      });
+    }
+    testClock = null;
+    testCallbacks = [];
+  });
+
+  it('Test add and remove clock callback', async function () {
     const clock = new Clock(ClockType.ROS_TIME);
+    testClock = clock;
 
     let preCallbackCalled = false;
     let postCallbackCalled = false;
@@ -36,6 +55,7 @@ describe('rclnodejs Clock Callback testing', function () {
 
     // Add callback
     clock.addClockCallback(callbackObj, true, 0n, 0n);
+    testCallbacks.push(callbackObj);
 
     // Enable ROS time override
     rclnodejsNative.setRosTimeOverrideIsEnabled(clock.handle, true);
@@ -45,6 +65,9 @@ describe('rclnodejs Clock Callback testing', function () {
 
     // Set override (should trigger jump)
     rclnodejsNative.setRosTimeOverride(clock.handle, timePoint._handle);
+
+    // Wait for callbacks to be processed
+    await new Promise((resolve) => setImmediate(resolve));
 
     assert.strictEqual(
       preCallbackCalled,
@@ -72,6 +95,9 @@ describe('rclnodejs Clock Callback testing', function () {
     const timePoint2 = new Time(200n, 0n, ClockType.ROS_TIME);
     rclnodejsNative.setRosTimeOverride(clock.handle, timePoint2._handle);
 
+    // Wait for any potential callbacks
+    await new Promise((resolve) => setImmediate(resolve));
+
     assert.strictEqual(
       preCallbackCalled,
       false,
@@ -84,8 +110,9 @@ describe('rclnodejs Clock Callback testing', function () {
     );
   });
 
-  it('Test clock callback thresholds', function () {
+  it('Test clock callback thresholds', async function () {
     const clock = new Clock(ClockType.ROS_TIME);
+    testClock = clock;
     let callbackCalled = false;
 
     const callbackObj = {
@@ -99,12 +126,17 @@ describe('rclnodejs Clock Callback testing', function () {
     // Add callback with threshold of 1 second (10^9 nanoseconds)
     // Set onClockChange to false to ensure we are testing time jump threshold
     clock.addClockCallback(callbackObj, false, 1000000000n, 0n);
+    testCallbacks.push(callbackObj);
 
     rclnodejsNative.setRosTimeOverrideIsEnabled(clock.handle, true);
 
     // Jump forward by 0.5 seconds (should NOT trigger)
     let timePoint = new Time(0n, 500000000n, ClockType.ROS_TIME);
     rclnodejsNative.setRosTimeOverride(clock.handle, timePoint._handle);
+
+    // Wait for callbacks to be processed
+    await new Promise((resolve) => setImmediate(resolve));
+
     assert.strictEqual(
       callbackCalled,
       false,
@@ -115,6 +147,10 @@ describe('rclnodejs Clock Callback testing', function () {
     // Current time is 0.5s. New time is 2.0s. Delta is 1.5s > 1.0s.
     timePoint = new Time(2n, 0n, ClockType.ROS_TIME);
     rclnodejsNative.setRosTimeOverride(clock.handle, timePoint._handle);
+
+    // Wait for callbacks to be processed
+    await new Promise((resolve) => setImmediate(resolve));
+
     assert.strictEqual(
       callbackCalled,
       true,
@@ -122,8 +158,9 @@ describe('rclnodejs Clock Callback testing', function () {
     );
   });
 
-  it('Test multiple clock callbacks', function () {
+  it('Test multiple clock callbacks', async function () {
     const clock = new Clock(ClockType.ROS_TIME);
+    testClock = clock;
     let callback1Called = false;
     let callback2Called = false;
 
@@ -142,11 +179,16 @@ describe('rclnodejs Clock Callback testing', function () {
     };
 
     clock.addClockCallback(callbackObj1, true, 0n, 0n);
+    testCallbacks.push(callbackObj1);
     clock.addClockCallback(callbackObj2, true, 0n, 0n);
+    testCallbacks.push(callbackObj2);
 
     rclnodejsNative.setRosTimeOverrideIsEnabled(clock.handle, true);
     const timePoint = new Time(1n, 0n, ClockType.ROS_TIME);
     rclnodejsNative.setRosTimeOverride(clock.handle, timePoint._handle);
+
+    // Wait for callbacks to be processed
+    await new Promise((resolve) => setImmediate(resolve));
 
     assert.strictEqual(callback1Called, true);
     assert.strictEqual(callback2Called, true);

--- a/test/test-clock-callback.js
+++ b/test/test-clock-callback.js
@@ -1,0 +1,154 @@
+'use strict';
+
+const assert = require('assert');
+const rclnodejs = require('../index.js');
+const rclnodejsNative = require('../lib/native_loader.js');
+const { Time, Clock } = rclnodejs;
+const { ClockType } = Clock;
+
+describe('rclnodejs Clock Callback testing', function () {
+  this.timeout(60 * 1000);
+
+  before(function () {
+    return rclnodejs.init();
+  });
+
+  after(function () {
+    rclnodejs.shutdown();
+  });
+
+  it('Test add and remove clock callback', function () {
+    const clock = new Clock(ClockType.ROS_TIME);
+
+    let preCallbackCalled = false;
+    let postCallbackCalled = false;
+    let lastJumpInfo = null;
+
+    const callbackObj = {
+      _pre_callback: function () {
+        preCallbackCalled = true;
+      },
+      _post_callback: function (jumpInfo) {
+        postCallbackCalled = true;
+        lastJumpInfo = jumpInfo;
+      },
+    };
+
+    // Add callback
+    clock.addClockCallback(callbackObj, true, 0n, 0n);
+
+    // Enable ROS time override
+    rclnodejsNative.setRosTimeOverrideIsEnabled(clock.handle, true);
+
+    // Create a time point for override
+    const timePoint = new Time(100n, 0n, ClockType.ROS_TIME);
+
+    // Set override (should trigger jump)
+    rclnodejsNative.setRosTimeOverride(clock.handle, timePoint._handle);
+
+    assert.strictEqual(
+      preCallbackCalled,
+      true,
+      'Pre callback should be called'
+    );
+    assert.strictEqual(
+      postCallbackCalled,
+      true,
+      'Post callback should be called'
+    );
+    assert.ok(lastJumpInfo, 'Jump info should be present');
+    assert.strictEqual(typeof lastJumpInfo.clock_change, 'number');
+    assert.strictEqual(typeof lastJumpInfo.delta, 'bigint');
+
+    // Reset flags
+    preCallbackCalled = false;
+    postCallbackCalled = false;
+    lastJumpInfo = null;
+
+    // Remove callback
+    clock.removeClockCallback(callbackObj);
+
+    // Trigger another jump
+    const timePoint2 = new Time(200n, 0n, ClockType.ROS_TIME);
+    rclnodejsNative.setRosTimeOverride(clock.handle, timePoint2._handle);
+
+    assert.strictEqual(
+      preCallbackCalled,
+      false,
+      'Pre callback should NOT be called after removal'
+    );
+    assert.strictEqual(
+      postCallbackCalled,
+      false,
+      'Post callback should NOT be called after removal'
+    );
+  });
+
+  it('Test clock callback thresholds', function () {
+    const clock = new Clock(ClockType.ROS_TIME);
+    let callbackCalled = false;
+
+    const callbackObj = {
+      _pre_callback: function () {},
+      _post_callback: function (jumpInfo) {
+        // console.log('Callback called with delta:', jumpInfo.delta);
+        callbackCalled = true;
+      },
+    };
+
+    // Add callback with threshold of 1 second (10^9 nanoseconds)
+    // Set onClockChange to false to ensure we are testing time jump threshold
+    clock.addClockCallback(callbackObj, false, 1000000000n, 0n);
+
+    rclnodejsNative.setRosTimeOverrideIsEnabled(clock.handle, true);
+
+    // Jump forward by 0.5 seconds (should NOT trigger)
+    let timePoint = new Time(0n, 500000000n, ClockType.ROS_TIME);
+    rclnodejsNative.setRosTimeOverride(clock.handle, timePoint._handle);
+    assert.strictEqual(
+      callbackCalled,
+      false,
+      'Callback should not be called for small jump'
+    );
+
+    // Jump forward by 1.5 seconds (total 2.0s) (should trigger)
+    // Current time is 0.5s. New time is 2.0s. Delta is 1.5s > 1.0s.
+    timePoint = new Time(2n, 0n, ClockType.ROS_TIME);
+    rclnodejsNative.setRosTimeOverride(clock.handle, timePoint._handle);
+    assert.strictEqual(
+      callbackCalled,
+      true,
+      'Callback should be called for large jump'
+    );
+  });
+
+  it('Test multiple clock callbacks', function () {
+    const clock = new Clock(ClockType.ROS_TIME);
+    let callback1Called = false;
+    let callback2Called = false;
+
+    const callbackObj1 = {
+      _pre_callback: () => {},
+      _post_callback: () => {
+        callback1Called = true;
+      },
+    };
+
+    const callbackObj2 = {
+      _pre_callback: () => {},
+      _post_callback: () => {
+        callback2Called = true;
+      },
+    };
+
+    clock.addClockCallback(callbackObj1, true, 0n, 0n);
+    clock.addClockCallback(callbackObj2, true, 0n, 0n);
+
+    rclnodejsNative.setRosTimeOverrideIsEnabled(clock.handle, true);
+    const timePoint = new Time(1n, 0n, ClockType.ROS_TIME);
+    rclnodejsNative.setRosTimeOverride(clock.handle, timePoint._handle);
+
+    assert.strictEqual(callback1Called, true);
+    assert.strictEqual(callback2Called, true);
+  });
+});

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -347,6 +347,8 @@ const clock = new rclnodejs.Clock(rclnodejs.ClockType.SYSTEM_TIME);
 expectType<rclnodejs.Clock>(clock);
 expectType<rclnodejs.ClockType>(clock.clockType);
 expectType<rclnodejs.Time>(clock.now());
+expectType<void>(clock.addClockCallback({}, true, 0n, 0n));
+expectType<void>(clock.removeClockCallback({}));
 
 // ---- Logging -----
 const logger = rclnodejs.Logging.getLogger('test_logger');

--- a/types/clock.d.ts
+++ b/types/clock.d.ts
@@ -18,6 +18,26 @@ declare module 'rclnodejs' {
     readonly clockType: ClockType;
 
     /**
+     * Add a clock callback.
+     * @param callbackObject - The object containing _pre_callback and _post_callback methods.
+     * @param onClockChange - Whether to call the callback on clock change.
+     * @param minForward - Minimum forward jump to trigger the callback.
+     * @param minBackward - Minimum backward jump to trigger the callback.
+     */
+    addClockCallback(
+      callbackObject: object,
+      onClockChange: boolean,
+      minForward: bigint,
+      minBackward: bigint
+    ): void;
+
+    /**
+     * Remove a clock callback.
+     * @param callbackObject - The object containing _pre_callback and _post_callback methods.
+     */
+    removeClockCallback(callbackObject: object): void;
+
+    /**
      * Return the current time.
      *
      * @returns The current time.


### PR DESCRIPTION
This PR adds support for clock callbacks in rclnodejs, allowing applications to be notified when time jumps occur (e.g., when ROS time is overridden or adjusted). This is useful for time-sensitive applications that need to handle discontinuities in the time stream.

- Adds `addClockCallback` and `removeClockCallback` methods to the Clock class
- Implements C++ bindings for registering/removing jump callbacks with RCL
- Includes comprehensive test coverage for callback functionality with various threshold scenarios

Fix: #1330 