### PR TITLE
Evaluate error message before resetting error state in macros

### DIFF
--- a/src/macros.h
+++ b/src/macros.h
@@ -22,8 +22,8 @@
 #define CHECK_OP_AND_THROW_ERROR_IF_NOT_TRUE(op, lhs, rhs, message) \
   {                                                                 \
     if (lhs op rhs) {                                               \
-      rcl_reset_error();                                            \
       Napi::Error::New(env, message).ThrowAsJavaScriptException();  \
+      rcl_reset_error();                                            \
       return env.Undefined();                                       \
     }                                                               \
   }
@@ -31,8 +31,8 @@
 #define CHECK_OP_AND_THROW_ERROR_IF_NOT_TRUE_NO_RETURN(op, lhs, rhs, message) \
   {                                                                           \
     if (lhs op rhs) {                                                         \
-      rcl_reset_error();                                                      \
       Napi::Error::New(env, message).ThrowAsJavaScriptException();            \
+      rcl_reset_error();                                                      \
     }                                                                         \
   }
 


### PR DESCRIPTION
This PR adjusts the ROS error-state reset behavior in the C++/N-API helper macros so the error message can be captured before the global RCL error state is cleared, improving the fidelity of JavaScript exceptions thrown from native bindings.

**Changes:**
- Move `rcl_reset_error()` to occur *after* `Napi::Error::New(...).ThrowAsJavaScriptException()` in `CHECK_OP_AND_THROW_ERROR_IF_NOT_TRUE`.
- Apply the same ordering fix to the `_NO_RETURN` variant.

Fix: #1405 