### PR TITLE
Re-enable rolling build on Windows

### DIFF
--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -39,7 +39,7 @@ jobs:
       if: ${{ matrix.ros_distribution == 'rolling' }}
       shell: bash
       run: |
-        wget --quiet https://ci.ros2.org/view/packaging/job/packaging_windows/lastSuccessfulBuild/artifact/ws/ros2-package-windows-AMD64.zip -O rolling.zip
+        wget --quiet https://github.com/ros2/ros2/releases/download/release-rolling-nightlies/ros2-rolling-nightly-windows-amd64.zip -O rolling.zip
         7z x rolling.zip -y -o/c/dev/rolling
 
     - name: Prebuild - Setup VS Dev Environment

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -19,6 +19,7 @@ jobs:
           - humble
           - jazzy
           - kilted
+          - rolling
     steps:
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6


### PR DESCRIPTION
This PR updates the URL for downloading ROS2 Rolling binaries on Windows, changing from the old ci.ros2.org build farm to the newer GitHub releases location. The title suggests this is meant to "re-enable" rolling builds on Windows.

**Changes:**
- Updated the wget URL from `ci.ros2.org/view/packaging/job/packaging_windows/lastSuccessfulBuild/artifact/ws/ros2-package-windows-AMD64.zip` to `github.com/ros2/ros2/releases/download/release-rolling-nightlies/ros2-rolling-nightly-windows-amd64.zip`

Fix: #1383