### PR TITLE
Align clang-format include ordering with cpplint rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,14 @@
 BasedOnStyle: Google
-Standard: Cpp11
+Standard: c++17
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:    '^<ext/.*\.h>'
+    Priority: 2
+  - Regex:    '^<.*\.h>'
+    Priority: 1
+  - Regex:    '^<[^./]+>'
+    Priority: 2
+  - Regex:    '^<.*'
+    Priority: 3
+  - Regex:    '.*'
+    Priority: 4

--- a/src/rcl_context_bindings.cpp
+++ b/src/rcl_context_bindings.cpp
@@ -17,9 +17,9 @@
 #include <rcl/logging.h>
 #include <rcl/rcl.h>
 
-#include <rcpputils/scope_exit.hpp>
-// NOLINTNEXTLINE
 #include <string>
+
+#include <rcpputils/scope_exit.hpp>
 
 #include "macros.h"
 #include "rcl_handle.h"

--- a/src/rcl_graph_bindings.cpp
+++ b/src/rcl_graph_bindings.cpp
@@ -18,9 +18,9 @@
 #include <rcl/graph.h>
 #include <rcl/rcl.h>
 
-#include <rcpputils/scope_exit.hpp>
-// NOLINTNEXTLINE
 #include <string>
+
+#include <rcpputils/scope_exit.hpp>
 
 #include "macros.h"
 #include "rcl_handle.h"

--- a/src/rcl_subscription_bindings.cpp
+++ b/src/rcl_subscription_bindings.cpp
@@ -19,9 +19,9 @@
 
 #include <cstdio>
 #include <memory>
-#include <rcpputils/scope_exit.hpp>
-// NOLINTNEXTLINE
 #include <string>
+
+#include <rcpputils/scope_exit.hpp>
 
 #include "macros.h"
 #include "rcl_handle.h"

--- a/src/rcl_utilities.cpp
+++ b/src/rcl_utilities.cpp
@@ -21,9 +21,9 @@
 
 #include <cstdio>
 #include <memory>
-#include <rcpputils/scope_exit.hpp>
-// NOLINTNEXTLINE
 #include <string>
+
+#include <rcpputils/scope_exit.hpp>
 
 namespace {
 


### PR DESCRIPTION
Previously, clang-format's default Google style IncludeCategories assigned the same priority to C++ standard library headers (e.g., <string>) and third-party headers (e.g., <rcpputils/scope_exit.hpp>), causing them to be sorted alphabetically within the same group. This violated cpplint's expected include order (C system → C++ system → other), requiring `// NOLINTNEXTLINE` comments as workarounds.

Changes:
- .clang-format: Add explicit IncludeCategories to separate C++ standard library headers (no slash, no extension) from third-party angle-bracket headers, and set IncludeBlocks to Regroup so clang-format enforces proper grouping
- .clang-format: Upgrade Standard from Cpp11 to c++17 to match binding.gyp
- Remove `// NOLINTNEXTLINE` from 4 source files: src/rcl_context_bindings.cpp, src/rcl_graph_bindings.cpp, src/rcl_subscription_bindings.cpp, src/rcl_utilities.cpp

Verified with `npm run format` and `npm run lint` (cpplint: 0 errors).

Fix: #1427 