### PR TITLE
Update docs and tutorials

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -4,7 +4,7 @@
 
 1.Install ROS 2 from binary package.
 
-ROS 2 is a cross-platform system, which covers Linux, macOS and Windows, and the `rclnodejs` module is developed against the [`master`](https://github.com/ros2/ros2/blob/master/ros2.repos) branch of ROS 2. You can download the latest binary packages from [ROS 2 build farm](http://ci.ros2.org/view/packaging/) and follow the instructions of [Linux](https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html)/[Windows](https://docs.ros.org/en/rolling/Installation/Windows-Install-Binary.html) to setup the environment (If you want to run your apps on a stable release of ROS 2, e.g. crystal-clemmys, please see the section `Running on Stable Release of ROS 2).
+ROS 2 is a cross-platform system, which covers Linux, macOS and Windows, and the `rclnodejs` module is developed against the [`master`](https://github.com/ros2/ros2/blob/master/ros2.repos) branch of ROS 2. You can download the latest binary packages from [ROS 2 build farm](http://ci.ros2.org/view/packaging/) and follow the instructions of [Linux](https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html)/[Windows](https://docs.ros.org/en/rolling/Installation/Windows-Install-Binary.html) to setup the environment. Supported ROS 2 distributions: Rolling, Kilted, Jazzy, and Humble.
 
 2.Build ROS 2 from scratch.
 
@@ -13,7 +13,7 @@ Alternatively, you can build ROS 2 from scratch. Please select the platform you 
 ### Install `Node.js`
 
 **Notice:**
-`rclnodejs` should only be used with node versions between 10.23.1 - 19.x. The lowest LTS Node.js we used to verify the unit tests is `10.23.1`.
+`rclnodejs` requires Node.js version >= 16.13.0.
 
 I install Nodejs from either:
 
@@ -56,11 +56,7 @@ This `Node.js` module is built by [node-gyp](https://www.npmjs.com/package/node-
 npm install
 ```
 
-**Windows-specific**: make sure Python 2.x interpreter is first searched in your `PATH` before running the command. You can change it temporarily by:
-
-```bash
-  set PATH=<path\to\python 2.x>;%PATH%
-```
+**Windows-specific**: make sure a Python 3.x interpreter is available in your `PATH` before running the command, as required by [node-gyp](https://github.com/nodejs/node-gyp#on-windows).
 
 ## Run Unit Tests
 

--- a/docs/EFFICIENCY.md
+++ b/docs/EFFICIENCY.md
@@ -24,7 +24,7 @@ let enableLifecycleCommInterface = false;
 let node = new LifecycleNode(
   nodeName,
   namespace,
-  Context.defaultContext,
+  Context.defaultContext(),
   NodeOptions.defaultOptions,
   enableLifecycleCommInterface
 );

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -20,10 +20,10 @@ ros2 pkg list
 
 If the package containing your target message is not listed then install it.
 
-Next, inspect the generated JavaScript message files by viewing the `./node_modules/rclnodejs/generated/` folder of your project for your target message. If you are unable to locate the message file then use the `generate-messages` script:
+Next, inspect the generated JavaScript message files by viewing the `./node_modules/rclnodejs/generated/` folder of your project for your target message. If you are unable to locate the message file then use the `generate-ros-messages` script:
 
 ```
-<your_project>/node_modules/.bin/generate-messages
+<your_project>/node_modules/.bin/generate-ros-messages
 ```
 
 ## Maximum call stack size exceeded error when running in Jest

--- a/tutorials/actionlib.md
+++ b/tutorials/actionlib.md
@@ -35,7 +35,7 @@ Defines the request parameters for the task to be performed.
 ```javascript
 // Example: Fibonacci.Goal
 {
-  order: 10 // Compute Fibonacci sequence up to order 10
+  order: 10; // Compute Fibonacci sequence up to order 10
 }
 ```
 
@@ -46,7 +46,7 @@ Provides periodic updates during task execution.
 ```javascript
 // Example: Fibonacci.Feedback
 {
-  sequence: [0, 1, 1, 2, 3, 5, 8] // Current progress
+  sequence: [0, 1, 1, 2, 3, 5, 8]; // Current progress
 }
 ```
 
@@ -57,7 +57,7 @@ Contains the final outcome when the task completes.
 ```javascript
 // Example: Fibonacci.Result
 {
-  sequence: [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55] // Final result
+  sequence: [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]; // Final result
 }
 ```
 
@@ -147,7 +147,7 @@ class FibonacciActionServer {
   }
 
   // Called when new goal is received
-  goalCallback(goalHandle) {
+  goalCallback(goal) {
     this._node.getLogger().info('Received goal request');
     // Accept or reject the goal
     return rclnodejs.GoalResponse.ACCEPT; // or REJECT
@@ -307,19 +307,19 @@ class MultiGoalActionServer {
     );
   }
 
-  goalCallback(goalHandle) {
+  goalCallback(goal) {
     // Accept up to 3 concurrent goals
     if (this._activeGoals.size >= 3) {
       this._node.getLogger().info('Too many active goals, rejecting');
       return rclnodejs.GoalResponse.REJECT;
     }
 
-    this._node.getLogger().info(`Accepting goal ${goalHandle.goalId}`);
-    this._activeGoals.set(goalHandle.goalId, goalHandle);
+    this._node.getLogger().info(`Accepting goal with order=${goal.order}`);
     return rclnodejs.GoalResponse.ACCEPT;
   }
 
   async executeCallback(goalHandle) {
+    this._activeGoals.set(goalHandle.goalId, goalHandle);
     try {
       // Execute goal logic...
       const result = await this.computeFibonacci(goalHandle);

--- a/tutorials/content-filtering-subscription.md
+++ b/tutorials/content-filtering-subscription.md
@@ -261,7 +261,7 @@ class SensorDataProcessor {
       parameters: [0.1, 5.0, 0.1], // Valid range and FOV
     };
 
-    const subscription = this.node.createSubscription(
+    this.subscription = this.node.createSubscription(
       'sensor_msgs/msg/Range',
       'sensor_data',
       options,

--- a/tutorials/type-description-service.md
+++ b/tutorials/type-description-service.md
@@ -39,17 +39,17 @@ Each node automatically creates a service at:
 
 The Type Description Service is available in:
 
-- **ROS 2 Iron** and newer distributions (officially supported starting from Iron)
+- **ROS 2 Jazzy** and newer distributions (officially supported starting from Jazzy)
 - **rclnodejs** with compatible ROS 2 installation
 
-**Note**: Type Description Service is **not available** in ROS 2 Humble and earlier versions.
+**Note**: Type Description Service is **not available** in ROS 2 Iron and earlier versions.
 
 ```javascript
 const rclnodejs = require('rclnodejs');
 const DistroUtils = require('rclnodejs/lib/distro');
 
 // Check if Type Description Service is supported
-if (DistroUtils.getDistroId() > DistroUtils.getDistroId('humble')) {
+if (DistroUtils.getDistroId() >= DistroUtils.getDistroId('jazzy')) {
   console.log('Type Description Service is supported');
 } else {
   console.warn(
@@ -288,7 +288,7 @@ const DistroUtils = require('rclnodejs/lib/distro');
 
 async function testTypeDescriptionService() {
   // Check if Type Description Service is supported
-  if (DistroUtils.getDistroId() <= DistroUtils.getDistroId('humble')) {
+  if (DistroUtils.getDistroId() < DistroUtils.getDistroId('jazzy')) {
     console.log(
       'Type Description Service is not supported in this ROS 2 version'
     );


### PR DESCRIPTION
Updates documentation/tutorials to align with current rclnodejs tooling, API signatures, and supported ROS/Node.js versions.

**Changes:**
- Update Type Description Service tutorial to reflect ROS 2 Jazzy+ availability and matching version checks.
- Fix content-filtering tutorial example to store the subscription on the class instance for later updates.
- Refresh docs for message generation command, lifecycle context usage, and build prerequisites (Node.js + Python on Windows).

Fix: #1415