### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ npm install rclnodejs
 source /opt/ros/<distro>/setup.bash
 ```
 
-2. Install the package.
+2. Install the repository dependencies.
 
 ```bash
-npm i rclnodejs
+npm install
 ```
 
-3. Run a publisher example.
+3. Run a publisher example from this checkout.
 
 ```bash
 node example/topics/publisher/publisher-example.js

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | :----------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | Rolling<br>Kilted<br>Jazzy<br>Humble | [![Linux](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-x64-push-test.yml/badge.svg?branch=develop)](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-x64-push-test.yml?query=branch%3Adevelop)<br>[![Linux](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-arm64-push-test.yml/badge.svg?branch=develop)](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-arm64-push-test.yml?query=branch%3Adevelop)<br>[![Windows](https://github.com/RobotWebTools/rclnodejs/actions/workflows/windows-push-test.yml/badge.svg?branch=develop)](https://github.com/RobotWebTools/rclnodejs/actions/workflows/windows-push-test.yml?query=branch%3Adevelop)<br>[![ASan](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-x64-asan-test.yml/badge.svg?branch=develop)](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-x64-asan-test.yml?query=branch%3Adevelop) |
 
-> **Note:** rclnodejs development and maintenance is limited to the ROS 2 LTS releases and the Rolling development branch
+> **Note:** Supported ROS 2 distributions include Humble, Jazzy, Kilted, and Rolling.
 
 **rclnodejs** is a Node.js client library for [ROS 2](https://www.ros.org/) that provides comprehensive JavaScript and TypeScript APIs for developing ROS 2 solutions.
 
@@ -22,19 +22,14 @@ rclnodejs.init().then(() => {
 
 ## Documentation
 
-- [Installation](#installation)
-- [rclnodejs-cli](#rclnodejs-cli)
-- [API Documentation](#api-documentation)
-- [Tutorials](./tutorials/)
-- [Electron-based Visualization](#electron-based-visualization)
-- [Using TypeScript](#using-rclnodejs-with-typescript)
-- [Observable Subscriptions](#observable-subscriptions)
-- [ROS2 Interface Message Generation](#ros2-interface-message-generation)
-- [Performance Benchmarks](#performance-benchmarks)
-- [Efficient Usage Tips](./docs/EFFICIENCY.md)
-- [FAQ and Known Issues](./docs/FAQ.md)
-- [Building from Scratch](./docs/BUILDING.md)
-- [Contributing](./docs/CONTRIBUTING.md)
+- Get started:
+  [Installation](#installation), [Quick Start](#quick-start), [Tutorials](./tutorials/)
+- Reference:
+  [API Documentation](#api-documentation), [Using TypeScript](#using-rclnodejs-with-typescript), [ROS2 Interface Message Generation](#ros2-interface-message-generation)
+- Features and examples:
+  [rclnodejs-cli](#rclnodejs-cli), [Electron-based Visualization](#electron-based-visualization), [Observable Subscriptions](#observable-subscriptions), [Performance Benchmarks](#performance-benchmarks)
+- Project docs:
+  [Efficient Usage Tips](./docs/EFFICIENCY.md), [FAQ and Known Issues](./docs/FAQ.md), [Building from Scratch](./docs/BUILDING.md), [Contributing](./docs/CONTRIBUTING.md)
 
 ## Installation
 
@@ -66,6 +61,8 @@ rclnodejs ships with prebuilt native binaries for common Linux configurations si
 - **Architectures:** x64, arm64
 - **Node.js:** >= 16.20.2 (N-API compatible)
 
+Installations outside this prebuilt matrix automatically fall back to building from source.
+
 **Force Building from Source:**
 
 If you need to build from source even when a prebuilt binary is available, set the environment variable:
@@ -75,21 +72,33 @@ export RCLNODEJS_FORCE_BUILD=1
 npm install rclnodejs
 ```
 
-## rclnodejs-cli
+## Quick Start
 
-[rclnodejs-cli](https://github.com/RobotWebTools/rclnodejs-cli/) is a companion project we recently launched to provide a commandline interface to a set of developer tools for working with this `rclnodejs`. You may find `rclnodejs-cli` particularly useful if you plan to create ROS 2 node(s) and launch files for working with multiple node orchestrations.
+1. Source your ROS 2 environment.
 
 ```bash
-Usage: rclnodejs [command] [options]
-
-Options:
-  -h, --help                               display help for command
-
-Commands:
-  create-package [options] <package-name>  Create a ROS2 package for Nodejs development.
-  generate-ros-messages                    Generate JavaScript code from ROS2 IDL interfaces
-  help [command]                           display help for command
+source /opt/ros/<distro>/setup.bash
 ```
+
+2. Install the package.
+
+```bash
+npm i rclnodejs
+```
+
+3. Run a publisher example.
+
+```bash
+node example/topics/publisher/publisher-example.js
+```
+
+You should see messages being published once per second. Explore more runnable examples in [example/](https://github.com/RobotWebTools/rclnodejs/tree/develop/example) and step-by-step guides in [tutorials/](./tutorials/).
+
+## rclnodejs-cli
+
+[rclnodejs-cli](https://github.com/RobotWebTools/rclnodejs-cli/) is a separate companion project that provides command-line tooling for working with rclnodejs-based ROS 2 applications. It is particularly useful for creating ROS 2 Node.js packages and working with launch files for multi-node orchestration.
+
+See the rclnodejs-cli repository for installation instructions and the current command set.
 
 ## API Documentation
 
@@ -108,7 +117,7 @@ Explore more examples in [electron_demo](https://github.com/RobotWebTools/rclnod
 
 ## Using rclnodejs with TypeScript
 
-TypeScript declaration files are included in the `types/` folder. Configure your `tsconfig.json`:
+TypeScript declaration files are included in the package and exposed through the `types` entry in `package.json`. In most projects, configuring your `tsconfig.json` is sufficient:
 
 ```jsonc
 {
@@ -177,7 +186,7 @@ npx generate-ros-messages
 
 Generated files are located at `<yourproject>/node_modules/rclnodejs/generated/`.
 
-> **Note:** This step is not needed for rclnodejs > 1.5.0
+> **Note:** rclnodejs already generates bundled interfaces during installation. Rerun this command only after adding new ROS packages to your environment.
 
 ### IDL Message Generation
 
@@ -193,13 +202,13 @@ npm run generate-messages-idl
 
 Benchmark results for 1000 iterations with 1024KB messages (Ubuntu 24.04.3 WSL2, i7-1185G7):
 
+These numbers are workload- and environment-specific. See [benchmark/README.md](./benchmark/README.md) for the full setup and methodology.
+
 | Library                 | Topic (ms) | Service (ms) |
 | ----------------------- | ---------- | ------------ |
 | **rclcpp (C++)**        | 168        | 627          |
 | **rclnodejs (Node.js)** | 744        | 927          |
 | **rclpy (Python)**      | 1,618      | 15,380       |
-
-See [benchmark/README.md](benchmark/README.md) for details.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ npx generate-ros-messages
 
 Generated files are located at `<yourproject>/node_modules/rclnodejs/generated/`.
 
-> **Note:** rclnodejs already generates bundled interfaces during installation. Rerun this command only after adding new ROS packages to your environment.
+> **Note:** This step is not needed for `rclnodejs > 1.5.0` because bundled interfaces are generated during installation. Rerun this command only after adding new ROS packages to your environment.
 
 ### IDL Message Generation
 

--- a/scripts/npmjs-readme.md
+++ b/scripts/npmjs-readme.md
@@ -59,7 +59,7 @@ npm install rclnodejs
 
 ## Message Generation
 
-rclnodejs generates JavaScript message interfaces and TypeScript declarations during installation. If you install additional ROS packages later, rerun:
+rclnodejs generates JavaScript message interfaces and TypeScript declarations during installation for `rclnodejs > 1.5.0`. If you install additional ROS packages later, rerun:
 
 ```bash
 npx generate-ros-messages

--- a/scripts/npmjs-readme.md
+++ b/scripts/npmjs-readme.md
@@ -1,18 +1,16 @@
-# rclnodejs [![Linux](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-x64-push-test.yml/badge.svg?branch=develop)](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-x64-push-test.yml?query=branch%3Adevelop)[![Linux](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-arm64-push-test.yml/badge.svg?branch=develop)](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-arm64-push-test.yml?query=branch%3Adevelop)
+# rclnodejs
 
-`rclnodejs` is a Node.js client for the Robot Operating System (ROS 2). It provides a simple and easy JavaScript API for ROS 2 programming. TypeScript declarations are included to support use of rclnodejs in TypeScript projects.
+`rclnodejs` is a Node.js client library for ROS 2 that provides JavaScript and TypeScript APIs for building ROS 2 applications.
 
-\* rclnodejs development and maintenance is limited to all active ROS 2 LTS releases and the Rolling development branch
+Supported ROS 2 distributions include Humble, Jazzy, Kilted, and Rolling.
 
-Here's an example for how to create a ROS 2 node that publishes a string message in a few lines of JavaScript.
-
-```JavaScript
+```javascript
 const rclnodejs = require('rclnodejs');
 rclnodejs.init().then(() => {
-  const node = rclnodejs.createNode('publisher_example_node');
+  const node = new rclnodejs.Node('publisher_example_node');
   const publisher = node.createPublisher('std_msgs/msg/String', 'topic');
   publisher.publish(`Hello ROS 2 from rclnodejs`);
-  rclnodejs.spin(node);
+  node.spin();
 });
 ```
 
@@ -29,11 +27,11 @@ rclnodejs.init().then(() => {
 npm i rclnodejs
 ```
 
-- **Note:** to install rclnodejs from GitHub: add `"rclnodejs":"RobotWebTools/rclnodejs#<branch>"` to your `package.json` dependency section.
+- **Note:** To install rclnodejs from GitHub, add `"rclnodejs":"RobotWebTools/rclnodejs#<branch>"` to your `package.json` dependencies.
 
 ### Prebuilt Binaries
 
-rclnodejs ships with prebuilt native binaries for common Linux configurations since `v1.5.2`, eliminating the need for compilation during installation. This significantly speeds up installation and reduces dependencies.
+rclnodejs ships with prebuilt native binaries for common Linux configurations since `v1.5.2`, eliminating the need for compilation during installation.
 
 **Supported Platforms:**
 
@@ -42,26 +40,36 @@ rclnodejs ships with prebuilt native binaries for common Linux configurations si
 - **Architectures:** x64, arm64
 - **Node.js:** >= 16.20.2 (N-API compatible)
 
-**Force Building from Source:**
+Installations outside this prebuilt matrix automatically fall back to building from source.
 
-If you need to build from source even when a prebuilt binary is available, set the environment variable:
+**Force Building from Source:**
 
 ```bash
 export RCLNODEJS_FORCE_BUILD=1
 npm install rclnodejs
 ```
 
-## Documentation
+## Documentation and Examples
 
-API [documentation](https://robotwebtools.github.io/rclnodejs/docs/index.html) is available online.
+- API documentation: [robotwebtools.github.io/rclnodejs/docs](https://robotwebtools.github.io/rclnodejs/docs/index.html)
+- JavaScript examples: [example/](https://github.com/RobotWebTools/rclnodejs/tree/develop/example)
+- TypeScript demos: [ts_demo/](https://github.com/RobotWebTools/rclnodejs/tree/develop/ts_demo)
+- Electron demos: [electron_demo/](https://github.com/RobotWebTools/rclnodejs/tree/develop/electron_demo)
+- Companion CLI: [rclnodejs-cli](https://github.com/RobotWebTools/rclnodejs-cli/)
 
-## JavaScript Examples
+## Message Generation
 
-Try the [examples](https://github.com/RobotWebTools/rclnodejs/tree/develop/example) to get started.
+rclnodejs generates JavaScript message interfaces and TypeScript declarations during installation. If you install additional ROS packages later, rerun:
+
+```bash
+npx generate-ros-messages
+```
+
+Generated files are written to `<your-project>/node_modules/rclnodejs/generated/`.
 
 ## Using rclnodejs with TypeScript
 
-TypeScript declaration files are included in the `types/` folder. Configure your `tsconfig.json`:
+TypeScript declaration files are included in the package. In most projects, configuring your `tsconfig.json` is sufficient:
 
 ```jsonc
 {
@@ -73,32 +81,16 @@ TypeScript declaration files are included in the `types/` folder. Configure your
 }
 ```
 
-TypeScript example:
-
 ```typescript
 import * as rclnodejs from 'rclnodejs';
+
 rclnodejs.init().then(() => {
-  const node = rclnodejs.createNode('publisher_example_node');
+  const node = new rclnodejs.Node('publisher_example_node');
   const publisher = node.createPublisher('std_msgs/msg/String', 'topic');
   publisher.publish(`Hello ROS 2 from rclnodejs`);
-  rclnodejs.spin(node);
+  node.spin();
 });
 ```
-
-See [TypeScript demos](https://github.com/RobotWebTools/rclnodejs/tree/develop/ts_demo) for more examples.
-
-**Note** that the interface.d.ts file is updated each time the generate_messages.js script is run.
-
-## Electron-based Visualization
-
-Create rich, interactive desktop applications using Electron and web technologies like Three.js. Build 3D visualizations, monitoring dashboards, and control interfaces that run on Windows, macOS, and Linux.
-
-|                                                  Demo                                                   |                                                              Description                                                              |                                                           Screenshot                                                            |
-| :-----------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------: |
-|  **🐢 [turtle_tf2](https://github.com/RobotWebTools/rclnodejs/tree/develop/electron_demo/turtle_tf2)**  |  Real-time coordinate frame visualization with turtle control. Features TF2 transforms, keyboard control, and dynamic frame updates.  |  ![turtle_tf2](https://github.com/RobotWebTools/rclnodejs/blob/develop/electron_demo/turtle_tf2/turtle-tf2-demo.png?raw=true)   |
-| **🦾 [manipulator](https://github.com/RobotWebTools/rclnodejs/tree/develop/electron_demo/manipulator)** | Interactive two-joint robotic arm simulation. Features 3D joint visualization, manual/automatic control, and visual movement markers. | ![manipulator](https://github.com/RobotWebTools/rclnodejs/blob/develop/electron_demo/manipulator/manipulator-demo.png?raw=true) |
-
-Explore more examples in [electron_demo](https://github.com/RobotWebTools/rclnodejs/tree/develop/electron_demo).
 
 ## License
 


### PR DESCRIPTION
Updates the project’s README content (repo README and npm package README) to reflect current supported ROS 2 distros, modernized API usage, and clearer install/docs guidance.

**Changes:**
- Refresh README messaging (supported ROS distros, reorganized documentation links, added Quick Start).
- Update README code snippets to use OO-style APIs (`new rclnodejs.Node()` + `node.spin()`).
- Improve installation/prebuilt-binary notes and clarify message generation workflow.

### Reviewed changes

Copilot reviewed 2 out of 2 changed files in this pull request and generated 2 comments.

| File | Description |
| ---- | ----------- |
| scripts/npmjs-readme.md | Updates the npm-published README content: modernizes example code, adds docs/examples links, and documents message generation and prebuilt-binary fallback behavior. |
| README.md | Updates the repo README: supported distro note, reorganized documentation section, adds Quick Start, clarifies TypeScript typing exposure, and adds benchmark methodology disclaimer. |

Fix: #1448 