### PR TITLE
Correct the type of return value for Time.toMsg()

### DIFF
--- a/lib/time.js
+++ b/lib/time.js
@@ -352,8 +352,8 @@ class Time {
   toMsg() {
     const secondsAndNanoseconds = this.secondsAndNanoseconds;
     return {
-      sec: secondsAndNanoseconds.seconds,
-      nanosec: secondsAndNanoseconds.nanoseconds,
+      sec: Number(secondsAndNanoseconds.seconds),
+      nanosec: Number(secondsAndNanoseconds.nanoseconds),
     };
   }
 

--- a/test/test-time.js
+++ b/test/test-time.js
@@ -48,6 +48,11 @@ describe('rclnodejs Time/Clock testing', function () {
     assert.strictEqual(time.nanoseconds, 1000000064n);
     assert.strictEqual(time.clockType, ClockType.ROS_TIME);
 
+    // Test with number types (compatible with updated interface)
+    time = Time.fromMsg({ sec: 1, nanosec: 64 });
+    assert.strictEqual(time.nanoseconds, 1000000064n);
+    assert.strictEqual(time.clockType, ClockType.ROS_TIME);
+
     assert.throws(() => {
       new Time(1n, 1n, 'SYSTEM_TIME');
     }, rclnodejs.TypeValidationError);
@@ -200,7 +205,9 @@ describe('rclnodejs Time/Clock testing', function () {
     let time = new Time(100n, 200n);
     let msg = time.toMsg();
 
-    assert.strictEqual(msg.sec, 100n);
-    assert.strictEqual(msg.nanosec, 200n);
+    assert.strictEqual(msg.sec, 100);
+    assert.strictEqual(msg.nanosec, 200);
+    assert.strictEqual(typeof msg.sec, 'number');
+    assert.strictEqual(typeof msg.nanosec, 'number');
   });
 });


### PR DESCRIPTION
This pull request corrects the return type of the `Time.toMsg()` method to return JavaScript numbers instead of bigints for the `sec` and `nanosec` fields, aligning with ROS2's builtin_interfaces.msg.Time message specification which uses int32 for sec and uint32 for nanosec.

**Changes:**
- Modified `Time.toMsg()` to convert bigint values to numbers using `Number()`
- Updated test expectations to verify numbers are returned instead of bigints
- Added test case verifying `Time.fromMsg()` compatibility with number types

Fix: #1370