### PR TITLE
Add support check for content filter feature in subscription

### DIFF
--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -40,6 +40,7 @@ jobs:
           # Rolling Ridley (No End-Of-Life)
           - docker_image: ubuntu:noble
             ros_distribution: rolling
+            ros_tar_url: "https://github.com/ros2/ros2/releases/download/release-rolling-nightlies/ros2-rolling-nightly-linux-amd64.tar.bz2"
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
       uses: actions/setup-node@v6
@@ -48,12 +49,23 @@ jobs:
         architecture: ${{ matrix.architecture }}
 
     - name: Setup ROS2
+      if: ${{ !matrix.ros_tar_url }}
       uses: ros-tooling/setup-ros@v0.7
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
-        use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
+
+    - name: Install ROS2 Rolling Nightly
+      if: ${{ matrix.ros_tar_url }}
+      run: |
+        apt-get update
+        apt-get install -y build-essential cmake curl tar bzip2 python3
+        curl -sL "${{ matrix.ros_tar_url }}" -o /tmp/ros2-nightly.tar.bz2
+        mkdir -p /opt/ros2_nightly
+        tar xjf /tmp/ros2-nightly.tar.bz2 -C /opt/ros2_nightly
+        rm /tmp/ros2-nightly.tar.bz2
 
     - name: Install test-msgs and mrpt_msgs on Linux
+      if: ${{ !matrix.ros_tar_url }}
       run: |
         sudo apt install ros-${{ matrix.ros_distribution }}-test-msgs ros-${{ matrix.ros_distribution }}-mrpt-msgs
         # Adjust dependencies based on Ubuntu version
@@ -65,7 +77,15 @@ jobs:
 
     - uses: actions/checkout@v6
 
+    - name: Build rclnodejs (nightly)
+      if: ${{ matrix.ros_tar_url }}
+      run: |
+        uname -a
+        source /opt/ros2_nightly/ros2-linux/setup.bash
+        npm i
+
     - name: Build and test rclnodejs
+      if: ${{ !matrix.ros_tar_url }}
       run: |
         uname -a
         source /opt/ros/${{ matrix.ros_distribution }}/setup.bash
@@ -75,7 +95,7 @@ jobs:
         npm run clean
 
     - name: Test with IDL ROS messages against rolling
-      if: ${{ matrix.ros_distribution == 'rolling' }}
+      if: ${{ !matrix.ros_tar_url && matrix.ros_distribution == 'rolling' }}
       run: |
         source /opt/ros/${{ matrix.ros_distribution }}/setup.bash
         npm i
@@ -83,7 +103,7 @@ jobs:
         npm run clean
 
     - name: Coveralls
-      if: ${{ matrix.ros_distribution == 'rolling' && matrix['node-version'] == '24.X' }}
+      if: ${{ !matrix.ros_tar_url && matrix.ros_distribution == 'rolling' && matrix['node-version'] == '24.X' }}
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -70,16 +70,16 @@ jobs:
         apt-get update
         apt-get install -y build-essential cmake tar bzip2 python3 python3-rosdep python3-colcon-common-extensions
 
-        # Download and extract nightly binary
-        mkdir -p /opt/ros2_rolling
+        # Download and extract nightly binary into /opt/ros/rolling/
         curl -sL "${{ matrix.ros_tar_url }}" -o /tmp/ros2-nightly.tar.bz2
-        tar xf /tmp/ros2-nightly.tar.bz2 -C /opt/ros2_rolling
+        mkdir -p /opt/ros/rolling
+        tar xf /tmp/ros2-nightly.tar.bz2 --strip-components=1 -C /opt/ros/rolling
         rm /tmp/ros2-nightly.tar.bz2
 
         # Install runtime dependencies using rosdep
         rosdep init || true
         rosdep update
-        rosdep install --from-paths /opt/ros2_rolling/ros2-linux/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 urdfdom_headers"
+        rosdep install --from-paths /opt/ros/rolling/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 urdfdom_headers"
 
     - name: Install test-msgs and mrpt_msgs on Linux
       run: |
@@ -98,7 +98,6 @@ jobs:
       run: |
         uname -a
         source /opt/ros/rolling/setup.bash
-        source /opt/ros2_rolling/ros2-linux/local_setup.bash
         npm i
         npm run lint
         npm test
