### PR TITLE
Fix Node creation crash when using plain object as options

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -97,7 +97,30 @@ class Node extends rclnodejs.ShadowNode {
     );
   }
 
+  static _normalizeOptions(options) {
+    if (options instanceof NodeOptions) {
+      return options;
+    }
+    const defaults = NodeOptions.defaultOptions;
+    return {
+      startParameterServices:
+        options.startParameterServices ?? defaults.startParameterServices,
+      parameterOverrides:
+        options.parameterOverrides ?? defaults.parameterOverrides,
+      automaticallyDeclareParametersFromOverrides:
+        options.automaticallyDeclareParametersFromOverrides ??
+        defaults.automaticallyDeclareParametersFromOverrides,
+      startTypeDescriptionService:
+        options.startTypeDescriptionService ??
+        defaults.startTypeDescriptionService,
+      enableRosout: options.enableRosout ?? defaults.enableRosout,
+      rosoutQos: options.rosoutQos ?? defaults.rosoutQos,
+    };
+  }
+
   _init(name, namespace, options, context, args, useGlobalArguments) {
+    options = Node._normalizeOptions(options);
+
     this.handle = rclnodejs.createNode(
       name,
       namespace,
@@ -149,9 +172,8 @@ class Node extends rclnodejs.ShadowNode {
     this._parameterOverrides = this._getNativeParameterOverrides();
 
     // override cli parameterOverrides with those specified in options
-    const parameterOverrides = options.parameterOverrides || [];
-    if (parameterOverrides.length > 0) {
-      for (const parameter of parameterOverrides) {
+    if (options.parameterOverrides.length > 0) {
+      for (const parameter of options.parameterOverrides) {
         if (!(parameter instanceof Parameter)) {
           throw new TypeValidationError(
             'parameterOverride',

--- a/lib/node.js
+++ b/lib/node.js
@@ -149,8 +149,9 @@ class Node extends rclnodejs.ShadowNode {
     this._parameterOverrides = this._getNativeParameterOverrides();
 
     // override cli parameterOverrides with those specified in options
-    if (options.parameterOverrides.length > 0) {
-      for (const parameter of options.parameterOverrides) {
+    const parameterOverrides = options.parameterOverrides || [];
+    if (parameterOverrides.length > 0) {
+      for (const parameter of parameterOverrides) {
         if (!(parameter instanceof Parameter)) {
           throw new TypeValidationError(
             'parameterOverride',

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -145,26 +145,22 @@ describe('rclnodejs node test suite', function () {
     });
 
     it('Create a node with a plain object as options', function () {
-      assert.doesNotThrow(() => {
-        const node = new rclnodejs.Node('plain_opts_node', '/ns', undefined, {
-          enableRosout: false,
-        });
-        assert.strictEqual(node.name(), 'plain_opts_node');
-        node.destroy();
+      const node = new rclnodejs.Node('plain_opts_node', '/ns', undefined, {
+        enableRosout: false,
       });
+      assert.strictEqual(node.name(), 'plain_opts_node');
+      node.destroy();
     });
 
     it('Create a node with options missing parameterOverrides', function () {
-      assert.doesNotThrow(() => {
-        const node = new rclnodejs.Node(
-          'partial_opts_node',
-          '/ns',
-          undefined,
-          {}
-        );
-        assert.strictEqual(node.name(), 'partial_opts_node');
-        node.destroy();
-      });
+      const node = new rclnodejs.Node(
+        'partial_opts_node',
+        '/ns',
+        undefined,
+        {}
+      );
+      assert.strictEqual(node.name(), 'partial_opts_node');
+      node.destroy();
     });
   });
 });

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -143,6 +143,29 @@ describe('rclnodejs node test suite', function () {
         );
       });
     });
+
+    it('Create a node with a plain object as options', function () {
+      assert.doesNotThrow(() => {
+        const node = new rclnodejs.Node('plain_opts_node', '/ns', undefined, {
+          enableRosout: false,
+        });
+        assert.strictEqual(node.name(), 'plain_opts_node');
+        node.destroy();
+      });
+    });
+
+    it('Create a node with options missing parameterOverrides', function () {
+      assert.doesNotThrow(() => {
+        const node = new rclnodejs.Node(
+          'partial_opts_node',
+          '/ns',
+          undefined,
+          {}
+        );
+        assert.strictEqual(node.name(), 'partial_opts_node');
+        node.destroy();
+      });
+    });
   });
 });
 


### PR DESCRIPTION
When a plain object (e.g., `{ enableRosout: false }`) is passed as options instead of a `NodeOptions` instance, `options.parameterOverrides` is `undefined`, causing `TypeError: Cannot read properties of undefined (reading 'length')`.

Added `Node._normalizeOptions()` to merge plain objects with `NodeOptions.defaultOptions` defaults using nullish coalescing (`??`), ensuring all documented defaults are preserved for unspecified fields while respecting explicitly set values (including `false`).

**Files:**
- `lib/node.js` — added `static _normalizeOptions()`, called at the top of `_init()`
- `test/test-node.js` — added tests for node creation with plain object options and empty object options

Fix: #1423