### PR TITLE
Support pre-release publishing in npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -70,13 +70,12 @@ jobs:
         run: ./scripts/npm-pack.sh
 
       - name: Determine dist-tag
-        id: dist-tag
+        id: dist_tag
         run: |
           TAG=$(node -p "
             const v = require('./package.json').version;
             const pre = v.split('-')[1];
-            if (!pre) { 'latest' }
-            else { pre.split('.')[0].replace(/[0-9]+$/, '') || 'next' }
+            !pre ? 'latest' : (pre.split('.')[0].replace(/[0-9]+$/, '') || 'next')
           ")
           if [[ -z "$TAG" ]]; then
             echo "::error::Failed to determine dist-tag"
@@ -87,7 +86,7 @@ jobs:
 
       - name: Publish
         run: |
-          TAG="${{ steps.dist-tag.outputs.tag }}"
+          TAG="${{ steps.dist_tag.outputs.tag }}"
           if [[ -z "$TAG" ]]; then
             echo "::error::dist-tag is empty, aborting publish"
             exit 1

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -69,11 +69,24 @@ jobs:
       - name: Pack
         run: ./scripts/npm-pack.sh
 
+      - name: Determine dist-tag
+        id: dist-tag
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *-* ]]; then
+            # Pre-release version (e.g. 1.9.0-alpha.0) — extract pre-release label
+            TAG=$(echo "$VERSION" | sed 's/.*-\([a-zA-Z]*\).*/\1/')
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
+          echo "Version: $VERSION, Tag: $(cat $GITHUB_OUTPUT | grep tag | cut -d= -f2)"
+
       - name: Publish
         run: |
           if [[ "${{ inputs.dry_run }}" == "true" ]]; then
             echo "=== DRY RUN ==="
-            npm publish --provenance --access public --dry-run ./dist/rclnodejs-*.tgz
+            npm publish --provenance --access public --tag ${{ steps.dist-tag.outputs.tag }} --dry-run ./dist/rclnodejs-*.tgz
           else
-            npm publish --provenance --access public ./dist/rclnodejs-*.tgz
+            npm publish --provenance --access public --tag ${{ steps.dist-tag.outputs.tag }} ./dist/rclnodejs-*.tgz
           fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -72,21 +72,29 @@ jobs:
       - name: Determine dist-tag
         id: dist-tag
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          if [[ "$VERSION" == *-* ]]; then
-            # Pre-release version (e.g. 1.9.0-alpha.0) — extract pre-release label
-            TAG=$(echo "$VERSION" | sed 's/.*-\([a-zA-Z]*\).*/\1/')
-            echo "tag=$TAG" >> $GITHUB_OUTPUT
-          else
-            echo "tag=latest" >> $GITHUB_OUTPUT
+          TAG=$(node -p "
+            const v = require('./package.json').version;
+            const pre = v.split('-')[1];
+            if (!pre) { 'latest' }
+            else { pre.split('.')[0].replace(/[0-9]+$/, '') || 'next' }
+          ")
+          if [[ -z "$TAG" ]]; then
+            echo "::error::Failed to determine dist-tag"
+            exit 1
           fi
-          echo "Version: $VERSION, Tag: $(cat $GITHUB_OUTPUT | grep tag | cut -d= -f2)"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved dist-tag: $TAG"
 
       - name: Publish
         run: |
+          TAG="${{ steps.dist-tag.outputs.tag }}"
+          if [[ -z "$TAG" ]]; then
+            echo "::error::dist-tag is empty, aborting publish"
+            exit 1
+          fi
           if [[ "${{ inputs.dry_run }}" == "true" ]]; then
             echo "=== DRY RUN ==="
-            npm publish --provenance --access public --tag ${{ steps.dist-tag.outputs.tag }} --dry-run ./dist/rclnodejs-*.tgz
+            npm publish --provenance --access public --tag "$TAG" --dry-run ./dist/rclnodejs-*.tgz
           else
-            npm publish --provenance --access public --tag ${{ steps.dist-tag.outputs.tag }} ./dist/rclnodejs-*.tgz
+            npm publish --provenance --access public --tag "$TAG" ./dist/rclnodejs-*.tgz
           fi


### PR DESCRIPTION
Add automatic dist-tag detection to the publish step. npm requires `--tag` when publishing pre-release versions to prevent them from becoming the default `latest` on the registry.

The new `Determine dist-tag` step reads the version from `package.json` and extracts the pre-release label (e.g. `alpha`, `beta`, `rc`) if present, otherwise defaults to `latest`. This tag is passed to `npm publish --tag`.

Examples:
- `1.9.0-alpha.0` → `--tag alpha`
- `1.9.0-beta.1` → `--tag beta`
- `1.9.0-rc.0` → `--tag rc`
- `1.9.0` → `--tag latest`

Fix: #1459 