@@ -118,7 +117,6 @@ jobs:
       if: ${{ matrix.ros_distribution == 'rolling' }}
       run: |
         source /opt/ros/rolling/setup.bash
-        source /opt/ros2_rolling/ros2-linux/local_setup.bash
         npm i
         npm run test-idl
         npm run clean

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -58,7 +58,8 @@ jobs:
       if: ${{ matrix.ros_distribution == 'rolling' }}
       run: |
         apt-get update
-        apt-get install -y build-essential cmake curl tar bzip2 python3 python3-rosdep software-properties-common
+        apt-get install -y build-essential cmake curl tar bzip2 python3 python3-pip software-properties-common
+        pip3 install --break-system-packages rosdep
 
         # Download and extract nightly binary (per https://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Install-Binary.html)
         mkdir -p /opt/ros2_rolling

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -66,22 +66,24 @@ jobs:
         curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
         dpkg -i /tmp/ros2-apt-source.deb
 
-        # Install prerequisites
+        # Install prerequisites and apt packages BEFORE nightly tarball
         apt-get update
         apt-get install -y build-essential cmake tar bzip2 python3 python3-rosdep python3-colcon-common-extensions
+        apt-get install -y ros-rolling-test-msgs ros-rolling-mrpt-msgs
 
-        # Download and extract nightly binary into /opt/ros/rolling/
+        # Extract nightly binary AFTER apt packages so nightly's newer libs overwrite apt's older ones
         curl -sL "${{ matrix.ros_tar_url }}" -o /tmp/ros2-nightly.tar.bz2
         mkdir -p /opt/ros/rolling
         tar xf /tmp/ros2-nightly.tar.bz2 --strip-components=1 -C /opt/ros/rolling
         rm /tmp/ros2-nightly.tar.bz2
 
-        # Install runtime dependencies using rosdep
+        # Install any remaining runtime dependencies using rosdep
         rosdep init || true
         rosdep update
         rosdep install --from-paths /opt/ros/rolling/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 urdfdom_headers"
 
     - name: Install test-msgs and mrpt_msgs on Linux
+      if: ${{ matrix.ros_distribution != 'rolling' }}
       run: |
         sudo apt install -y ros-${{ matrix.ros_distribution }}-test-msgs ros-${{ matrix.ros_distribution }}-mrpt-msgs
         # Adjust dependencies based on Ubuntu version

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -49,23 +49,37 @@ jobs:
         architecture: ${{ matrix.architecture }}
 
     - name: Setup ROS2
-      if: ${{ !matrix.ros_tar_url }}
+      if: ${{ matrix.ros_distribution != 'rolling' }}
       uses: ros-tooling/setup-ros@v0.7
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
 
     - name: Install ROS2 Rolling Nightly
-      if: ${{ matrix.ros_tar_url }}
+      if: ${{ matrix.ros_distribution == 'rolling' }}
+      env:
+        ROS2_ROLLING_DIR: /opt/ros2_rolling
       run: |
-        apt-get update
-        apt-get install -y build-essential cmake curl tar bzip2 python3
-        curl -sL "${{ matrix.ros_tar_url }}" -o /tmp/ros2-nightly.tar.bz2
-        mkdir -p /opt/ros2_nightly
-        tar xjf /tmp/ros2-nightly.tar.bz2 -C /opt/ros2_nightly
-        rm /tmp/ros2-nightly.tar.bz2
+        apt-get update && apt-get install -y locales
+        locale-gen en_US en_US.UTF-8
+        update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+        export LANG=en_US.UTF-8
+
+        apt-get install -y build-essential cmake curl tar bzip2 wget python3 python3-rosdep
+
+        # Download and extract nightly binary
+        mkdir -p $ROS2_ROLLING_DIR
+        cd $ROS2_ROLLING_DIR
+        curl -sL "${{ matrix.ros_tar_url }}" -o ros2-nightly.tar.bz2
+        tar xf ros2-nightly.tar.bz2
+        rm ros2-nightly.tar.bz2
+
+        # Install dependencies using rosdep
+        rosdep init || true
+        rosdep update
+        rosdep install --from-paths $ROS2_ROLLING_DIR/ros2-linux/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 urdfdom_headers"
 
     - name: Install test-msgs and mrpt_msgs on Linux
