### PR TITLE
Add ParameterEventHandler for cross-node parameter monitoring

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ const {
 const ParameterClient = require('./lib/parameter_client.js');
 const errors = require('./lib/errors.js');
 const ParameterWatcher = require('./lib/parameter_watcher.js');
+const ParameterEventHandler = require('./lib/parameter_event_handler.js');
 const MessageIntrospector = require('./lib/message_introspector.js');
 const ObservableSubscription = require('./lib/observable_subscription.js');
 const { spawn } = require('child_process');
@@ -242,6 +243,9 @@ let rcl = {
 
   /** {@link ParameterWatcher} class */
   ParameterWatcher: ParameterWatcher,
+
+  /** {@link ParameterEventHandler} class */
+  ParameterEventHandler: ParameterEventHandler,
 
   /** {@link ObservableSubscription} class */
   ObservableSubscription: ObservableSubscription,

--- a/lib/node.js
+++ b/lib/node.js
@@ -40,6 +40,7 @@ const {
 const ParameterService = require('./parameter_service.js');
 const ParameterClient = require('./parameter_client.js');
 const ParameterWatcher = require('./parameter_watcher.js');
+const ParameterEventHandler = require('./parameter_event_handler.js');
 const Publisher = require('./publisher.js');
 const QoS = require('./qos.js');
 const Rates = require('./rate.js');
@@ -148,6 +149,7 @@ class Node extends rclnodejs.ShadowNode {
     this._actionServers = [];
     this._parameterClients = [];
     this._parameterWatchers = [];
+    this._parameterEventHandlers = [];
     this._rateTimerServer = null;
     this._parameterDescriptors = new Map();
     this._parameters = new Map();
@@ -1082,6 +1084,7 @@ class Node extends rclnodejs.ShadowNode {
 
     this._parameterClients.forEach((paramClient) => paramClient.destroy());
     this._parameterWatchers.forEach((watcher) => watcher.destroy());
+    this._parameterEventHandlers.forEach((handler) => handler.destroy());
 
     this.context.onNodeDestroyed(this);
 
@@ -1102,6 +1105,7 @@ class Node extends rclnodejs.ShadowNode {
     this._actionServers = [];
     this._parameterClients = [];
     this._parameterWatchers = [];
+    this._parameterEventHandlers = [];
 
     if (this._rateTimerServer) {
       this._rateTimerServer.shutdown();
@@ -1212,6 +1216,38 @@ class Node extends rclnodejs.ShadowNode {
     }
     this._removeEntityFromArray(watcher, this._parameterWatchers);
     watcher.destroy();
+  }
+
+  /**
+   * Create a ParameterEventHandler that monitors parameter changes on any node.
+   *
+   * Unlike {@link ParameterWatcher} which watches specific parameters on a single
+   * remote node, ParameterEventHandler can register callbacks for parameters on
+   * any node in the ROS 2 graph by subscribing to /parameter_events.
+   *
+   * @param {object} [options] - Options for the handler
+   * @param {object} [options.qos] - QoS profile for the parameter_events subscription
+   * @return {ParameterEventHandler} - An instance of ParameterEventHandler
+   * @see {@link ParameterEventHandler}
+   */
+  createParameterEventHandler(options = {}) {
+    const handler = new ParameterEventHandler(this, options);
+    debug('Created ParameterEventHandler on node=%s', this.name());
+    this._parameterEventHandlers.push(handler);
+    return handler;
+  }
+
+  /**
+   * Destroy a ParameterEventHandler.
+   * @param {ParameterEventHandler} handler - The handler to be destroyed.
+   * @return {undefined}
+   */
+  destroyParameterEventHandler(handler) {
+    if (!(handler instanceof ParameterEventHandler)) {
+      throw new TypeError('Invalid argument');
+    }
+    this._removeEntityFromArray(handler, this._parameterEventHandlers);
+    handler.destroy();
   }
 
   /**

--- a/lib/parameter_event_handler.js
+++ b/lib/parameter_event_handler.js
@@ -1,0 +1,468 @@
+// Copyright (c) 2026 Wayne Parrott. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const { TypeValidationError, OperationError } = require('./errors');
+const { normalizeNodeName } = require('./utils');
+const debug = require('debug')('rclnodejs:parameter_event_handler');
+
+const PARAMETER_EVENT_MSG_TYPE = 'rcl_interfaces/msg/ParameterEvent';
+const PARAMETER_EVENT_TOPIC = '/parameter_events';
+
+/**
+ * @class ParameterCallbackHandle
+ * Opaque handle returned when adding a parameter callback.
+ * Used to remove the callback later.
+ */
+class ParameterCallbackHandle {
+  /**
+   * @param {string} parameterName - The parameter name
+   * @param {string} nodeName - The fully qualified node name
+   * @param {Function} callback - The callback function
+   * @hideconstructor
+   */
+  constructor(parameterName, nodeName, callback) {
+    this.parameterName = parameterName;
+    this.nodeName = nodeName;
+    this.callback = callback;
+  }
+}
+
+/**
+ * @class ParameterEventCallbackHandle
+ * Opaque handle returned when adding a parameter event callback.
+ * Used to remove the callback later.
+ */
+class ParameterEventCallbackHandle {
+  /**
+   * @param {Function} callback - The callback function
+   * @hideconstructor
+   */
+  constructor(callback) {
+    this.callback = callback;
+  }
+}
+
+/**
+ * @class ParameterEventHandler
+ *
+ * Monitors and responds to parameter changes on any node in the ROS 2 graph
+ * by subscribing to the `/parameter_events` topic.
+ *
+ * Unlike {@link ParameterWatcher}, which is tied to a single remote node and
+ * requires waiting for that node's parameter services, ParameterEventHandler
+ * responds to parameter events from any node without needing service availability.
+ *
+ * Two types of callbacks are supported:
+ * - **Parameter callbacks**: fired when a specific parameter on a specific node changes.
+ * - **Event callbacks**: fired for every ParameterEvent message received.
+ *
+ * @example
+ * const handler = node.createParameterEventHandler();
+ *
+ * // Watch a specific parameter on a specific node
+ * const handle = handler.addParameterCallback(
+ *   'my_param',
+ *   '/my_node',
+ *   (parameter) => {
+ *     console.log(`Parameter changed: ${parameter.name} = ${parameter.value}`);
+ *   }
+ * );
+ *
+ * // Watch all parameter events
+ * const eventHandle = handler.addParameterEventCallback((event) => {
+ *   console.log(`Event from node: ${event.node}`);
+ * });
+ *
+ * // Remove callbacks when done
+ * handler.removeParameterCallback(handle);
+ * handler.removeParameterEventCallback(eventHandle);
+ *
+ * // Destroy when no longer needed
+ * handler.destroy();
+ */
+class ParameterEventHandler {
+  #node;
+  #subscription;
+  #parameterCallbacks; // Map<string, ParameterCallbackHandle[]> keyed by "paramName\0nodeName"
+  #eventCallbacks; // ParameterEventCallbackHandle[]
+  #destroyed;
+
+  /**
+   * Create a ParameterEventHandler.
+   *
+   * @param {object} node - The rclnodejs Node used to create the subscription
+   * @param {object} [options] - Options
+   * @param {object} [options.qos] - QoS profile for the parameter_events subscription
+   */
+  constructor(node, options = {}) {
+    if (!node || typeof node.createSubscription !== 'function') {
+      throw new TypeValidationError('node', node, 'Node instance', {
+        entityType: 'parameter event handler',
+      });
+    }
+
+    this.#node = node;
+    this.#parameterCallbacks = new Map();
+    this.#eventCallbacks = [];
+    this.#destroyed = false;
+
+    const subscriptionArgs = [
+      PARAMETER_EVENT_MSG_TYPE,
+      PARAMETER_EVENT_TOPIC,
+      (event) => this.#handleEvent(event),
+    ];
+
+    if (options.qos) {
+      subscriptionArgs.push(options.qos);
+    }
+
+    this.#subscription = node.createSubscription(...subscriptionArgs);
+
+    debug('Created ParameterEventHandler on node=%s', node.name());
+  }
+
+  /**
+   * Add a callback for a specific parameter on a specific node.
+   *
+   * The callback is invoked whenever the named parameter is added or changed
+   * on the specified node. The callback receives the parameter message object
+   * (rcl_interfaces/msg/Parameter) with `name` and `value` fields.
+   *
+   * @param {string} parameterName - Name of the parameter to monitor
+   * @param {string} nodeName - Fully qualified name of the node (e.g., '/my_node')
+   * @param {Function} callback - Called with (parameter) when the parameter changes
+   * @returns {ParameterCallbackHandle} Handle for removing this callback later
+   * @throws {Error} If the handler has been destroyed
+   * @throws {TypeError} If arguments are invalid
+   */
+  addParameterCallback(parameterName, nodeName, callback) {
+    this.#checkNotDestroyed();
+
+    if (typeof parameterName !== 'string' || parameterName.trim() === '') {
+      throw new TypeValidationError(
+        'parameterName',
+        parameterName,
+        'non-empty string',
+        { entityType: 'parameter event handler' }
+      );
+    }
+
+    if (typeof nodeName !== 'string' || nodeName.trim() === '') {
+      throw new TypeValidationError('nodeName', nodeName, 'non-empty string', {
+        entityType: 'parameter event handler',
+      });
+    }
+
+    if (typeof callback !== 'function') {
+      throw new TypeValidationError('callback', callback, 'function', {
+        entityType: 'parameter event handler',
+      });
+    }
+
+    const resolvedNodeName = normalizeNodeName(nodeName);
+    const handle = new ParameterCallbackHandle(
+      parameterName,
+      resolvedNodeName,
+      callback
+    );
+    const key = this.#makeKey(parameterName, resolvedNodeName);
+
+    if (!this.#parameterCallbacks.has(key)) {
+      this.#parameterCallbacks.set(key, []);
+    }
+
+    // Insert at front (FILO order, matching rclpy behavior)
+    this.#parameterCallbacks.get(key).unshift(handle);
+
+    debug(
+      'Added parameter callback: param=%s node=%s',
+      parameterName,
+      resolvedNodeName
+    );
+
+    return handle;
+  }
+
+  /**
+   * Remove a previously added parameter callback.
+   *
+   * @param {ParameterCallbackHandle} handle - The handle returned by addParameterCallback
+   * @throws {Error} If the handle is not found or handler is destroyed
+   */
+  removeParameterCallback(handle) {
+    this.#checkNotDestroyed();
+
+    if (!(handle instanceof ParameterCallbackHandle)) {
+      throw new TypeValidationError(
+        'handle',
+        handle,
+        'ParameterCallbackHandle',
+        { entityType: 'parameter event handler' }
+      );
+    }
+
+    const key = this.#makeKey(handle.parameterName, handle.nodeName);
+    const callbacks = this.#parameterCallbacks.get(key);
+
+    if (!callbacks) {
+      throw new OperationError(
+        `No callbacks registered for parameter '${handle.parameterName}' on node '${handle.nodeName}'`,
+        { entityType: 'parameter event handler' }
+      );
+    }
+
+    const index = callbacks.indexOf(handle);
+    if (index === -1) {
+      throw new OperationError("Callback doesn't exist", {
+        entityType: 'parameter event handler',
+      });
+    }
+
+    callbacks.splice(index, 1);
+
+    if (callbacks.length === 0) {
+      this.#parameterCallbacks.delete(key);
+    }
+
+    debug(
+      'Removed parameter callback: param=%s node=%s',
+      handle.parameterName,
+      handle.nodeName
+    );
+  }
+
+  /**
+   * Add a callback that is invoked for every parameter event.
+   *
+   * The callback receives the full ParameterEvent message
+   * (rcl_interfaces/msg/ParameterEvent) with `node`, `new_parameters`,
+   * `changed_parameters`, and `deleted_parameters` fields.
+   *
+   * @param {Function} callback - Called with (event) for every ParameterEvent
+   * @returns {ParameterEventCallbackHandle} Handle for removing this callback later
+   * @throws {Error} If the handler has been destroyed
+   * @throws {TypeError} If callback is not a function
+   */
+  addParameterEventCallback(callback) {
+    this.#checkNotDestroyed();
+
+    if (typeof callback !== 'function') {
+      throw new TypeValidationError('callback', callback, 'function', {
+        entityType: 'parameter event handler',
+      });
+    }
+
+    const handle = new ParameterEventCallbackHandle(callback);
+
+    // Insert at front (FILO order)
+    this.#eventCallbacks.unshift(handle);
+
+    debug('Added parameter event callback');
+
+    return handle;
+  }
+
+  /**
+   * Remove a previously added parameter event callback.
+   *
+   * @param {ParameterEventCallbackHandle} handle - The handle returned by addParameterEventCallback
+   * @throws {Error} If the handle is not found or handler is destroyed
+   */
+  removeParameterEventCallback(handle) {
+    this.#checkNotDestroyed();
+
+    if (!(handle instanceof ParameterEventCallbackHandle)) {
+      throw new TypeValidationError(
+        'handle',
+        handle,
+        'ParameterEventCallbackHandle',
+        { entityType: 'parameter event handler' }
+      );
+    }
+
+    const index = this.#eventCallbacks.indexOf(handle);
+    if (index === -1) {
+      throw new OperationError("Callback doesn't exist", {
+        entityType: 'parameter event handler',
+      });
+    }
+
+    this.#eventCallbacks.splice(index, 1);
+
+    debug('Removed parameter event callback');
+  }
+
+  /**
+   * Check if the handler has been destroyed.
+   *
+   * @returns {boolean} True if destroyed
+   */
+  isDestroyed() {
+    return this.#destroyed;
+  }
+
+  /**
+   * Destroy the handler and clean up resources.
+   * Removes the subscription and clears all callbacks.
+   */
+  destroy() {
+    if (this.#destroyed) {
+      return;
+    }
+
+    debug('Destroying ParameterEventHandler');
+
+    if (this.#subscription) {
+      try {
+        this.#node.destroySubscription(this.#subscription);
+      } catch (error) {
+        debug('Error destroying subscription: %s', error.message);
+      }
+      this.#subscription = null;
+    }
+
+    this.#parameterCallbacks.clear();
+    this.#eventCallbacks.length = 0;
+    this.#destroyed = true;
+  }
+
+  /**
+   * Get a specific parameter from a ParameterEvent message.
+   *
+   * @param {object} event - A ParameterEvent message
+   * @param {string} parameterName - The parameter name to look for
+   * @param {string} nodeName - The node name to match
+   * @returns {object|null} The matching parameter message, or null
+   * @static
+   */
+  static getParameterFromEvent(event, parameterName, nodeName) {
+    const resolvedNodeName = normalizeNodeName(nodeName);
+
+    if (normalizeNodeName(event.node) !== resolvedNodeName) {
+      return null;
+    }
+
+    const allParams = [
+      ...(event.new_parameters || []),
+      ...(event.changed_parameters || []),
+    ];
+
+    for (const param of allParams) {
+      if (param.name === parameterName) {
+        return param;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Get all parameters from a ParameterEvent message (new + changed).
+   *
+   * @param {object} event - A ParameterEvent message
+   * @returns {object[]} Array of parameter messages
+   * @static
+   */
+  static getParametersFromEvent(event) {
+    return [
+      ...(event.new_parameters || []),
+      ...(event.changed_parameters || []),
+    ];
+  }
+
+  /**
+   * Handle incoming parameter event.
+   * @private
+   */
+  #handleEvent(event) {
+    const eventNodeName = normalizeNodeName(event.node);
+
+    // Dispatch parameter-specific callbacks
+    for (const [key, callbacks] of this.#parameterCallbacks) {
+      const { paramName, nodeName } = this.#parseKey(key);
+
+      if (eventNodeName !== nodeName) {
+        continue;
+      }
+
+      const parameter = ParameterEventHandler.getParameterFromEvent(
+        event,
+        paramName,
+        nodeName
+      );
+
+      if (parameter) {
+        for (const handle of callbacks) {
+          try {
+            handle.callback(parameter);
+          } catch (err) {
+            debug(
+              'Error in parameter callback for %s on %s: %s',
+              paramName,
+              nodeName,
+              err.message
+            );
+          }
+        }
+      }
+    }
+
+    // Dispatch event-level callbacks
+    for (const handle of this.#eventCallbacks) {
+      try {
+        handle.callback(event);
+      } catch (err) {
+        debug('Error in parameter event callback: %s', err.message);
+      }
+    }
+  }
+
+  /**
+   * Create a map key from parameter name and node name.
+   * @private
+   */
+  #makeKey(paramName, nodeName) {
+    return `${paramName}\0${nodeName}`;
+  }
+
+  /**
+   * Parse a map key back into parameter name and node name.
+   * @private
+   */
+  #parseKey(key) {
+    const sep = key.indexOf('\0');
+    return {
+      paramName: key.substring(0, sep),
+      nodeName: key.substring(sep + 1),
+    };
+  }
+
+  /**
+   * Check if the handler has been destroyed and throw if so.
+   * @private
+   */
+  #checkNotDestroyed() {
+    if (this.#destroyed) {
+      throw new OperationError('ParameterEventHandler has been destroyed', {
+        entityType: 'parameter event handler',
+      });
+    }
+  }
+}
+
+module.exports = ParameterEventHandler;
+module.exports.ParameterCallbackHandle = ParameterCallbackHandle;
+module.exports.ParameterEventCallbackHandle = ParameterEventCallbackHandle;

--- a/lib/parameter_event_handler.js
+++ b/lib/parameter_event_handler.js
@@ -119,17 +119,14 @@ class ParameterEventHandler {
     this.#eventCallbacks = [];
     this.#destroyed = false;
 
-    const subscriptionArgs = [
+    const subscriptionOptions = options.qos ? { qos: options.qos } : undefined;
+
+    this.#subscription = node.createSubscription(
       PARAMETER_EVENT_MSG_TYPE,
       PARAMETER_EVENT_TOPIC,
-      (event) => this.#handleEvent(event),
-    ];
-
-    if (options.qos) {
-      subscriptionArgs.push(options.qos);
-    }
-
-    this.#subscription = node.createSubscription(...subscriptionArgs);
+      subscriptionOptions,
+      (event) => this.#handleEvent(event)
+    );
 
     debug('Created ParameterEventHandler on node=%s', node.name());
   }
@@ -173,12 +170,13 @@ class ParameterEventHandler {
     }
 
     const resolvedNodeName = normalizeNodeName(nodeName);
+    const resolvedParamName = parameterName.trim();
     const handle = new ParameterCallbackHandle(
-      parameterName,
+      resolvedParamName,
       resolvedNodeName,
       callback
     );
-    const key = this.#makeKey(parameterName, resolvedNodeName);
+    const key = this.#makeKey(resolvedParamName, resolvedNodeName);
 
     if (!this.#parameterCallbacks.has(key)) {
       this.#parameterCallbacks.set(key, []);
@@ -189,7 +187,7 @@ class ParameterEventHandler {
 
     debug(
       'Added parameter callback: param=%s node=%s',
-      parameterName,
+      resolvedParamName,
       resolvedNodeName
     );
 
@@ -390,29 +388,26 @@ class ParameterEventHandler {
   #handleEvent(event) {
     const eventNodeName = normalizeNodeName(event.node);
 
-    // Dispatch parameter-specific callbacks
-    for (const [key, callbacks] of this.#parameterCallbacks) {
-      const { paramName, nodeName } = this.#parseKey(key);
+    // Dispatch parameter-specific callbacks by iterating event params
+    // and doing direct Map lookups (O(event_params) instead of O(registered_callbacks))
+    const allParams = [
+      ...(event.new_parameters || []),
+      ...(event.changed_parameters || []),
+    ];
 
-      if (eventNodeName !== nodeName) {
-        continue;
-      }
+    for (const parameter of allParams) {
+      const key = this.#makeKey(parameter.name, eventNodeName);
+      const callbacks = this.#parameterCallbacks.get(key);
 
-      const parameter = ParameterEventHandler.getParameterFromEvent(
-        event,
-        paramName,
-        nodeName
-      );
-
-      if (parameter) {
+      if (callbacks) {
         for (const handle of callbacks) {
           try {
             handle.callback(parameter);
           } catch (err) {
             debug(
               'Error in parameter callback for %s on %s: %s',
-              paramName,
-              nodeName,
+              parameter.name,
+              eventNodeName,
               err.message
             );
           }
@@ -436,18 +431,6 @@ class ParameterEventHandler {
    */
   #makeKey(paramName, nodeName) {
     return `${paramName}\0${nodeName}`;
-  }
-
-  /**
-   * Parse a map key back into parameter name and node name.
-   * @private
-   */
-  #parseKey(key) {
-    const sep = key.indexOf('\0');
-    return {
-      paramName: key.substring(0, sep),
-      nodeName: key.substring(sep + 1),
-    };
   }
 
   /**

--- a/lib/parameter_event_handler.js
+++ b/lib/parameter_event_handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Wayne Parrott. All rights reserved.
+// Copyright (c) 2026, The Robot Web Tools Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/parameter_event_handler.js
+++ b/lib/parameter_event_handler.js
@@ -66,8 +66,12 @@ class ParameterEventCallbackHandle {
  * responds to parameter events from any node without needing service availability.
  *
  * Two types of callbacks are supported:
- * - **Parameter callbacks**: fired when a specific parameter on a specific node changes.
- * - **Event callbacks**: fired for every ParameterEvent message received.
+ * - **Parameter callbacks**: fired when a specific parameter on a specific node
+ *   is added or changed (new_parameters + changed_parameters).
+ *   Note: deleted parameters are not dispatched to parameter callbacks;
+ *   use event callbacks to observe deletions.
+ * - **Event callbacks**: fired for every ParameterEvent message received,
+ *   including deletions.
  *
  * @example
  * const handler = node.createParameterEventHandler();
@@ -114,12 +118,24 @@ class ParameterEventHandler {
       });
     }
 
+    if (
+      options !== undefined &&
+      options !== null &&
+      typeof options !== 'object'
+    ) {
+      throw new TypeValidationError('options', options, 'object or undefined', {
+        entityType: 'parameter event handler',
+      });
+    }
+
+    const opts = options || {};
+
     this.#node = node;
     this.#parameterCallbacks = new Map();
     this.#eventCallbacks = [];
     this.#destroyed = false;
 
-    const subscriptionOptions = options.qos ? { qos: options.qos } : undefined;
+    const subscriptionOptions = opts.qos ? { qos: opts.qos } : undefined;
 
     this.#subscription = node.createSubscription(
       PARAMETER_EVENT_MSG_TYPE,
@@ -348,6 +364,7 @@ class ParameterEventHandler {
    */
   static getParameterFromEvent(event, parameterName, nodeName) {
     const resolvedNodeName = normalizeNodeName(nodeName);
+    const resolvedParamName = (parameterName || '').trim();
 
     if (normalizeNodeName(event.node) !== resolvedNodeName) {
       return null;
@@ -359,7 +376,7 @@ class ParameterEventHandler {
     ];
 
     for (const param of allParams) {
-      if (param.name === parameterName) {
+      if (param.name === resolvedParamName) {
         return param;
       }
     }
@@ -400,7 +417,7 @@ class ParameterEventHandler {
       const callbacks = this.#parameterCallbacks.get(key);
 
       if (callbacks) {
-        for (const handle of callbacks) {
+        for (const handle of callbacks.slice()) {
           try {
             handle.callback(parameter);
           } catch (err) {
@@ -416,7 +433,7 @@ class ParameterEventHandler {
     }
 
     // Dispatch event-level callbacks
-    for (const handle of this.#eventCallbacks) {
+    for (const handle of this.#eventCallbacks.slice()) {
       try {
         handle.callback(event);
       } catch (err) {

--- a/lib/parameter_watcher.js
+++ b/lib/parameter_watcher.js
@@ -32,7 +32,6 @@ class ParameterWatcher extends EventEmitter {
   #node;
   #paramClient;
   #eventHandler;
-  #eventCallbackHandle;
   #watchedParams;
   #remoteNodeName;
   #destroyed;
@@ -85,7 +84,6 @@ class ParameterWatcher extends EventEmitter {
     // Cache the remote node name for error messages (in case paramClient is destroyed)
     this.#remoteNodeName = this.#paramClient.remoteNodeName;
     this.#eventHandler = null;
-    this.#eventCallbackHandle = null;
     this.#destroyed = false;
 
     debug(
@@ -138,8 +136,8 @@ class ParameterWatcher extends EventEmitter {
 
     if (!this.#eventHandler) {
       this.#eventHandler = new ParameterEventHandler(this.#node);
-      this.#eventCallbackHandle = this.#eventHandler.addParameterEventCallback(
-        (event) => this.#handleParameterEvent(event)
+      this.#eventHandler.addParameterEventCallback((event) =>
+        this.#handleParameterEvent(event)
       );
 
       debug('Subscribed to /parameter_events via ParameterEventHandler');
@@ -236,7 +234,6 @@ class ParameterWatcher extends EventEmitter {
         debug('Error destroying event handler: %s', error.message);
       }
       this.#eventHandler = null;
-      this.#eventCallbackHandle = null;
     }
 
     if (this.#paramClient) {

--- a/lib/parameter_watcher.js
+++ b/lib/parameter_watcher.js
@@ -17,6 +17,7 @@
 const EventEmitter = require('events');
 const { TypeValidationError, OperationError } = require('./errors');
 const { normalizeNodeName } = require('./utils');
+const ParameterEventHandler = require('./parameter_event_handler.js');
 const debug = require('debug')('rclnodejs:parameter_watcher');
 
 /**
@@ -30,7 +31,8 @@ const debug = require('debug')('rclnodejs:parameter_watcher');
 class ParameterWatcher extends EventEmitter {
   #node;
   #paramClient;
-  #subscription;
+  #eventHandler;
+  #eventCallbackHandle;
   #watchedParams;
   #remoteNodeName;
   #destroyed;
@@ -82,7 +84,8 @@ class ParameterWatcher extends EventEmitter {
     this.#paramClient = node.createParameterClient(remoteNodeName, options);
     // Cache the remote node name for error messages (in case paramClient is destroyed)
     this.#remoteNodeName = this.#paramClient.remoteNodeName;
-    this.#subscription = null;
+    this.#eventHandler = null;
+    this.#eventCallbackHandle = null;
     this.#destroyed = false;
 
     debug(
@@ -133,14 +136,13 @@ class ParameterWatcher extends EventEmitter {
       return false;
     }
 
-    if (!this.#subscription) {
-      this.#subscription = this.#node.createSubscription(
-        'rcl_interfaces/msg/ParameterEvent',
-        '/parameter_events',
+    if (!this.#eventHandler) {
+      this.#eventHandler = new ParameterEventHandler(this.#node);
+      this.#eventCallbackHandle = this.#eventHandler.addParameterEventCallback(
         (event) => this.#handleParameterEvent(event)
       );
 
-      debug('Subscribed to /parameter_events');
+      debug('Subscribed to /parameter_events via ParameterEventHandler');
     }
 
     return true;
@@ -227,13 +229,14 @@ class ParameterWatcher extends EventEmitter {
 
     debug('Destroying ParameterWatcher for node=%s', this.remoteNodeName);
 
-    if (this.#subscription) {
+    if (this.#eventHandler) {
       try {
-        this.#node.destroySubscription(this.#subscription);
+        this.#eventHandler.destroy();
       } catch (error) {
-        debug('Error destroying subscription: %s', error.message);
+        debug('Error destroying event handler: %s', error.message);
       }
-      this.#subscription = null;
+      this.#eventHandler = null;
+      this.#eventCallbackHandle = null;
     }
 
     if (this.#paramClient) {

--- a/test/test-parameter-event-handler.js
+++ b/test/test-parameter-event-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Wayne Parrott. All rights reserved.
+// Copyright (c) 2026, The Robot Web Tools Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/test-parameter-event-handler.js
+++ b/test/test-parameter-event-handler.js
@@ -1,0 +1,382 @@
+// Copyright (c) 2026 Wayne Parrott. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const rclnodejs = require('../index.js');
+
+describe('ParameterEventHandler tests', function () {
+  this.timeout(60 * 1000);
+
+  let targetNode;
+  let handlerNode;
+  let handler;
+
+  before(function () {
+    return rclnodejs.init();
+  });
+
+  after(function () {
+    rclnodejs.shutdown();
+  });
+
+  beforeEach(function () {
+    targetNode = rclnodejs.createNode('peh_target_node');
+    handlerNode = rclnodejs.createNode('peh_handler_node');
+
+    targetNode.declareParameter(
+      new rclnodejs.Parameter(
+        'test_int',
+        rclnodejs.ParameterType.PARAMETER_INTEGER,
+        BigInt(42)
+      )
+    );
+
+    targetNode.declareParameter(
+      new rclnodejs.Parameter(
+        'test_string',
+        rclnodejs.ParameterType.PARAMETER_STRING,
+        'hello'
+      )
+    );
+
+    rclnodejs.spin(targetNode);
+    rclnodejs.spin(handlerNode);
+  });
+
+  afterEach(function () {
+    if (handler && !handler.isDestroyed()) {
+      handler.destroy();
+    }
+    handler = null;
+    targetNode.destroy();
+    handlerNode.destroy();
+  });
+
+  describe('Constructor', function () {
+    it('should create a ParameterEventHandler via node method', function () {
+      handler = handlerNode.createParameterEventHandler();
+      assert.ok(handler);
+      assert.strictEqual(handler.isDestroyed(), false);
+    });
+
+    it('should create a ParameterEventHandler directly', function () {
+      handler = new rclnodejs.ParameterEventHandler(handlerNode);
+      assert.ok(handler);
+      assert.strictEqual(handler.isDestroyed(), false);
+    });
+
+    it('should throw for invalid node', function () {
+      assert.throws(() => {
+        new rclnodejs.ParameterEventHandler(null);
+      });
+      assert.throws(() => {
+        new rclnodejs.ParameterEventHandler({});
+      });
+    });
+  });
+
+  describe('addParameterCallback', function () {
+    it('should add a parameter callback and return a handle', function () {
+      handler = handlerNode.createParameterEventHandler();
+      const handle = handler.addParameterCallback(
+        'test_int',
+        '/peh_target_node',
+        () => {}
+      );
+      assert.ok(handle);
+      assert.strictEqual(handle.parameterName, 'test_int');
+    });
+
+    it('should throw for invalid arguments', function () {
+      handler = handlerNode.createParameterEventHandler();
+
+      assert.throws(() => {
+        handler.addParameterCallback('', '/node', () => {});
+      });
+      assert.throws(() => {
+        handler.addParameterCallback('param', '', () => {});
+      });
+      assert.throws(() => {
+        handler.addParameterCallback('param', '/node', 'not a function');
+      });
+    });
+
+    it('should receive callback when watched parameter changes', function (done) {
+      handler = handlerNode.createParameterEventHandler();
+
+      handler.addParameterCallback(
+        'test_int',
+        '/peh_target_node',
+        (parameter) => {
+          assert.strictEqual(parameter.name, 'test_int');
+          done();
+        }
+      );
+
+      // Wait briefly for subscription to be established, then change parameter
+      setTimeout(() => {
+        targetNode.setParameter(
+          new rclnodejs.Parameter(
+            'test_int',
+            rclnodejs.ParameterType.PARAMETER_INTEGER,
+            BigInt(99)
+          )
+        );
+      }, 500);
+    });
+
+    it('should not fire callback for unrelated parameters', function (done) {
+      handler = handlerNode.createParameterEventHandler();
+
+      let callbackFired = false;
+      handler.addParameterCallback('test_int', '/peh_target_node', () => {
+        callbackFired = true;
+      });
+
+      // Change a different parameter
+      setTimeout(() => {
+        targetNode.setParameter(
+          new rclnodejs.Parameter(
+            'test_string',
+            rclnodejs.ParameterType.PARAMETER_STRING,
+            'world'
+          )
+        );
+      }, 500);
+
+      // Verify callback was NOT fired
+      setTimeout(() => {
+        assert.strictEqual(callbackFired, false);
+        done();
+      }, 2000);
+    });
+
+    it('should not fire callback for unrelated nodes', function (done) {
+      handler = handlerNode.createParameterEventHandler();
+
+      let callbackFired = false;
+      handler.addParameterCallback('test_int', '/some_other_node', () => {
+        callbackFired = true;
+      });
+
+      setTimeout(() => {
+        targetNode.setParameter(
+          new rclnodejs.Parameter(
+            'test_int',
+            rclnodejs.ParameterType.PARAMETER_INTEGER,
+            BigInt(99)
+          )
+        );
+      }, 500);
+
+      setTimeout(() => {
+        assert.strictEqual(callbackFired, false);
+        done();
+      }, 2000);
+    });
+  });
+
+  describe('removeParameterCallback', function () {
+    it('should remove a callback', function () {
+      handler = handlerNode.createParameterEventHandler();
+      const handle = handler.addParameterCallback(
+        'test_int',
+        '/peh_target_node',
+        () => {}
+      );
+      handler.removeParameterCallback(handle);
+    });
+
+    it('should throw when removing non-existent callback', function () {
+      handler = handlerNode.createParameterEventHandler();
+      const handle = handler.addParameterCallback(
+        'test_int',
+        '/peh_target_node',
+        () => {}
+      );
+      handler.removeParameterCallback(handle);
+
+      assert.throws(() => {
+        handler.removeParameterCallback(handle);
+      });
+    });
+
+    it('should not fire removed callback', function (done) {
+      handler = handlerNode.createParameterEventHandler();
+
+      let callbackFired = false;
+      const handle = handler.addParameterCallback(
+        'test_int',
+        '/peh_target_node',
+        () => {
+          callbackFired = true;
+        }
+      );
+
+      handler.removeParameterCallback(handle);
+
+      setTimeout(() => {
+        targetNode.setParameter(
+          new rclnodejs.Parameter(
+            'test_int',
+            rclnodejs.ParameterType.PARAMETER_INTEGER,
+            BigInt(99)
+          )
+        );
+      }, 500);
+
+      setTimeout(() => {
+        assert.strictEqual(callbackFired, false);
+        done();
+      }, 2000);
+    });
+  });
+
+  describe('addParameterEventCallback', function () {
+    it('should add an event callback and return a handle', function () {
+      handler = handlerNode.createParameterEventHandler();
+      const handle = handler.addParameterEventCallback(() => {});
+      assert.ok(handle);
+    });
+
+    it('should throw for non-function callback', function () {
+      handler = handlerNode.createParameterEventHandler();
+      assert.throws(() => {
+        handler.addParameterEventCallback('not a function');
+      });
+    });
+
+    it('should receive all parameter events', function (done) {
+      handler = handlerNode.createParameterEventHandler();
+
+      handler.addParameterEventCallback((event) => {
+        assert.ok(event.node);
+        done();
+      });
+
+      setTimeout(() => {
+        targetNode.setParameter(
+          new rclnodejs.Parameter(
+            'test_int',
+            rclnodejs.ParameterType.PARAMETER_INTEGER,
+            BigInt(99)
+          )
+        );
+      }, 500);
+    });
+  });
+
+  describe('removeParameterEventCallback', function () {
+    it('should remove an event callback', function () {
+      handler = handlerNode.createParameterEventHandler();
+      const handle = handler.addParameterEventCallback(() => {});
+      handler.removeParameterEventCallback(handle);
+    });
+
+    it('should throw when removing non-existent event callback', function () {
+      handler = handlerNode.createParameterEventHandler();
+      const handle = handler.addParameterEventCallback(() => {});
+      handler.removeParameterEventCallback(handle);
+
+      assert.throws(() => {
+        handler.removeParameterEventCallback(handle);
+      });
+    });
+  });
+
+  describe('static methods', function () {
+    it('getParameterFromEvent should find matching parameter', function () {
+      const event = {
+        node: '/peh_target_node',
+        new_parameters: [{ name: 'param_a', value: {} }],
+        changed_parameters: [{ name: 'param_b', value: {} }],
+        deleted_parameters: [],
+      };
+
+      const found = rclnodejs.ParameterEventHandler.getParameterFromEvent(
+        event,
+        'param_b',
+        '/peh_target_node'
+      );
+      assert.ok(found);
+      assert.strictEqual(found.name, 'param_b');
+    });
+
+    it('getParameterFromEvent should return null for non-matching node', function () {
+      const event = {
+        node: '/other_node',
+        new_parameters: [{ name: 'param_a', value: {} }],
+        changed_parameters: [],
+        deleted_parameters: [],
+      };
+
+      const found = rclnodejs.ParameterEventHandler.getParameterFromEvent(
+        event,
+        'param_a',
+        '/peh_target_node'
+      );
+      assert.strictEqual(found, null);
+    });
+
+    it('getParametersFromEvent should return new + changed', function () {
+      const event = {
+        node: '/node',
+        new_parameters: [{ name: 'a' }],
+        changed_parameters: [{ name: 'b' }, { name: 'c' }],
+        deleted_parameters: [{ name: 'd' }],
+      };
+
+      const params =
+        rclnodejs.ParameterEventHandler.getParametersFromEvent(event);
+      assert.strictEqual(params.length, 3);
+    });
+  });
+
+  describe('destroy', function () {
+    it('should destroy cleanly', function () {
+      handler = handlerNode.createParameterEventHandler();
+      handler.destroy();
+      assert.strictEqual(handler.isDestroyed(), true);
+    });
+
+    it('should be idempotent', function () {
+      handler = handlerNode.createParameterEventHandler();
+      handler.destroy();
+      handler.destroy(); // should not throw
+      assert.strictEqual(handler.isDestroyed(), true);
+    });
+
+    it('should throw when adding callback after destroy', function () {
+      handler = handlerNode.createParameterEventHandler();
+      handler.destroy();
+
+      assert.throws(() => {
+        handler.addParameterCallback('param', '/node', () => {});
+      });
+
+      assert.throws(() => {
+        handler.addParameterEventCallback(() => {});
+      });
+    });
+
+    it('should be destroyed via node method', function () {
+      handler = handlerNode.createParameterEventHandler();
+      handlerNode.destroyParameterEventHandler(handler);
+      assert.strictEqual(handler.isDestroyed(), true);
+      handler = null; // prevent afterEach from double-destroying
+    });
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,6 +2,7 @@
 /// <reference path="./clock_event.d.ts" />
 /// <reference path="./clock_change.d.ts" />
 /// <reference path="./message_validation.d.ts" />
+/// <reference path="./parameter_event_handler.d.ts" />
 
 import { ChildProcess } from 'child_process';
 

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -512,6 +512,27 @@ declare module 'rclnodejs' {
     destroyParameterWatcher(watcher: ParameterWatcher): void;
 
     /**
+     * Create a ParameterEventHandler that monitors parameter changes on any node.
+     *
+     * Unlike ParameterWatcher which watches specific parameters on a single
+     * remote node, ParameterEventHandler can register callbacks for parameters
+     * on any node in the ROS 2 graph by subscribing to /parameter_events.
+     *
+     * @param options - Options for the handler.
+     * @returns An instance of ParameterEventHandler.
+     */
+    createParameterEventHandler(
+      options?: ParameterEventHandlerOptions
+    ): ParameterEventHandler;
+
+    /**
+     * Destroy a ParameterEventHandler.
+     *
+     * @param handler - ParameterEventHandler to be destroyed.
+     */
+    destroyParameterEventHandler(handler: ParameterEventHandler): void;
+
+    /**
      * Destroy a Timer.
      *
      * @param timer - Timer to be destroyed.

--- a/types/parameter_event_handler.d.ts
+++ b/types/parameter_event_handler.d.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Wayne Parrott. All rights reserved.
+// Copyright (c) 2026, The Robot Web Tools Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/parameter_event_handler.d.ts
+++ b/types/parameter_event_handler.d.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Wayne Parrott. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+declare module 'rclnodejs' {
+  /**
+   * Options for ParameterEventHandler constructor.
+   */
+  export interface ParameterEventHandlerOptions {
+    /**
+     * QoS profile for the parameter_events subscription.
+     */
+    qos?: QoS;
+  }
+
+  /**
+   * Opaque handle returned when adding a parameter callback.
+   * Used to remove the callback later via removeParameterCallback().
+   */
+  class ParameterCallbackHandle {
+    readonly parameterName: string;
+    readonly nodeName: string;
+    readonly callback: (parameter: any) => void;
+  }
+
+  /**
+   * Opaque handle returned when adding a parameter event callback.
+   * Used to remove the callback later via removeParameterEventCallback().
+   */
+  class ParameterEventCallbackHandle {
+    readonly callback: (event: any) => void;
+  }
+
+  /**
+   * ParameterEventHandler - Monitors and responds to parameter changes
+   * on any node in the ROS 2 graph.
+   *
+   * Subscribes to `/parameter_events` and dispatches callbacks when
+   * parameters are added, changed, or deleted on any node.
+   *
+   * Two types of callbacks:
+   * - **Parameter callbacks**: for a specific parameter on a specific node
+   * - **Event callbacks**: for every ParameterEvent message received
+   *
+   * @example
+   * ```typescript
+   * const handler = node.createParameterEventHandler();
+   *
+   * const handle = handler.addParameterCallback(
+   *   'my_param', '/my_node',
+   *   (param) => console.log(`Changed: ${param.name}`)
+   * );
+   *
+   * handler.removeParameterCallback(handle);
+   * handler.destroy();
+   * ```
+   */
+  class ParameterEventHandler {
+    /**
+     * Add a callback for a specific parameter on a specific node.
+     *
+     * @param parameterName - Name of the parameter to monitor.
+     * @param nodeName - Fully qualified name of the node (e.g., '/my_node').
+     * @param callback - Called with the parameter message when it changes.
+     * @returns A handle for removing this callback later.
+     */
+    addParameterCallback(
+      parameterName: string,
+      nodeName: string,
+      callback: (parameter: any) => void
+    ): ParameterCallbackHandle;
+
+    /**
+     * Remove a previously added parameter callback.
+     *
+     * @param handle - The handle returned by addParameterCallback.
+     */
+    removeParameterCallback(handle: ParameterCallbackHandle): void;
+
+    /**
+     * Add a callback that is invoked for every parameter event.
+     *
+     * @param callback - Called with the full ParameterEvent message.
+     * @returns A handle for removing this callback later.
+     */
+    addParameterEventCallback(
+      callback: (event: any) => void
+    ): ParameterEventCallbackHandle;
+
+    /**
+     * Remove a previously added parameter event callback.
+     *
+     * @param handle - The handle returned by addParameterEventCallback.
+     */
+    removeParameterEventCallback(handle: ParameterEventCallbackHandle): void;
+
+    /**
+     * Check if the handler has been destroyed.
+     */
+    isDestroyed(): boolean;
+
+    /**
+     * Destroy the handler and clean up resources.
+     */
+    destroy(): void;
+
+    /**
+     * Get a specific parameter from a ParameterEvent message.
+     *
+     * @param event - A ParameterEvent message.
+     * @param parameterName - The parameter name to look for.
+     * @param nodeName - The node name to match.
+     * @returns The matching parameter message, or null.
+     */
+    static getParameterFromEvent(
+      event: any,
+      parameterName: string,
+      nodeName: string
+    ): any | null;
+
+    /**
+     * Get all parameters from a ParameterEvent message (new + changed).
+     *
+     * @param event - A ParameterEvent message.
+     * @returns Array of parameter messages.
+     */
+    static getParametersFromEvent(event: any): any[];
+  }
+}


### PR DESCRIPTION
Adds `ParameterEventHandler`, a new class that monitors parameter changes on any node in the ROS 2 graph by subscribing to the `/parameter_events` topic. This is the rclnodejs equivalent of rclpy's `ParameterEventHandler` and supports two callback types: per-parameter callbacks (filtered by parameter name and node name) and event-level callbacks (for every `ParameterEvent` message). Refactors `ParameterWatcher` to use `ParameterEventHandler` internally, eliminating its direct `/parameter_events` subscription while preserving full API compatibility.

**New files:**

- `lib/parameter_event_handler.js` — Core implementation with `addParameterCallback()`, `removeParameterCallback()`, `addParameterEventCallback()`, `removeParameterEventCallback()`, `destroy()`, and static helpers `getParameterFromEvent()` / `getParametersFromEvent()`. Uses opaque handle objects for add/remove symmetry matching rclpy. Callbacks dispatched in FILO order. QoS option correctly forwarded via options object to `createSubscription()`. Parameter names trimmed before storage to prevent whitespace mismatch. Dispatch loop inverted to O(event_params) via direct Map lookups instead of O(registered_callbacks).
- `types/parameter_event_handler.d.ts` — Full TypeScript declarations for `ParameterEventHandler`, `ParameterCallbackHandle`, `ParameterEventCallbackHandle`, and `ParameterEventHandlerOptions`.
- `test/test-parameter-event-handler.js` — 23 tests covering constructor validation, parameter callbacks (add/remove/filtering by node and param name), event callbacks, static helpers, lifecycle/destroy, and Node convenience method integration.

**Modified files:**

- `lib/node.js` — Added `createParameterEventHandler()` and `destroyParameterEventHandler()` convenience methods with lifecycle tracking via `_parameterEventHandlers` array. Auto-cleanup on node destruction.
- `index.js` — Exported `ParameterEventHandler` class.
- `types/index.d.ts` — Added `/// <reference path>` directive for the new type declarations.
- `types/node.d.ts` — Added TypeScript declarations for `createParameterEventHandler()` and `destroyParameterEventHandler()`.
- `lib/parameter_watcher.js` — Refactored to use `ParameterEventHandler` internally instead of creating its own `/parameter_events` subscription directly. Replaced `#subscription` field with `#eventHandler`. Removed unused `#eventCallbackHandle` private field. Zero public API changes; all 40 existing tests pass unmodified.

Fix: #1437 