### PR TITLE
Pump @eslint/js and eslint to latest

### DIFF
--- a/lib/parameter.js
+++ b/lib/parameter.js
@@ -883,7 +883,7 @@ function validValue(value, type) {
     return type === ParameterType.PARAMETER_NOT_SET;
   }
 
-  let result = true;
+  let result;
   switch (type) {
     case ParameterType.PARAMETER_NOT_SET:
       result = !value;

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "url": "git+https://github.com/RobotWebTools/rclnodejs.git"
   },
   "devDependencies": {
-    "@eslint/js": "^9.36.0",
+    "@eslint/js": "^10.0.1",
     "@types/node": "^25.0.2",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",
@@ -56,7 +56,7 @@
     "commander": "^14.0.0",
     "coveralls": "^3.1.1",
     "deep-equal": "^2.2.3",
-    "eslint": "^9.16.0",
+    "eslint": "^10.0.2",
     "eslint-config-prettier": "^10.0.2",
     "eslint-plugin-prettier": "^5.2.1",
     "globals": "^17.0.0",


### PR DESCRIPTION
This pull request updates ESLint and `@eslint/js` to their latest major version 10. The changes upgrade the linting infrastructure from version 9 to version 10 for both packages.

**Changes:**
- Updated `@eslint/js` from ^9.36.0 to ^10.0.1
- Updated eslint from ^9.16.0 to ^10.0.2

Fix: #1395