-      if: ${{ !matrix.ros_tar_url }}
+      if: ${{ matrix.ros_distribution != 'rolling' }}
       run: |
         sudo apt install ros-${{ matrix.ros_distribution }}-test-msgs ros-${{ matrix.ros_distribution }}-mrpt-msgs
         # Adjust dependencies based on Ubuntu version
@@ -77,15 +91,18 @@ jobs:
 
     - uses: actions/checkout@v6
 
-    - name: Build rclnodejs (nightly)
-      if: ${{ matrix.ros_tar_url }}
+    - name: Build and test rclnodejs (nightly)
+      if: ${{ matrix.ros_distribution == 'rolling' }}
       run: |
         uname -a
-        source /opt/ros2_nightly/ros2-linux/setup.bash
+        source /opt/ros2_rolling/ros2-linux/setup.bash
         npm i
+        npm run lint
+        npm test
+        npm run clean
 
     - name: Build and test rclnodejs
-      if: ${{ !matrix.ros_tar_url }}
+      if: ${{ matrix.ros_distribution != 'rolling' }}
       run: |
         uname -a
         source /opt/ros/${{ matrix.ros_distribution }}/setup.bash
@@ -95,15 +112,15 @@ jobs:
         npm run clean
 
     - name: Test with IDL ROS messages against rolling
-      if: ${{ !matrix.ros_tar_url && matrix.ros_distribution == 'rolling' }}
+      if: ${{ matrix.ros_distribution == 'rolling' }}
       run: |
-        source /opt/ros/${{ matrix.ros_distribution }}/setup.bash
+        source /opt/ros2_rolling/ros2-linux/setup.bash
         npm i
         npm run test-idl
         npm run clean
 
     - name: Coveralls
-      if: ${{ !matrix.ros_tar_url && matrix.ros_distribution == 'rolling' && matrix['node-version'] == '24.X' }}
+      if: ${{ matrix.ros_distribution == 'rolling' && matrix['node-version'] == '24.X' }}
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -56,27 +56,13 @@ jobs:
 
     - name: Install ROS2 Rolling Nightly
       if: ${{ matrix.ros_distribution == 'rolling' }}
-      env:
-        ROS2_ROLLING_DIR: /opt/ros2_rolling
       run: |
-        apt-get update && apt-get install -y locales
-        locale-gen en_US en_US.UTF-8
-        update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
-        export LANG=en_US.UTF-8
-
-        apt-get install -y build-essential cmake curl tar bzip2 wget python3 python3-rosdep
-
-        # Download and extract nightly binary
-        mkdir -p $ROS2_ROLLING_DIR
-        cd $ROS2_ROLLING_DIR
-        curl -sL "${{ matrix.ros_tar_url }}" -o ros2-nightly.tar.bz2
-        tar xf ros2-nightly.tar.bz2
-        rm ros2-nightly.tar.bz2
-
-        # Install dependencies using rosdep
-        rosdep init || true
-        rosdep update
-        rosdep install --from-paths $ROS2_ROLLING_DIR/ros2-linux/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 urdfdom_headers"
+        apt-get update
+        apt-get install -y build-essential cmake curl tar bzip2 python3
+        mkdir -p /opt/ros2_rolling
+        curl -sL "${{ matrix.ros_tar_url }}" -o /tmp/ros2-nightly.tar.bz2
+        tar xf /tmp/ros2-nightly.tar.bz2 -C /opt/ros2_rolling
+        rm /tmp/ros2-nightly.tar.bz2
 
     - name: Install test-msgs and mrpt_msgs on Linux
       if: ${{ matrix.ros_distribution != 'rolling' }}

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -58,10 +58,19 @@ jobs:
       if: ${{ matrix.ros_distribution == 'rolling' }}
       run: |
         apt-get update
-        apt-get install -y build-essential cmake curl tar bzip2 python3 python3-pip software-properties-common
-        pip3 install --break-system-packages rosdep
+        apt-get install -y software-properties-common curl
 
