### PR TITLE
Fix bugs in rosidl_gen and index.js, add tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ async function getCurrentGeneratorVersion() {
   const jsonFilePath = path.join(generator.generatedRoot, 'generator.json');
 
   return new Promise((resolve, reject) => {
-    fs.open(jsonFilePath, 'r', (err) => {
+    fs.readFile(jsonFilePath, 'utf8', (err, data) => {
       if (err) {
         if (err.code === 'ENOENT') {
           resolve(null);
@@ -93,13 +93,11 @@ async function getCurrentGeneratorVersion() {
           reject(err);
         }
       } else {
-        fs.readFile(jsonFilePath, 'utf8', (err, data) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(JSON.parse(data).version);
-          }
-        });
+        try {
+          resolve(JSON.parse(data).version);
+        } catch (parseErr) {
+          reject(parseErr);
+        }
       }
     });
   });

--- a/rosidl_gen/packages.js
+++ b/rosidl_gen/packages.js
@@ -150,9 +150,7 @@ async function generateMsgForSrv(filePath, interfaceInfo, pkgMap) {
   const arr = data.split(/-{3,}/);
   if (arr.length == 2) {
     const packagePath = path.join(serviceMsgPath, interfaceInfo.pkgName);
-    if (!fs.existsSync(packagePath)) {
-      fs.mkdirSync(packagePath);
-    }
+    fs.mkdirSync(packagePath, { recursive: true });
 
     await fsp.writeFile(path.join(packagePath, requestMsgName), arr[0]);
     await fsp.writeFile(path.join(packagePath, responseMsgName), arr[1]);

--- a/rosidl_gen/primitive_types.js
+++ b/rosidl_gen/primitive_types.js
@@ -26,14 +26,14 @@ const StringRefStruct = StructType({
 
 function initString(str, own = false) {
   if (own) {
-    if ((!str) instanceof Buffer) {
+    if (!(str instanceof Buffer)) {
       throw new TypeError(
         'Invalid argument: should provide a Node Buffer to bindingsStringInit()'
       );
     }
     rclnodejs.initString(str);
   } else {
-    if ((!str) instanceof StringRefStruct) {
+    if (!(str instanceof StringRefStruct)) {
       throw new TypeError(
         'Invalid argument: should provide a type of StringRefStruct'
       );

--- a/test/test-primitive-types.js
+++ b/test/test-primitive-types.js
@@ -1,3 +1,5 @@
+// Copyright (c) 2026, The Robot Web Tools Contributors
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/test/test-primitive-types.js
+++ b/test/test-primitive-types.js
@@ -1,0 +1,93 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const primitiveTypes = require('../rosidl_gen/primitive_types.js');
+
+describe('rosidl_gen primitive_types', function () {
+  describe('initString(str, own=true)', function () {
+    it('should throw TypeError when str is a number', function () {
+      assert.throws(
+        () => primitiveTypes.initString(123, true),
+        TypeError,
+        'should provide a Node Buffer'
+      );
+    });
+
+    it('should throw TypeError when str is a plain string', function () {
+      assert.throws(
+        () => primitiveTypes.initString('hello', true),
+        TypeError,
+        'should provide a Node Buffer'
+      );
+    });
+
+    it('should throw TypeError when str is null', function () {
+      assert.throws(
+        () => primitiveTypes.initString(null, true),
+        TypeError,
+        'should provide a Node Buffer'
+      );
+    });
+
+    it('should throw TypeError when str is undefined', function () {
+      assert.throws(
+        () => primitiveTypes.initString(undefined, true),
+        TypeError,
+        'should provide a Node Buffer'
+      );
+    });
+  });
+
+  describe('initString(str, own=false)', function () {
+    it('should throw TypeError when str is a number', function () {
+      assert.throws(
+        () => primitiveTypes.initString(123),
+        TypeError,
+        'should provide a type of StringRefStruct'
+      );
+    });
+
+    it('should throw TypeError when str is a plain string', function () {
+      assert.throws(
+        () => primitiveTypes.initString('hello'),
+        TypeError,
+        'should provide a type of StringRefStruct'
+      );
+    });
+
+    it('should throw TypeError when str is a Buffer', function () {
+      assert.throws(
+        () => primitiveTypes.initString(Buffer.alloc(10)),
+        TypeError,
+        'should provide a type of StringRefStruct'
+      );
+    });
+
+    it('should throw TypeError when str is null', function () {
+      assert.throws(
+        () => primitiveTypes.initString(null),
+        TypeError,
+        'should provide a type of StringRefStruct'
+      );
+    });
+
+    it('should initialize a valid StringRefStruct', function () {
+      const str = new primitiveTypes.string();
+      primitiveTypes.initString(str);
+      assert.strictEqual(str.size, 0);
+      assert.strictEqual(str.capacity, 1);
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes a couple of correctness issues in message generation and generator version detection, and adds targeted tests to prevent regressions in `rosidl_gen` primitive type initialization.

**Changes:**

**index.js**
- Fix file descriptor leak in `getCurrentGeneratorVersion()`: replaced `fs.open()` followed by nested `fs.readFile()` with a single `fs.readFile()` call, eliminating the unclosed fd when the file exists
- Add `try/catch` around `JSON.parse()` to properly reject on malformed JSON instead of throwing an unhandled exception

**rosidl_gen/primitive_types.js**
- Fix operator precedence bug in `initString()`: `(!str) instanceof Buffer` always evaluated to `false` (negating `str` first, then checking if `true`/`false` is an instance of `Buffer`); corrected to `!(str instanceof Buffer)` so the type guard works as intended
- Same fix for the `(!str) instanceof StringRefStruct` check in the `own=false` branch

**rosidl_gen/packages.js**
- Fix TOCTOU race in `generateMsgForSrv()`: replaced `existsSync()` + `mkdirSync()` with `mkdirSync(path, { recursive: true })`, which is atomic and won't throw if the directory already exists

**test/test-primitive-types.js** *(new)*
- Add 9 unit tests for `initString()` covering both `own=true` and `own=false` branches: rejects invalid types (number, string, null, undefined, Buffer-when-struct-expected) and correctly initializes a valid `StringRefStruct`

Fix: #1411