### PR TITLE
Fix bugs in examples and electron demos

### DIFF
--- a/electron_demo/manipulator/main.js
+++ b/electron_demo/manipulator/main.js
@@ -24,6 +24,7 @@ let jointStatePublisher;
 let jointStateSubscriber;
 let isAnimating = false;
 let animationInterval;
+let publishingInterval;
 
 // Current joint positions (in radians)
 let currentJointPositions = {
@@ -79,6 +80,9 @@ app.whenReady().then(async () => {
 app.on('window-all-closed', function () {
   if (process.platform !== 'darwin') {
     // Clean up ROS2 resources
+    if (publishingInterval) {
+      clearInterval(publishingInterval);
+    }
     if (animationInterval) {
       clearInterval(animationInterval);
     }
@@ -131,7 +135,7 @@ async function initializeROS2() {
 
 function startJointStatePublishing() {
   // Publish joint states at 10 Hz
-  setInterval(() => {
+  publishingInterval = setInterval(() => {
     publishJointStates();
   }, 100); // 100ms = 10 Hz
 }

--- a/electron_demo/turtle_tf2/main.js
+++ b/electron_demo/turtle_tf2/main.js
@@ -759,24 +759,19 @@ app.whenReady().then(async () => {
 
 app.on('window-all-closed', function () {
   if (process.platform !== 'darwin') {
-    // Clean up ROS2 nodes
-    Object.values(turtleTf2Nodes).forEach((node) => {
-      try {
-        rclnodejs.shutdown();
-      } catch (error) {
-        console.error('Error shutting down node:', error);
-      }
-    });
+    try {
+      rclnodejs.shutdown();
+    } catch (error) {
+      console.error('Error shutting down ROS2:', error);
+    }
     app.quit();
   }
 });
 
 app.on('before-quit', () => {
-  Object.values(turtleTf2Nodes).forEach((node) => {
-    try {
-      rclnodejs.shutdown();
-    } catch (error) {
-      console.error('Error shutting down node:', error);
-    }
-  });
+  try {
+    rclnodejs.shutdown();
+  } catch (error) {
+    console.error('Error shutting down ROS2:', error);
+  }
 });

--- a/example/actions/action_client/action-client-example.js
+++ b/example/actions/action_client/action-client-example.js
@@ -55,7 +55,9 @@ class FibonacciActionClient {
         .getLogger()
         .info(`Goal suceeded with result: ${result.sequence}`);
     } else {
-      this._node.getLogger().info(`Goal failed with status: ${status}`);
+      this._node
+        .getLogger()
+        .info(`Goal failed with status: ${goalHandle.status}`);
     }
 
     rclnodejs.shutdown();

--- a/example/actions/action_client/action-client-example.js
+++ b/example/actions/action_client/action-client-example.js
@@ -53,7 +53,7 @@ class FibonacciActionClient {
     if (goalHandle.isSucceeded()) {
       this._node
         .getLogger()
-        .info(`Goal suceeded with result: ${result.sequence}`);
+        .info(`Goal succeeded with result: ${result.sequence}`);
     } else {
       this._node
         .getLogger()

--- a/example/topics/publisher/publisher-qos-example.js
+++ b/example/topics/publisher/publisher-qos-example.js
@@ -21,7 +21,7 @@ rclnodejs.init().then(() => {
   const node = rclnodejs.createNode('publisher_qos_example_node');
 
   let qos = new QoS();
-  qos.hitory = QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT;
+  qos.history = QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT;
   qos.reliability =
     QoS.ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT;
   qos.durability =


### PR DESCRIPTION
This PR fixes small but user-facing issues in the JavaScript examples and Electron demos, improving correctness of sample code and shutdown/cleanup behavior.

**Changes:**

**example/topics/publisher/publisher-qos-example.js**
- Fix typo `qos.hitory` → `qos.history`; the misspelled property silently created a non-existent field, so the history policy was never actually configured

**example/actions/action_client/action-client-example.js**
- Fix undefined variable `status` → `goalHandle.status` in the goal failure log message; the original code would throw a `ReferenceError` when a goal failed

**electron_demo/manipulator/main.js**
- Fix resource leak: store the publishing `setInterval` return value in `publishingInterval` and clear it on app shutdown; previously the interval ID was discarded, making cleanup impossible

**electron_demo/turtle_tf2/main.js**
- Fix incorrect `rclnodejs.shutdown()` usage: call it once globally instead of once per node in a `forEach` loop; `shutdown()` tears down the entire ROS2 context, so calling it multiple times risks context corruption

Fix: #1413