### PR TITLE
 Shorten ASan workflow name for badge display

### DIFF
--- a/.github/workflows/linux-x64-asan-test.yml
+++ b/.github/workflows/linux-x64-asan-test.yml
@@ -1,4 +1,4 @@
-name: ASan Memory Test
+name: ASan
 
 on:
   push:


### PR DESCRIPTION
Rename GitHub Actions workflow from "ASan Memory Test" to "ASan" for a more concise badge label in README, consistent with other badge names ("Linux", "Windows").

Fix: #1431 