### PR TITLE
NPM Publish Workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,15 +22,15 @@ permissions:
 
 jobs:
   prebuild-x64:
+    if: github.repository == 'RobotWebTools/rclnodejs'
     uses: ./.github/workflows/prebuild-linux-x64.yml
 
   prebuild-arm64:
+    if: github.repository == 'RobotWebTools/rclnodejs'
     uses: ./.github/workflows/prebuild-linux-arm64.yml
 
   publish:
     needs: [prebuild-x64, prebuild-arm64]
-    # Only publish from the official repository, not forks
-    if: github.repository == 'RobotWebTools/rclnodejs'
     runs-on: ubuntu-latest
     environment: npm-publish
     permissions:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Perform a dry run (skip actual publish)'
+        required: true
+        type: boolean
+        default: true
 
 # Ensure only one publish runs at a time
 concurrency:
@@ -30,7 +37,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -39,14 +46,14 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download x64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: prebuilt-linux-x64-*
           path: prebuilds/linux-x64
           merge-multiple: true
 
       - name: Download arm64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: prebuilt-linux-arm64-*
           path: prebuilds/linux-arm64
@@ -63,4 +70,10 @@ jobs:
         run: ./scripts/npm-pack.sh
 
       - name: Publish
-        run: npm publish --provenance --access public ./dist/rclnodejs-*.tgz
+        run: |
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            echo "=== DRY RUN ==="
+            npm publish --provenance --access public --dry-run ./dist/rclnodejs-*.tgz
+          else
+            npm publish --provenance --access public ./dist/rclnodejs-*.tgz
+          fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,66 @@
+name: NPM Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+# Ensure only one publish runs at a time
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  prebuild-x64:
+    uses: ./.github/workflows/prebuild-linux-x64.yml
+
+  prebuild-arm64:
+    uses: ./.github/workflows/prebuild-linux-arm64.yml
+
+  publish:
+    needs: [prebuild-x64, prebuild-arm64]
+    # Only publish from the official repository, not forks
+    if: github.repository == 'RobotWebTools/rclnodejs'
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download x64 prebuilds
+        uses: actions/download-artifact@v4
+        with:
+          pattern: prebuilt-linux-x64-*
+          path: prebuilds/linux-x64
+          merge-multiple: true
+
+      - name: Download arm64 prebuilds
+        uses: actions/download-artifact@v4
+        with:
+          pattern: prebuilt-linux-arm64-*
+          path: prebuilds/linux-arm64
+          merge-multiple: true
+
+      - name: List prebuilds
+        run: |
+          echo "=== x64 prebuilds ==="
+          ls -la prebuilds/linux-x64/
+          echo "=== arm64 prebuilds ==="
+          ls -la prebuilds/linux-arm64/
+
+      - name: Pack
+        run: ./scripts/npm-pack.sh
+
+      - name: Publish
+        run: npm publish --provenance --access public ./dist/rclnodejs-*.tgz

--- a/.github/workflows/prebuild-linux-arm64.yml
+++ b/.github/workflows/prebuild-linux-arm64.yml
@@ -2,9 +2,7 @@ name: Prebuild Linux ARM64
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - '*'
+  workflow_call:
 
 jobs:
   prebuild:

--- a/.github/workflows/prebuild-linux-arm64.yml
+++ b/.github/workflows/prebuild-linux-arm64.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       shell: bash
@@ -59,7 +59,7 @@ jobs:
         npm run prebuild
 
     - name: Upload prebuilt binary
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: prebuilt-linux-arm64-node${{ matrix.node-version }}-${{ matrix.ubuntu_codename }}-${{ matrix.ros_distribution }}
         path: prebuilds/linux-arm64/*.node

--- a/.github/workflows/prebuild-linux-x64.yml
+++ b/.github/workflows/prebuild-linux-x64.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       shell: bash
@@ -59,7 +59,7 @@ jobs:
         npm run prebuild
 
     - name: Upload prebuilt binary
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: prebuilt-linux-x64-node${{ matrix.node-version }}-${{ matrix.ubuntu_codename }}-${{ matrix.ros_distribution }}
         path: prebuilds/linux-x64/*.node

--- a/.github/workflows/prebuild-linux-x64.yml
+++ b/.github/workflows/prebuild-linux-x64.yml
@@ -2,9 +2,7 @@ name: Prebuild Linux x64
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - '*'
+  workflow_call:
 
 jobs:
   prebuild:


### PR DESCRIPTION
Automate npm publishing via GitHub Actions when a new tag is pushed. Prebuilt binaries for both x64 and arm64 are built in parallel, bundled into the tarball, and published to npm with SLSA provenance attestation using OIDC trusted publishing (no long-lived npm token required).

### Changes

**New: `.github/workflows/npm-publish.yml`** — Triggers on tag push or manual `workflow_dispatch` (with dry-run option). Calls `prebuild-linux-x64.yml` and `prebuild-linux-arm64.yml` as reusable sub-workflows in parallel. After both complete, the `publish` job downloads all prebuilt `.node` artifacts, runs `./scripts/npm-pack.sh` to create the tarball, and publishes via `npm publish --provenance --access public`. Security: fork protection (`if: github.repository == 'RobotWebTools/rclnodejs'`), concurrency guard, GitHub environment (`npm-publish`) for deployment protection, and `id-token: write` for OIDC trusted publishing.

**Modified: `.github/workflows/prebuild-linux-arm64.yml`** — Replaced `push: tags: '*'` trigger with `workflow_call:` so it can be invoked as a reusable workflow from `npm-publish.yml`. `workflow_dispatch:` retained for manual runs.

**Modified: `.github/workflows/prebuild-linux-x64.yml`** — Same change as arm64: replaced `push: tags:` with `workflow_call:`.

Fix: #1459