### PR TITLE
Fix compiling error on ROS2 rolling

### DIFF
--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -291,7 +291,8 @@ class LifecycleNode extends Node {
     // initialize native handle to rcl_lifecycle_state_machine
     this._stateMachineHandle = rclnodejs.createLifecycleStateMachine(
       this.handle,
-      enableCommunicationInterface
+      enableCommunicationInterface,
+      this._clock.handle
     );
 
     // initialize Map<transitionId,TransitionCallback>

--- a/src/rcl_lifecycle_bindings.cpp
+++ b/src/rcl_lifecycle_bindings.cpp
@@ -71,7 +71,30 @@ Napi::Value CreateLifecycleStateMachine(const Napi::CallbackInfo& info) {
   const rosidl_service_type_support_t* gs =
       GetServiceTypeSupport("lifecycle_msgs", "GetState");
 
-#if ROS_VERSION >= 2105
+#if ROS_VERSION >= 5000  // ROS2 Rolling
+  rcl_lifecycle_state_machine_options_t options =
+      rcl_lifecycle_get_default_state_machine_options();
+  options.enable_com_interface = info[1].As<Napi::Boolean>().Value();
+
+  RclHandle* clock_handle = RclHandle::Unwrap(info[2].As<Napi::Object>());
+  rcl_clock_t* clock = reinterpret_cast<rcl_clock_t*>(clock_handle->ptr());
+
+  THROW_ERROR_IF_NOT_EQUAL(
+      RCL_RET_OK,
+      rcl_lifecycle_state_machine_init(state_machine, node, clock, pn, cs, gs,
+                                       gas, gat, gtg, &options),
+      rcl_get_error_string().str);
+
+  auto js_obj = RclHandle::NewInstance(
+      env, state_machine, node_handle, [node, env](void* ptr) {
+        rcl_lifecycle_state_machine_t* state_machine =
+            reinterpret_cast<rcl_lifecycle_state_machine_t*>(ptr);
+        rcl_ret_t ret = rcl_lifecycle_state_machine_fini(state_machine, node);
+        free(ptr);
+        THROW_ERROR_IF_NOT_EQUAL_NO_RETURN(RCL_RET_OK, ret,
+                                           rcl_get_error_string().str);
+      });
+#elif ROS_VERSION >= 2105
   rcl_lifecycle_state_machine_options_t options =
       rcl_lifecycle_get_default_state_machine_options();
   options.enable_com_interface = info[1].As<Napi::Boolean>().Value();


### PR DESCRIPTION
This PR fixes a compilation error when building against ROS2 Rolling by adapting to a breaking API change in the ROS2 lifecycle state machine initialization. The ROS2 Rolling API now requires a clock parameter for `rcl_lifecycle_state_machine_init`, which was not present in earlier versions.

**Changes:**
- Added version-specific code path for ROS2 Rolling (ROS_VERSION >= 5000) that includes the new clock parameter requirement
- Updated JavaScript code to pass the node's clock handle to the native lifecycle state machine creation function

Fix: #1391