### PR TITLE
Fix: correct bugs in test files

### DIFF
--- a/test/client_setup.js
+++ b/test/client_setup.js
@@ -37,7 +37,6 @@ rclnodejs
     rclnodejs.spin(node);
 
     process.on('SIGINT', function () {
-      timer.cancel();
       node.destroy();
       rclnodejs.shutdown();
       process.exit(0);

--- a/test/test-lifecycle.js
+++ b/test/test-lifecycle.js
@@ -260,9 +260,9 @@ describe('LifecycleNode test suite', function () {
         transitions[1].transition.id === 6
     ); // shutdown
     assert.ok(
-      transitions[1].transition.id === 2 || // cleanup
-        transitions[1].transition.id === 3 || // activate
-        transitions[1].transition.id === 6
+      transitions[2].transition.id === 2 || // cleanup
+        transitions[2].transition.id === 3 || // activate
+        transitions[2].transition.id === 6
     ); // shutdown
   });
 

--- a/test/test-parameter-service.js
+++ b/test/test-parameter-service.js
@@ -251,7 +251,7 @@ describe('Parameter_server tests', function () {
 
       // A.p3 value
       const p3 = Parameter.fromParameterMessage({
-        name: 'p1',
+        name: 'A.p3',
         value: response.values[1],
       });
       assert.equal(p3.type, ParameterType.PARAMETER_BOOL);

--- a/test/test-rate.js
+++ b/test/test-rate.js
@@ -107,5 +107,12 @@ describe('rclnodejs rate test suite', function () {
       arr.reduce((prev, cur) => {
         return prev + cur;
       }, 0) / dataSize;
+
+    // avg sleep time should be within a reasonable range of the expected period
+    const expectedPeriod = 1000 / hz; // 1ms
+    assert.ok(
+      avg < expectedPeriod * 5,
+      `Average sleep time ${avg}ms exceeded 5x the expected period ${expectedPeriod}ms`
+    );
   });
 });

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -45,8 +45,6 @@ describe('Utils testing', function () {
     await utils.ensureDir(dir);
   });
 
-  it('should valid ensureDirSync works correctly', function () {});
-
   it('should verify ensureDirSync works correctly', function () {
     const dir = path.join(tmpDir, 'nested/sync/dir');
     utils.ensureDirSync(dir);

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -472,7 +472,6 @@ const actionClient = new rclnodejs.ActionClient(
 expectType<rclnodejs.ActionClient<'example_interfaces/action/Fibonacci'>>(
   actionClient
 );
-expectType<boolean>(client.isServiceServerAvailable());
 expectType<Promise<boolean>>(actionClient.waitForServer());
 expectType<void>(actionClient.destroy());
 


### PR DESCRIPTION
### Summary

Fixed 6 bugs across 6 test files discovered during code review. All issues were in test code only — no library changes.

### Changes

#### 1. `test/client_setup.js` — Remove reference to undefined `timer`

The `SIGINT` handler called `timer.cancel()`, but `timer` is not defined in this scope. Removed the call to prevent a `ReferenceError` if the signal is received.

#### 2. `test/test-lifecycle.js` — Fix duplicate transition index

Two consecutive assertions both checked `transitions[1]`, meaning `transitions[2]` was never validated. Changed the second check from `transitions[1]` to `transitions[2]`.

#### 3. `test/test-parameter-service.js` — Fix wrong parameter name

`Parameter.fromParameterMessage` was called with `name: 'p1'` but the test was validating parameter `A.p3`. Changed to `name: 'A.p3'`.

#### 4. `test/test-rate.js` — Add missing assertion

The test computed an average sleep time but never asserted on it. Added an assertion that the average is within 5x the expected period.

#### 5. `test/test-utils.js` — Remove empty duplicate test

An empty test body `it('should valid ensureDirSync works correctly', function () {})` duplicated the immediately following test `it('should verify ensureDirSync works correctly', ...)`. Removed the empty duplicate.

#### 6. `test/types/index.test-d.ts` — Remove misplaced type assertion

`expectType<boolean>(client.isServiceServerAvailable())` was in the **ActionClient** section but tested `client` (the service client variable). The same assertion already exists in the correct Client section. Removed the misplaced copy.

### Files changed

| File | Change |
|------|--------|
| `test/client_setup.js` | Remove undefined `timer.cancel()` |
| `test/test-lifecycle.js` | `transitions[1]` → `transitions[2]` in second assertion |
| `test/test-parameter-service.js` | `'p1'` → `'A.p3'` |
| `test/test-rate.js` | Add avg sleep time assertion |
| `test/test-utils.js` | Remove empty duplicate test |
| `test/types/index.test-d.ts` | Remove misplaced `client.isServiceServerAvailable()` |

Fix: #1417 