-        # Download and extract nightly binary (per https://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Install-Binary.html)
+        # Enable required repositories (per https://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Install-Binary.html)
+        add-apt-repository universe
+        ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
+        curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
+        dpkg -i /tmp/ros2-apt-source.deb
+
+        # Install prerequisites
+        apt-get update
+        apt-get install -y build-essential cmake tar bzip2 python3 python3-rosdep
+
+        # Download and extract nightly binary
         mkdir -p /opt/ros2_rolling
         curl -sL "${{ matrix.ros_tar_url }}" -o /tmp/ros2-nightly.tar.bz2
         tar xf /tmp/ros2-nightly.tar.bz2 -C /opt/ros2_rolling
@@ -73,7 +82,6 @@ jobs:
         rosdep install --from-paths /opt/ros2_rolling/ros2-linux/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 urdfdom_headers"
 
     - name: Install test-msgs and mrpt_msgs on Linux
-      if: ${{ matrix.ros_distribution != 'rolling' }}
       run: |
         sudo apt install ros-${{ matrix.ros_distribution }}-test-msgs ros-${{ matrix.ros_distribution }}-mrpt-msgs
         # Adjust dependencies based on Ubuntu version

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -86,6 +86,9 @@ jobs:
       if: ${{ matrix.ros_distribution != 'rolling' }}
       run: |
         sudo apt install -y ros-${{ matrix.ros_distribution }}-test-msgs ros-${{ matrix.ros_distribution }}-mrpt-msgs
+
+    - name: Install Electron test dependencies
+      run: |
         # Adjust dependencies based on Ubuntu version
         LIBASOUND_PKG="libasound2"
         if grep -q "24.04" /etc/os-release; then

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -58,11 +58,18 @@ jobs:
       if: ${{ matrix.ros_distribution == 'rolling' }}
       run: |
         apt-get update
-        apt-get install -y build-essential cmake curl tar bzip2 python3
+        apt-get install -y build-essential cmake curl tar bzip2 python3 python3-rosdep software-properties-common
+
+        # Download and extract nightly binary (per https://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Install-Binary.html)
         mkdir -p /opt/ros2_rolling
         curl -sL "${{ matrix.ros_tar_url }}" -o /tmp/ros2-nightly.tar.bz2
         tar xf /tmp/ros2-nightly.tar.bz2 -C /opt/ros2_rolling
         rm /tmp/ros2-nightly.tar.bz2
+
+        # Install runtime dependencies using rosdep
+        rosdep init || true
+        rosdep update
+        rosdep install --from-paths /opt/ros2_rolling/ros2-linux/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 urdfdom_headers"
 
     - name: Install test-msgs and mrpt_msgs on Linux
       if: ${{ matrix.ros_distribution != 'rolling' }}

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -68,7 +68,7 @@ jobs:
 
         # Install prerequisites
         apt-get update
-        apt-get install -y build-essential cmake tar bzip2 python3 python3-rosdep
+        apt-get install -y build-essential cmake tar bzip2 python3 python3-rosdep python3-colcon-common-extensions
 
         # Download and extract nightly binary
         mkdir -p /opt/ros2_rolling
@@ -97,8 +97,8 @@ jobs:
       if: ${{ matrix.ros_distribution == 'rolling' }}
       run: |
         uname -a
-        source /opt/ros2_rolling/ros2-linux/setup.bash
-        source /opt/ros/rolling/local_setup.bash
+        source /opt/ros/rolling/setup.bash
+        source /opt/ros2_rolling/ros2-linux/local_setup.bash
         npm i
         npm run lint
         npm test
@@ -117,8 +117,8 @@ jobs:
     - name: Test with IDL ROS messages against rolling
       if: ${{ matrix.ros_distribution == 'rolling' }}
       run: |
-        source /opt/ros2_rolling/ros2-linux/setup.bash
-        source /opt/ros/rolling/local_setup.bash
+        source /opt/ros/rolling/setup.bash
+        source /opt/ros2_rolling/ros2-linux/local_setup.bash
         npm i
         npm run test-idl
         npm run clean

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -80,7 +80,7 @@ jobs:
         # Install any remaining runtime dependencies using rosdep
         rosdep init || true
         rosdep update
-        rosdep install --from-paths /opt/ros/rolling/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 urdfdom_headers"
+        rosdep install --rosdistro rolling --from-paths /opt/ros/rolling/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 urdfdom_headers"
 
     - name: Install test-msgs and mrpt_msgs on Linux
       if: ${{ matrix.ros_distribution != 'rolling' }}

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Install test-msgs and mrpt_msgs on Linux
       run: |
