### PR TITLE
Pump globals to 17.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint": "^9.16.0",
     "eslint-config-prettier": "^10.0.2",
     "eslint-plugin-prettier": "^5.2.1",
-    "globals": "^16.0.0",
+    "globals": "^17.0.0",
     "husky": "^9.1.7",
     "jsdoc": "^4.0.4",
     "lint-staged": "^16.2.0",


### PR DESCRIPTION
This pull request updates the `globals` package from version 16.0.0 to 17.0.0, keeping the development tooling dependencies current. The `globals` package provides environment-specific global variable definitions used by ESLint configuration.

**Changes:**
- Bump `globals` package version from ^16.0.0 to ^17.0.0 in devDependencies

Fix: #1364