### PR TITLE
Prevent CI hangs from unbounded subprocess waits

### DIFF
--- a/test/electron/run_test.js
+++ b/test/electron/run_test.js
@@ -28,17 +28,32 @@ console.log('Launching Electron to run test_usability.js...');
 const child = spawn(command, args, {
   stdio: 'inherit',
   env: { ...process.env, ELECTRON_ENABLE_LOGGING: true },
+  detached: true,
 });
 
-// Kill the child process if it doesn't exit within 30 seconds
+// Kill the child process tree if it doesn't exit within 30 seconds
 const killTimeout = setTimeout(() => {
   console.error('Electron process did not exit in time, killing...');
-  child.kill('SIGKILL');
+  try {
+    process.kill(-child.pid, 'SIGKILL');
+  } catch (err) {
+    try {
+      child.kill('SIGKILL');
+    } catch (e) {
+      // Process already dead
+    }
+  }
 }, 30 * 1000);
 
-child.on('close', (code) => {
+child.on('close', (code, signal) => {
   clearTimeout(killTimeout);
-  console.log(`Electron process exited with code ${code}`);
+  if (code !== null) {
+    console.log(`Electron process exited with code ${code}`);
+  } else {
+    console.log(
+      `Electron process was terminated by signal ${signal || 'unknown'}`
+    );
+  }
   if (code === 0) {
     console.log('Test Passed!');
     process.exit(0);

--- a/test/electron/run_test.js
+++ b/test/electron/run_test.js
@@ -30,7 +30,14 @@ const child = spawn(command, args, {
   env: { ...process.env, ELECTRON_ENABLE_LOGGING: true },
 });
 
+// Kill the child process if it doesn't exit within 30 seconds
+const killTimeout = setTimeout(() => {
+  console.error('Electron process did not exit in time, killing...');
+  child.kill('SIGKILL');
+}, 30 * 1000);
+
 child.on('close', (code) => {
+  clearTimeout(killTimeout);
   console.log(`Electron process exited with code ${code}`);
   if (code === 0) {
     console.log('Test Passed!');

--- a/test/test-message-generation-bin.js
+++ b/test/test-message-generation-bin.js
@@ -33,6 +33,39 @@ function getNodeVersionInfo() {
     .map((x) => parseInt(x));
 }
 
+function runCommand(command, args, options) {
+  const result = childProcess.spawnSync(command, args, options);
+  if (
+    result.error ||
+    (typeof result.status === 'number' && result.status !== 0)
+  ) {
+    const parts = [
+      `Failed to run: ${command} ${Array.isArray(args) ? args.join(' ') : ''}`,
+    ];
+    if (
+      result.error &&
+      result.error.code === 'ETIMEDOUT' &&
+      options &&
+      options.timeout
+    ) {
+      parts.push(`Command timed out after ${options.timeout} ms`);
+    } else if (result.error) {
+      parts.push(`Error: ${result.error.message}`);
+    }
+    if (typeof result.status === 'number' && result.status !== 0) {
+      parts.push(`Exit status: ${result.status}`);
+    }
+    if (result.stdout) {
+      parts.push(`stdout:\n${result.stdout.toString()}`);
+    }
+    if (result.stderr) {
+      parts.push(`stderr:\n${result.stderr.toString()}`);
+    }
+    throw new Error(parts.join('\n'));
+  }
+  return result;
+}
+
 describe('rclnodejs generate-messages binary-script tests', function () {
   let cwd;
   let tmpPkg;
@@ -62,7 +95,7 @@ describe('rclnodejs generate-messages binary-script tests', function () {
       cwd: this.tmpPkg,
       timeout: 60 * 1000,
     });
-    childProcess.spawnSync('npm', ['pack', this.cwd], {
+    runCommand('npm', ['pack', this.cwd], {
       // stdio: 'inherit',
       shell: true,
       cwd: this.tmpPkg,
@@ -82,7 +115,7 @@ describe('rclnodejs generate-messages binary-script tests', function () {
       return;
     }
     let tgzPath = path.join(this.tmpPkg, tgz);
-    childProcess.spawnSync('npm', ['install', tgzPath], {
+    runCommand('npm', ['install', tgzPath], {
       // stdio: 'inherit',
       shell: true,
       cwd: this.tmpPkg,
@@ -117,7 +150,7 @@ describe('rclnodejs generate-messages binary-script tests', function () {
 
   it('test generate-ros-messages script operation', function (done) {
     let script = createScriptFolderPath(this.tmpPkg);
-    childProcess.spawnSync(script, args, {
+    runCommand(script, args, {
       // stdio: 'inherit',
       shell: true,
       timeout: 120 * 1000,
@@ -136,7 +169,7 @@ describe('rclnodejs generate-messages binary-script tests', function () {
   });
 
   it('test npx generate-ros-messages script operation', function (done) {
-    childProcess.spawnSync('npx', [SCRIPT_NAME, ...args], {
+    runCommand('npx', [SCRIPT_NAME, ...args], {
       // stdio: 'inherit',
       shell: true,
       cwd: this.tmpPkg,

--- a/test/test-message-generation-bin.js
+++ b/test/test-message-generation-bin.js
@@ -60,11 +60,13 @@ describe('rclnodejs generate-messages binary-script tests', function () {
       // stdio: 'inherit',
       shell: true,
       cwd: this.tmpPkg,
+      timeout: 60 * 1000,
     });
     childProcess.spawnSync('npm', ['pack', this.cwd], {
       // stdio: 'inherit',
       shell: true,
       cwd: this.tmpPkg,
+      timeout: 120 * 1000,
     });
 
     let tgz;
@@ -84,6 +86,7 @@ describe('rclnodejs generate-messages binary-script tests', function () {
       // stdio: 'inherit',
       shell: true,
       cwd: this.tmpPkg,
+      timeout: 300 * 1000,
     });
 
     let generatedFolderPath = createGeneratedFolderPath(this.tmpPkg);
@@ -117,6 +120,7 @@ describe('rclnodejs generate-messages binary-script tests', function () {
     childProcess.spawnSync(script, args, {
       // stdio: 'inherit',
       shell: true,
+      timeout: 120 * 1000,
     });
 
     let generatedFolderPath = createGeneratedFolderPath(this.tmpPkg);
@@ -136,6 +140,7 @@ describe('rclnodejs generate-messages binary-script tests', function () {
       // stdio: 'inherit',
       shell: true,
       cwd: this.tmpPkg,
+      timeout: 120 * 1000,
     });
 
     let generatedFolderPath = createGeneratedFolderPath(this.tmpPkg);


### PR DESCRIPTION
Two intermittent CI hang issues were identified:

1. test-message-generation-bin.js: The before() hook runs spawnSync for npm init, npm pack, and npm install (full native rebuild from tarball) with no timeout. If any of these hangs (network issue, lock contention, slow arm64 runner), mocha blocks indefinitely until the GitHub Actions runner is reclaimed, producing a "context canceled" error with no useful diagnostics. Fixed by adding timeout to all spawnSync calls (60s for init, 120s for pack/scripts, 300s for install).

2. test/electron/run_test.js: The parent process spawns Electron via xvfb-run and waits for the close event. If the Electron child process or lingering DDS/FastDDS background threads don't terminate cleanly (due to async app.quit() racing with process.exit(), or xvfb-run holding stdio pipes open), the parent hangs forever. Fixed by adding a 30-second kill timeout that forcibly terminates the child if it doesn't exit after the test completes.

Fix: #1433 