-        sudo apt install ros-${{ matrix.ros_distribution }}-test-msgs ros-${{ matrix.ros_distribution }}-mrpt-msgs
+        sudo apt install -y ros-${{ matrix.ros_distribution }}-test-msgs ros-${{ matrix.ros_distribution }}-mrpt-msgs
         # Adjust dependencies based on Ubuntu version
         LIBASOUND_PKG="libasound2"
         if grep -q "24.04" /etc/os-release; then

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -98,6 +98,7 @@ jobs:
       run: |
         uname -a
         source /opt/ros2_rolling/ros2-linux/setup.bash
+        source /opt/ros/rolling/local_setup.bash
         npm i
         npm run lint
         npm test
@@ -117,6 +118,7 @@ jobs:
       if: ${{ matrix.ros_distribution == 'rolling' }}
       run: |
         source /opt/ros2_rolling/ros2-linux/setup.bash
+        source /opt/ros/rolling/local_setup.bash
         npm i
         npm run test-idl
         npm run clean

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -145,6 +145,14 @@ class Subscription extends Entity {
   }
 
   /**
+   * Check if content filtering is supported for this subscription.
+   * @returns {boolean} True if the subscription instance supports content filtering; otherwise false.
+   */
+  isContentFilterSupported() {
+    return rclnodejs.isContentFilterSupported(this.handle);
+  }
+
+  /**
    * Test if the RMW supports content-filtered topics and that this subscription
    * has an active wellformed content-filter.
    * @returns {boolean} True if content-filtering will be applied; otherwise false.

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -16,6 +16,7 @@
 
 const rclnodejs = require('./native_loader.js');
 const Entity = require('./entity.js');
+const DistroUtils = require('./distro.js');
 const { applySerializationMode } = require('./message_serialization.js');
 const debug = require('debug')('rclnodejs:subscription');
 
@@ -146,9 +147,13 @@ class Subscription extends Entity {
 
   /**
    * Check if content filtering is supported for this subscription.
+   * Requires ROS 2 Rolling or later.
    * @returns {boolean} True if the subscription instance supports content filtering; otherwise false.
    */
   isContentFilterSupported() {
+    if (DistroUtils.getDistroId() < DistroUtils.DistroId.ROLLING) {
+      return false;
+    }
     return rclnodejs.isContentFilterSupported(this.handle);
   }
 

--- a/rosidl_parser/parser.py
+++ b/rosidl_parser/parser.py
@@ -47,7 +47,7 @@ def get_json_object_from_msg_spec_object(msg_spec_object):
 
 if __name__ == '__main__':
     if len(sys.argv) < 4:
-        print('Wrong number of argments')
+        print('Usage: {} <command> <packageName> <filePath>'.format(sys.argv[0]), file=sys.stderr)
         sys.exit(1)
     try:
         parser_method = getattr(parser, sys.argv[1])

--- a/rosidl_parser/parser.py
+++ b/rosidl_parser/parser.py
@@ -52,6 +52,7 @@ if __name__ == '__main__':
     try:
         parser_method = getattr(parser, sys.argv[1])
         spec = parser_method(sys.argv[2], sys.argv[3])
+
         if sys.argv[1] == 'parse_message_file':
             json_obj = get_json_object_from_msg_spec_object(spec)
         elif sys.argv[1] == 'parse_service_file':

--- a/rosidl_parser/parser.py
+++ b/rosidl_parser/parser.py
@@ -47,12 +47,11 @@ def get_json_object_from_msg_spec_object(msg_spec_object):
 
 if __name__ == '__main__':
     if len(sys.argv) < 4:
-        print('Usage: {} <command> <packageName> <filePath>'.format(sys.argv[0]), file=sys.stderr)
+        print('Wrong number of argments')
         sys.exit(1)
     try:
         parser_method = getattr(parser, sys.argv[1])
         spec = parser_method(sys.argv[2], sys.argv[3])
-
         if sys.argv[1] == 'parse_message_file':
             json_obj = get_json_object_from_msg_spec_object(spec)
         elif sys.argv[1] == 'parse_service_file':

