### PR TITLE
Leverage fs.stat to ensure it works by Electron package

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,7 +54,7 @@ function ensureDirSync(dirPath) {
  */
 async function pathExists(filePath) {
   try {
-    await fsPromises.access(filePath);
+    await fsPromises.stat(filePath);
     return true;
   } catch {
     return false;

--- a/rosidl_gen/packages.js
+++ b/rosidl_gen/packages.js
@@ -223,7 +223,7 @@ async function findPackagesInDirectory(dir, useIDL) {
 
     // If there is a folder named 'share' under the root path, we consider that
     // the ament build tool has been executed and |amentExecuted| will be true.
-    fs.access(path.join(dir, 'share'), (err) => {
+    fs.stat(path.join(dir, 'share'), (err) => {
       if (err) {
         amentExecuted = false;
       }


### PR DESCRIPTION
This pull request updates file system operations to improve compatibility with Electron's ASAR packaging system by replacing `fs.access()` with `fs.stat()` for existence checks. This is important since the project explicitly targets Electron (as seen in `package.json` with `--target electron@23.0.0`).

**Changes:**
- Replaced `fs.access()` with `fs.stat()` in the `findPackagesInDirectory` function
- Replaced `fsPromises.access()` with `fsPromises.stat()` in the `pathExists` utility function

Fix: #1375