### PR TITLE
Fix poetenial issues in parser.py

### DIFF
--- a/rosidl_parser/parser.py
+++ b/rosidl_parser/parser.py
@@ -47,7 +47,7 @@ def get_json_object_from_msg_spec_object(msg_spec_object):
 
 if __name__ == '__main__':
     if len(sys.argv) < 4:
-        print('Wrong number of argments')
+        print('Usage: {} <command> <packageName> <filePath>'.format(sys.argv[0]), file=sys.stderr)
         sys.exit(1)
     try:
         parser_method = getattr(parser, sys.argv[1])

--- a/rosidl_parser/parser.py
+++ b/rosidl_parser/parser.py
@@ -15,7 +15,6 @@
 import sys
 import json
 
-import rosidl_parser
 from rosidl_adapter import parser
 
 def get_json_object_from_base_type_object(base_type_obj):
@@ -41,14 +40,13 @@ def get_json_object_from_msg_spec_object(msg_spec_object):
     for constant in msg_spec_object.constants:
         constants.append({'type': constant.type, 'name': constant.name, 'value': constant.value})
 
-    msg_name = {'msgName': msg_spec_object.msg_name}
     json_obj = {'constants': constants, 'fields': fields, 'baseType': get_json_object_from_base_type_object(msg_spec_object.base_type),
         'msgName': msg_spec_object.msg_name}
 
     return json_obj
 
 if __name__ == '__main__':
-    if len(sys.argv) < 3:
+    if len(sys.argv) < 4:
         print('Wrong number of argments')
         sys.exit(1)
     try:


### PR DESCRIPTION
This PR tightens up the `rosidl_parser/parser.py` CLI wrapper used by the Node-side `rosidl_parser.js` helper by removing unused code and correcting the expected CLI argument count.

**Changes:**
- Remove an unused `rosidl_parser` import.
- Remove an unused intermediate `msg_name` variable.
- Update the CLI argument count check to require 3 parameters after the script name (command, package, file path).

Fix: #1403