### PR TITLE
Fix github actions failure on Windows

### DIFF
--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -25,6 +25,11 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Setup Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
     - name: Setup ROS2
       uses: ros-tooling/setup-ros@v0.7
       with:


### PR DESCRIPTION
This PR fixes GitHub Actions failures on Windows by adding explicit Python 3.11 setup to the Windows build and test workflow. The `node-gyp` build tool and ROS2 both require Python to be available, and the `windows-2025` runner apparently doesn't have Python pre-installed or doesn't have the correct version available by default.

**Changes:**
- Added Python 3.11 setup step before ROS2 installation in the Windows workflow

Fix: #1377