--- a/src/rcl_subscription_bindings.cpp
+++ b/src/rcl_subscription_bindings.cpp
@@ -16,6 +16,7 @@
 
 #include <rcl/error_handling.h>
 #include <rcl/rcl.h>
+#include <rcl/subscription.h>
 #include <rmw/types.h>
 
 #include <cstdio>

--- a/src/rcl_subscription_bindings.cpp
+++ b/src/rcl_subscription_bindings.cpp
@@ -265,6 +265,7 @@ Napi::Value GetSubscriptionTopic(const Napi::CallbackInfo& info) {
   return Napi::String::New(env, topic);
 }
 
+#if ROS_VERSION > 2505  // Rolling only
 Napi::Value IsContentFilterSupported(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
 
@@ -276,6 +277,7 @@ Napi::Value IsContentFilterSupported(const Napi::CallbackInfo& info) {
   bool is_supported = rcl_subscription_is_cft_supported(subscription);
   return Napi::Boolean::New(env, is_supported);
 }
+#endif
 
 Napi::Value HasContentFilter(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
@@ -489,8 +491,10 @@ Napi::Object InitSubscriptionBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("rclTakeRaw", Napi::Function::New(env, RclTakeRaw));
   exports.Set("getSubscriptionTopic",
               Napi::Function::New(env, GetSubscriptionTopic));
+#if ROS_VERSION > 2505  // Rolling only
   exports.Set("isContentFilterSupported",
               Napi::Function::New(env, IsContentFilterSupported));
+#endif
   exports.Set("hasContentFilter", Napi::Function::New(env, HasContentFilter));
   exports.Set("setContentFilter", Napi::Function::New(env, SetContentFilter));
   exports.Set("getContentFilter", Napi::Function::New(env, GetContentFilter));

--- a/src/rcl_subscription_bindings.cpp
+++ b/src/rcl_subscription_bindings.cpp
@@ -264,6 +264,18 @@ Napi::Value GetSubscriptionTopic(const Napi::CallbackInfo& info) {
   return Napi::String::New(env, topic);
 }
 
+Napi::Value IsContentFilterSupported(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  RclHandle* subscription_handle =
+      RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_subscription_t* subscription =
+      reinterpret_cast<rcl_subscription_t*>(subscription_handle->ptr());
+
+  bool is_supported = rcl_subscription_is_cft_supported(subscription);
+  return Napi::Boolean::New(env, is_supported);
+}
+
 Napi::Value HasContentFilter(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
 
@@ -476,6 +488,8 @@ Napi::Object InitSubscriptionBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("rclTakeRaw", Napi::Function::New(env, RclTakeRaw));
   exports.Set("getSubscriptionTopic",
               Napi::Function::New(env, GetSubscriptionTopic));
+  exports.Set("isContentFilterSupported",
+              Napi::Function::New(env, IsContentFilterSupported));
   exports.Set("hasContentFilter", Napi::Function::New(env, HasContentFilter));
   exports.Set("setContentFilter", Napi::Function::New(env, SetContentFilter));
   exports.Set("getContentFilter", Napi::Function::New(env, GetContentFilter));

--- a/test/test-subscription-content-filter.js
+++ b/test/test-subscription-content-filter.js
@@ -505,8 +505,9 @@ describe('subscription isContentFilterSupported', function () {
     const supported = subscription.isContentFilterSupported();
     assert.strictEqual(typeof supported, 'boolean');
 
-    // Validate against known RMW capabilities
-    const expectedSupported = isContentFilteringSupported();
+    // isContentFilterSupported requires rolling; on older distros it returns false
+    const isRolling = DistroUtils.getDistroId() >= DistroUtils.DistroId.ROLLING;
+    const expectedSupported = isRolling && isContentFilteringSupported();
     assert.strictEqual(supported, expectedSupported);
 
     done();

--- a/test/test-subscription-content-filter.js
+++ b/test/test-subscription-content-filter.js
@@ -480,3 +480,35 @@ describe('subscription content-filtering', function () {
     done();
   });
 });
+
+describe('subscription isContentFilterSupported', function () {
+  this.timeout(30 * 1000);
+
+  beforeEach(async function () {
+    await rclnodejs.init();
+    this.node = new Node('cft_support_test_node');
+  });
+
+  afterEach(function () {
+    this.node.destroy();
+    rclnodejs.shutdown();
+  });
+
+  it('isContentFilterSupported returns boolean matching RMW capability', function (done) {
+    const typeclass = 'std_msgs/msg/Int16';
+    const subscription = this.node.createSubscription(
+      typeclass,
+      TOPIC,
+      (msg) => {}
+    );
+
+    const supported = subscription.isContentFilterSupported();
+    assert.strictEqual(typeof supported, 'boolean');
+
+    // Validate against known RMW capabilities
+    const expectedSupported = isContentFilteringSupported();
+    assert.strictEqual(supported, expectedSupported);
+
+    done();
+  });
+});

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -245,6 +245,7 @@ expectType<rclnodejs.SubscriptionWithRawMessageCallback>(rawMessageCallback);
 
 expectType<string>(subscription.topic);
 expectType<boolean>(subscription.isDestroyed());
+expectType<boolean>(subscription.isContentFilterSupported());
 expectType<boolean>(subscription.setContentFilter(contentFilter));
 expectType<rclnodejs.SubscriptionContentFilter | undefined>(
   subscription.getContentFilter()

--- a/types/subscription.d.ts
+++ b/types/subscription.d.ts
@@ -52,6 +52,12 @@ declare module 'rclnodejs' {
     readonly isRaw: boolean;
 
     /**
+     * Check if content filtering is supported for this subscription.
+     * @returns True if the subscription instance supports content filtering; otherwise false.
+     */
+    isContentFilterSupported(): boolean;
+
+    /**
      * Test if the RMW supports content-filtered topics and that this subscription
      * is configured with a well formed content-filter.
      * @returns {boolean} True if content-filtering will be applied; otherwise false.


### PR DESCRIPTION
Corresponding to rclpy  [d892204](https://github.com/ros2/rclpy/commit/d892204c2722cd18447b257f93b80af141a83048) and rcl's `rcl_subscription_is_cft_supported()` API, this adds `isContentFilterSupported()` to the `Subscription` class. This allows users to query at runtime whether the underlying RMW supports content-filtered topics for a given subscription, rather than relying on hardcoded RMW name checks. Currently gated to ROS 2 Rolling only (`ROS_VERSION > 2505`); on older distros it returns `false`.

### Feature changes

- **src/rcl_subscription_bindings.cpp** — Added `IsContentFilterSupported()` N-API function calling `rcl_subscription_is_cft_supported()`, guarded by `#if ROS_VERSION > 2505`. Added `#include <rcl/subscription.h>`. Registered as `"isContentFilterSupported"` in `InitSubscriptionBindings()`.
- **lib/subscription.js** — Added `isContentFilterSupported()` method with a distro guard (`DistroUtils.getDistroId() < ROLLING` returns `false`). Added `DistroUtils` import.
- **types/subscription.d.ts** — Added `isContentFilterSupported(): boolean` to the `Subscription` interface.
- **test/test-subscription-content-filter.js** — Added a separate top-level `describe('subscription isContentFilterSupported')` block that runs on all distros. Validates the return value accounts for both the rolling requirement and RMW capability.
- **test/types/index.test-d.ts** — Added `expectType<boolean>` assertion for `isContentFilterSupported()`.

### CI changes

- **.github/workflows/linux-x64-build-and-test.yml** — Replaced `setup-ros` with `use-ros2-testing` for rolling with a nightly binary tarball approach, following the [official ROS 2 Rolling binary installation guide](https://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Install-Binary.html):
  - Configures ROS apt sources via `ros2-apt-source` deb package.
  - Installs apt packages (`test-msgs`, `mrpt-msgs`, `colcon`, `rosdep`) **before** extracting the nightly tarball, so the nightly's newer libs (e.g. `librcutils.so` with `rcutils_decode_base64`) overwrite apt's older versions.
  - Extracts nightly tarball with `--strip-components=1` into `/opt/ros/rolling/` so everything lives under one prefix — single `source /opt/ros/rolling/setup.bash` like all other distros.
  - Runs `rosdep install` for remaining runtime dependencies.
  - Separated Electron test dependencies (`xvfb`, `libgtk-3-0`, etc.) into its own step that runs for all distros.
  - Added `-y` to `apt install` for test-msgs.
  - Removed stale `use-ros2-testing` parameter from `setup-ros`.

Fix: #1450