### PR TITLE
Add getNextCallTime() into Timer

### DIFF
--- a/lib/clock.js
+++ b/lib/clock.js
@@ -50,10 +50,15 @@ class Clock {
 
   /**
    * Add a clock callback.
-   * @param {object} callbackObject - The object containing _pre_callback and _post_callback methods.
+   * @param {object} callbackObject - The object containing callback methods.
+   * @param {Function} [callbackObject._pre_callback] - Optional callback invoked before a time jump. Takes no arguments.
+   * @param {Function} [callbackObject._post_callback] - Optional callback invoked after a time jump.
+   *   Receives a jumpInfo object with properties:
+   *   - clock_change {number}: Type of clock change that occurred.
+   *   - delta {bigint}: Time delta in nanoseconds.
    * @param {boolean} onClockChange - Whether to call the callback on clock change.
-   * @param {bigint} minForward - Minimum forward jump to trigger the callback.
-   * @param {bigint} minBackward - Minimum backward jump to trigger the callback.
+   * @param {bigint} minForward - Minimum forward jump in nanoseconds to trigger the callback.
+   * @param {bigint} minBackward - Minimum backward jump in nanoseconds to trigger the callback.
    */
   addClockCallback(callbackObject, onClockChange, minForward, minBackward) {
     if (typeof callbackObject !== 'object' || callbackObject === null) {
@@ -92,7 +97,7 @@ class Clock {
 
   /**
    * Remove a clock callback.
-   * @param {object} callbackObject - The object containing _pre_callback and _post_callback methods.
+   * @param {object} callbackObject - The callback object that was previously registered with addClockCallback().
    */
   removeClockCallback(callbackObject) {
     if (typeof callbackObject !== 'object' || callbackObject === null) {

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -90,9 +90,14 @@ class Timer {
 
   /**
    * Get the absolute time in nanoseconds when the next callback is due.
+   * Note: Only available on ROS2 distributions after Humble.
    * @return {bigint | null} - The next call time in nanoseconds, or null if the timer is canceled.
+   *   Returns undefined if not supported on current ROS2 distribution.
    */
   getNextCallTime() {
+    if (typeof rclnodejs.getTimerNextCallTime !== 'function') {
+      return undefined;
+    }
     return rclnodejs.getTimerNextCallTime(this._handle);
   }
 

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -89,6 +89,14 @@ class Timer {
   }
 
   /**
+   * Get the absolute time in nanoseconds when the next callback is due.
+   * @return {bigint | null} - The next call time in nanoseconds, or null if the timer is canceled.
+   */
+  getNextCallTime() {
+    return rclnodejs.getTimerNextCallTime(this._handle);
+  }
+
+  /**
    * Change the timer period.
    * @param {bigint} period - The new period in nanoseconds.
    * @return {undefined}

--- a/src/rcl_timer_bindings.cpp
+++ b/src/rcl_timer_bindings.cpp
@@ -257,6 +257,7 @@ Napi::Value GetTimerPeriod(const Napi::CallbackInfo& info) {
   return Napi::BigInt::New(env, period_nsec);
 }
 
+#if ROS_VERSION > 2205  // 2205 == Humble
 Napi::Value GetTimerNextCallTime(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   RclHandle* timer_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
@@ -274,6 +275,7 @@ Napi::Value GetTimerNextCallTime(const Napi::CallbackInfo& info) {
     return env.Undefined();
   }
 }
+#endif
 
 #if ROS_VERSION > 2205  // 2205 == Humble
 Napi::Value CallTimerWithInfo(const Napi::CallbackInfo& info) {
@@ -362,9 +364,9 @@ Napi::Object InitTimerBindings(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, TimerGetTimeUntilNextCall));
   exports.Set("changeTimerPeriod", Napi::Function::New(env, ChangeTimerPeriod));
   exports.Set("getTimerPeriod", Napi::Function::New(env, GetTimerPeriod));
+#if ROS_VERSION > 2205  // 2205 == Humble
   exports.Set("getTimerNextCallTime",
               Napi::Function::New(env, GetTimerNextCallTime));
-#if ROS_VERSION > 2205  // 2205 == Humble
   exports.Set("setTimerOnResetCallback",
               Napi::Function::New(env, SetTimerOnResetCallback));
   exports.Set("clearTimerOnResetCallback",

--- a/src/rcl_timer_bindings.cpp
+++ b/src/rcl_timer_bindings.cpp
@@ -101,7 +101,10 @@ Napi::Value CreateTimer(const Napi::CallbackInfo& info) {
 #if ROS_VERSION > 2205
         // Clear the callback first to prevent any new callbacks from being
         // triggered
-        rcl_timer_set_on_reset_callback(timer, nullptr, nullptr);
+        rcl_ret_t callback_ret =
+            rcl_timer_set_on_reset_callback(timer, nullptr, nullptr);
+        (void)callback_ret;  // Suppress unused variable warning if error
+                             // handling is not needed
 #endif
 
         std::shared_ptr<TimerContext> context;
@@ -254,6 +257,24 @@ Napi::Value GetTimerPeriod(const Napi::CallbackInfo& info) {
   return Napi::BigInt::New(env, period_nsec);
 }
 
+Napi::Value GetTimerNextCallTime(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  RclHandle* timer_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_timer_t* timer = reinterpret_cast<rcl_timer_t*>(timer_handle->ptr());
+  int64_t next_call_time = 0;
+
+  rcl_ret_t ret = rcl_timer_get_next_call_time(timer, &next_call_time);
+
+  if (ret == RCL_RET_OK) {
+    return Napi::BigInt::New(env, next_call_time);
+  } else if (ret == RCL_RET_TIMER_CANCELED) {
+    return env.Null();
+  } else {
+    THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
+    return env.Undefined();
+  }
+}
+
 #if ROS_VERSION > 2205  // 2205 == Humble
 Napi::Value CallTimerWithInfo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
@@ -341,6 +362,8 @@ Napi::Object InitTimerBindings(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, TimerGetTimeUntilNextCall));
   exports.Set("changeTimerPeriod", Napi::Function::New(env, ChangeTimerPeriod));
   exports.Set("getTimerPeriod", Napi::Function::New(env, GetTimerPeriod));
+  exports.Set("getTimerNextCallTime",
+              Napi::Function::New(env, GetTimerNextCallTime));
 #if ROS_VERSION > 2205  // 2205 == Humble
   exports.Set("setTimerOnResetCallback",
               Napi::Function::New(env, SetTimerOnResetCallback));

--- a/src/rcl_timer_bindings.cpp
+++ b/src/rcl_timer_bindings.cpp
@@ -103,8 +103,8 @@ Napi::Value CreateTimer(const Napi::CallbackInfo& info) {
         // triggered
         rcl_ret_t callback_ret =
             rcl_timer_set_on_reset_callback(timer, nullptr, nullptr);
-        (void)callback_ret;  // Suppress unused variable warning if error
-                             // handling is not needed
+        THROW_ERROR_IF_NOT_EQUAL_NO_RETURN(RCL_RET_OK, callback_ret,
+                                           rcl_get_error_string().str);
 #endif
 
         std::shared_ptr<TimerContext> context;
@@ -272,7 +272,6 @@ Napi::Value GetTimerNextCallTime(const Napi::CallbackInfo& info) {
     return env.Null();
   } else {
     THROW_ERROR_IF_NOT_EQUAL(RCL_RET_OK, ret, rcl_get_error_string().str);
-    return env.Undefined();
   }
 }
 #endif

--- a/test/test-timer.js
+++ b/test/test-timer.js
@@ -140,6 +140,10 @@ describe('rclnodejs Timer class testing', function () {
     });
 
     it('timer.getNextCallTime', function (done) {
+      // Skip test if ROS2 version is Humble or earlier (not supported)
+      if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
+        this.skip();
+      }
       var timer = node.createTimer(TIMER_INTERVAL, function () {
         var nextCallTime = timer.getNextCallTime();
         assert.deepStrictEqual(typeof nextCallTime, 'bigint');

--- a/test/test-timer.js
+++ b/test/test-timer.js
@@ -139,6 +139,20 @@ describe('rclnodejs Timer class testing', function () {
       rclnodejs.spin(node);
     });
 
+    it('timer.getNextCallTime', function (done) {
+      var timer = node.createTimer(TIMER_INTERVAL, function () {
+        var nextCallTime = timer.getNextCallTime();
+        assert.deepStrictEqual(typeof nextCallTime, 'bigint');
+        assert.ok(nextCallTime > 0n);
+        timer.cancel();
+        // After cancellation, should return null
+        var canceledCallTime = timer.getNextCallTime();
+        assert.strictEqual(canceledCallTime, null);
+        done();
+      });
+      rclnodejs.spin(node);
+    });
+
     it('timer.timerPeriod', function (done) {
       const timer = node.createTimer(BigInt('100000000'), () => {});
       assert.deepStrictEqual(timer.timerPeriod, BigInt('100000000'));

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -285,6 +285,7 @@ expectType<bigint>(timer.period);
 expectType<boolean>(timer.isReady());
 expectType<bigint>(timer.timeSinceLastCall());
 expectType<bigint>(timer.timeUntilNextCall());
+expectType<bigint | null>(timer.getNextCallTime());
 expectType<boolean>(timer.isCanceled());
 expectType<void>(timer.cancel());
 expectType<void>(timer.changeTimerPeriod(BigInt(100000)));

--- a/types/clock.d.ts
+++ b/types/clock.d.ts
@@ -1,5 +1,36 @@
 declare module 'rclnodejs' {
   /**
+   * Jump information provided to clock jump callbacks.
+   */
+  interface ClockJumpInfo {
+    /**
+     * Type of clock change that occurred.
+     */
+    clock_change: number;
+
+    /**
+     * Time delta in nanoseconds.
+     */
+    delta: bigint;
+  }
+
+  /**
+   * Callback object for clock jump events.
+   */
+  interface ClockCallbackObject {
+    /**
+     * Optional callback invoked before a time jump.
+     */
+    _pre_callback?: () => void;
+
+    /**
+     * Optional callback invoked after a time jump.
+     * @param jumpInfo - Information about the time jump.
+     */
+    _post_callback?: (jumpInfo: ClockJumpInfo) => void;
+  }
+
+  /**
    * A ROS Clock.
    */
   class Clock {
@@ -19,13 +50,13 @@ declare module 'rclnodejs' {
 
     /**
      * Add a clock callback.
-     * @param callbackObject - The object containing _pre_callback and _post_callback methods.
+     * @param callbackObject - The object containing callback methods.
      * @param onClockChange - Whether to call the callback on clock change.
-     * @param minForward - Minimum forward jump to trigger the callback.
-     * @param minBackward - Minimum backward jump to trigger the callback.
+     * @param minForward - Minimum forward jump in nanoseconds to trigger the callback.
+     * @param minBackward - Minimum backward jump in nanoseconds to trigger the callback.
      */
     addClockCallback(
-      callbackObject: object,
+      callbackObject: ClockCallbackObject,
       onClockChange: boolean,
       minForward: bigint,
       minBackward: bigint
@@ -33,9 +64,9 @@ declare module 'rclnodejs' {
 
     /**
      * Remove a clock callback.
-     * @param callbackObject - The object containing _pre_callback and _post_callback methods.
+     * @param callbackObject - The callback object that was previously registered with addClockCallback().
      */
-    removeClockCallback(callbackObject: object): void;
+    removeClockCallback(callbackObject: ClockCallbackObject): void;
 
     /**
      * Return the current time.

--- a/types/timer.d.ts
+++ b/types/timer.d.ts
@@ -47,6 +47,13 @@ declare module 'rclnodejs' {
     timeUntilNextCall(): bigint;
 
     /**
+     * Get the absolute time in nanoseconds when the next callback is due.
+     *
+     * @returns The next call time in nanoseconds, or null if the timer is canceled.
+     */
+    getNextCallTime(): bigint | null;
+
+    /**
      * Change the timer period.
      * @param period - The new period in nanoseconds.
      */


### PR DESCRIPTION
This PR adds the `getNextCallTime()` method to the Timer class, providing access to the absolute time when the next timer callback is scheduled. Additionally, it improves the Clock API documentation by introducing proper TypeScript interfaces for clock jump callbacks and enhancing parameter descriptions.

- Adds `getNextCallTime()` method to Timer that returns the next call time as a bigint or null if canceled
- Introduces `ClockJumpInfo` and `ClockCallbackObject` TypeScript interfaces for better type safety
- Enhances documentation clarity for Clock callback methods with detailed parameter descriptions

Fix: #1330