### PR TITLE
Add QoS overriding options for publishers and subscriptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,10 @@ const {
 } = require('./lib/parameter.js');
 const path = require('path');
 const QoS = require('./lib/qos.js');
+const {
+  QoSPolicyKind,
+  QoSOverridingOptions,
+} = require('./lib/qos_overriding_options.js');
 const rclnodejs = require('./lib/native_loader.js');
 const tsdGenerator = require('./rostsd_gen/index.js');
 const validator = require('./lib/validator.js');
@@ -257,6 +261,12 @@ let rcl = {
 
   /** {@link QoS} class */
   QoS: QoS,
+
+  /** {@link QoSPolicyKind} enum */
+  QoSPolicyKind: QoSPolicyKind,
+
+  /** {@link QoSOverridingOptions} class */
+  QoSOverridingOptions: QoSOverridingOptions,
 
   /** {@link RMWUtils} */
   RMWUtils: RMWUtils,

--- a/lib/node.js
+++ b/lib/node.js
@@ -48,6 +48,10 @@ const Service = require('./service.js');
 const Subscription = require('./subscription.js');
 const ObservableSubscription = require('./observable_subscription.js');
 const MessageInfo = require('./message_info.js');
+const {
+  declareQosParameters,
+  _resolveQoS,
+} = require('./qos_overriding_options.js');
 const TimeSource = require('./time_source.js');
 const Timer = require('./timer.js');
 const TypeDescriptionService = require('./type_description_service.js');
@@ -752,6 +756,21 @@ class Node extends rclnodejs.ShadowNode {
       );
     }
 
+    // Apply QoS overriding options if provided
+    if (options.qosOverridingOptions) {
+      const resolvedTopic = this.resolveTopicName(topic);
+      if (typeof options.qos === 'string' || !(options.qos instanceof QoS)) {
+        options.qos = _resolveQoS(options.qos);
+      }
+      declareQosParameters(
+        'publisher',
+        this,
+        resolvedTopic,
+        options.qos,
+        options.qosOverridingOptions
+      );
+    }
+
     let publisher = publisherClass.createPublisher(
       this,
       typeClass,
@@ -845,6 +864,21 @@ class Node extends rclnodejs.ShadowNode {
           entityType: 'subscription',
           entityName: topic,
         }
+      );
+    }
+
+    // Apply QoS overriding options if provided
+    if (options.qosOverridingOptions) {
+      const resolvedTopic = this.resolveTopicName(topic);
+      if (typeof options.qos === 'string' || !(options.qos instanceof QoS)) {
+        options.qos = _resolveQoS(options.qos);
+      }
+      declareQosParameters(
+        'subscription',
+        this,
+        resolvedTopic,
+        options.qos,
+        options.qosOverridingOptions
       );
     }
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -709,6 +709,10 @@ class Node extends rclnodejs.ShadowNode {
    * @param {object} options - The options argument used to parameterize the publisher.
    * @param {boolean} options.enableTypedArray - The topic will use TypedArray if necessary, default: true.
    * @param {QoS} options.qos - ROS Middleware "quality of service" settings for the publisher, default: QoS.profileDefault.
+   * @param {QoSOverridingOptions} [options.qosOverridingOptions] - If provided, declares read-only ROS parameters
+   *  for the specified QoS policies (e.g. `qos_overrides./topic.publisher.depth`). These can be overridden at
+   *  startup via `--ros-args -p` or `--params-file`. If qos is a profile string, it will be resolved to a
+   *  mutable QoS object before overrides are applied.
    * @param {PublisherEventCallbacks} eventCallbacks - The event callbacks for the publisher.
    * @return {Publisher} - An instance of Publisher.
    */
@@ -814,6 +818,10 @@ class Node extends rclnodejs.ShadowNode {
    * @param {string[]} [options.contentFilter.parameters=undefined] - Array of strings that give values to
    *  the ‘parameters’ (i.e., "%n" tokens) in the filter_expression. The number of supplied parameters must
    *  fit with the requested values in the filter_expression (i.e., the number of %n tokens). default: undefined.
+   * @param {QoSOverridingOptions} [options.qosOverridingOptions] - If provided, declares read-only ROS parameters
+   *  for the specified QoS policies (e.g. `qos_overrides./topic.subscription.depth`). These can be overridden at
+   *  startup via `--ros-args -p` or `--params-file`. If qos is a profile string, it will be resolved to a
+   *  mutable QoS object before overrides are applied.
    * @param {SubscriptionCallback} callback - The callback to be call when receiving the topic subscribed. The topic will be an instance of null-terminated Buffer when options.isRaw is true.
    * @param {SubscriptionEventCallbacks} eventCallbacks - The event callbacks for the subscription.
    * @return {Subscription} - An instance of Subscription.

--- a/lib/qos_overriding_options.js
+++ b/lib/qos_overriding_options.js
@@ -209,6 +209,17 @@ function _resolveQoS(qos) {
   if (qos instanceof QoS) {
     return qos;
   }
+  // Plain object with QoS fields — construct a QoS from its properties
+  if (typeof qos === 'object' && qos !== null && !Array.isArray(qos)) {
+    return new QoS(
+      qos.history,
+      qos.depth,
+      qos.reliability,
+      qos.durability,
+      qos.liveliness,
+      qos.avoidRosNameSpaceConventions
+    );
+  }
   // Profile string: create a QoS with the corresponding defaults
   // Values must match the rmw_qos_profile_* definitions in rmw/types.h
   switch (qos) {

--- a/lib/qos_overriding_options.js
+++ b/lib/qos_overriding_options.js
@@ -35,10 +35,11 @@ const QoSPolicyKind = Object.freeze({
   AVOID_ROS_NAMESPACE_CONVENTIONS: 6,
 });
 
-// Maps QoSPolicyKind -> { qosProp, paramType, toParam, fromParam }
+// Maps QoSPolicyKind -> { qosProp, paramKey, paramType, toParam, fromParam }
 const POLICY_MAP = {
   [QoSPolicyKind.HISTORY]: {
     qosProp: 'history',
+    paramKey: 'history',
     enumObj: QoS.HistoryPolicy,
     paramType: ParameterType.PARAMETER_STRING,
     toParam: (val, enumObj) => _enumToString(val, enumObj),
@@ -46,12 +47,14 @@ const POLICY_MAP = {
   },
   [QoSPolicyKind.DEPTH]: {
     qosProp: 'depth',
+    paramKey: 'depth',
     paramType: ParameterType.PARAMETER_INTEGER,
-    toParam: (val) => val,
+    toParam: (val) => BigInt(val),
     fromParam: (val) => Number(val),
   },
   [QoSPolicyKind.RELIABILITY]: {
     qosProp: 'reliability',
+    paramKey: 'reliability',
     enumObj: QoS.ReliabilityPolicy,
     paramType: ParameterType.PARAMETER_STRING,
     toParam: (val, enumObj) => _enumToString(val, enumObj),
@@ -59,6 +62,7 @@ const POLICY_MAP = {
   },
   [QoSPolicyKind.DURABILITY]: {
     qosProp: 'durability',
+    paramKey: 'durability',
     enumObj: QoS.DurabilityPolicy,
     paramType: ParameterType.PARAMETER_STRING,
     toParam: (val, enumObj) => _enumToString(val, enumObj),
@@ -66,6 +70,7 @@ const POLICY_MAP = {
   },
   [QoSPolicyKind.LIVELINESS]: {
     qosProp: 'liveliness',
+    paramKey: 'liveliness',
     enumObj: QoS.LivelinessPolicy,
     paramType: ParameterType.PARAMETER_STRING,
     toParam: (val, enumObj) => _enumToString(val, enumObj),
@@ -73,6 +78,7 @@ const POLICY_MAP = {
   },
   [QoSPolicyKind.AVOID_ROS_NAMESPACE_CONVENTIONS]: {
     qosProp: 'avoidRosNameSpaceConventions',
+    paramKey: 'avoid_ros_namespace_conventions',
     paramType: ParameterType.PARAMETER_BOOL,
     toParam: (val) => val,
     fromParam: (val) => Boolean(val),
@@ -204,7 +210,23 @@ function _resolveQoS(qos) {
     return qos;
   }
   // Profile string: create a QoS with the corresponding defaults
+  // Values must match the rmw_qos_profile_* definitions in rmw/types.h
   switch (qos) {
+    case QoS.profileDefault:
+      return new QoS(
+        QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+        10,
+        QoS.ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+        QoS.DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE
+      );
+    case QoS.profileSystemDefault:
+      return new QoS(
+        QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT,
+        0,
+        QoS.ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT,
+        QoS.DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT,
+        QoS.LivelinessPolicy.RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT
+      );
     case QoS.profileSensorData:
       return new QoS(
         QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
@@ -219,8 +241,27 @@ function _resolveQoS(qos) {
         QoS.ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
         QoS.DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE
       );
-    case QoS.profileDefault:
-    case QoS.profileSystemDefault:
+    case QoS.profileParameters:
+      return new QoS(
+        QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+        1000,
+        QoS.ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+        QoS.DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE
+      );
+    case QoS.profileParameterEvents:
+      return new QoS(
+        QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+        1000,
+        QoS.ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+        QoS.DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE
+      );
+    case QoS.profileActionStatusDefault:
+      return new QoS(
+        QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+        1,
+        QoS.ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+        QoS.DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL
+      );
     default:
       return new QoS(
         QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
@@ -255,7 +296,7 @@ function declareQosParameters(entityType, node, topic, qos, options) {
       continue;
     }
 
-    const paramName = `${namePrefix}.${mapping.qosProp}`;
+    const paramName = `${namePrefix}.${mapping.paramKey}`;
     const currentValue = qos[mapping.qosProp];
     const paramValue = mapping.toParam(currentValue, mapping.enumObj);
 

--- a/lib/qos_overriding_options.js
+++ b/lib/qos_overriding_options.js
@@ -1,0 +1,306 @@
+// Copyright (c) 2026 The Robot Web Tools Contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const QoS = require('./qos.js');
+const {
+  Parameter,
+  ParameterType,
+  ParameterDescriptor,
+} = require('./parameter.js');
+
+/**
+ * Enum of overridable QoS policy kinds.
+ * Each value corresponds to a QoS property on the {@link QoS} class.
+ * @enum {number}
+ */
+const QoSPolicyKind = Object.freeze({
+  HISTORY: 1,
+  DEPTH: 2,
+  RELIABILITY: 3,
+  DURABILITY: 4,
+  LIVELINESS: 5,
+  AVOID_ROS_NAMESPACE_CONVENTIONS: 6,
+});
+
+// Maps QoSPolicyKind -> { qosProp, paramType, toParam, fromParam }
+const POLICY_MAP = {
+  [QoSPolicyKind.HISTORY]: {
+    qosProp: 'history',
+    enumObj: QoS.HistoryPolicy,
+    paramType: ParameterType.PARAMETER_STRING,
+    toParam: (val, enumObj) => _enumToString(val, enumObj),
+    fromParam: (val, enumObj) => _stringToEnum(val, enumObj),
+  },
+  [QoSPolicyKind.DEPTH]: {
+    qosProp: 'depth',
+    paramType: ParameterType.PARAMETER_INTEGER,
+    toParam: (val) => val,
+    fromParam: (val) => Number(val),
+  },
+  [QoSPolicyKind.RELIABILITY]: {
+    qosProp: 'reliability',
+    enumObj: QoS.ReliabilityPolicy,
+    paramType: ParameterType.PARAMETER_STRING,
+    toParam: (val, enumObj) => _enumToString(val, enumObj),
+    fromParam: (val, enumObj) => _stringToEnum(val, enumObj),
+  },
+  [QoSPolicyKind.DURABILITY]: {
+    qosProp: 'durability',
+    enumObj: QoS.DurabilityPolicy,
+    paramType: ParameterType.PARAMETER_STRING,
+    toParam: (val, enumObj) => _enumToString(val, enumObj),
+    fromParam: (val, enumObj) => _stringToEnum(val, enumObj),
+  },
+  [QoSPolicyKind.LIVELINESS]: {
+    qosProp: 'liveliness',
+    enumObj: QoS.LivelinessPolicy,
+    paramType: ParameterType.PARAMETER_STRING,
+    toParam: (val, enumObj) => _enumToString(val, enumObj),
+    fromParam: (val, enumObj) => _stringToEnum(val, enumObj),
+  },
+  [QoSPolicyKind.AVOID_ROS_NAMESPACE_CONVENTIONS]: {
+    qosProp: 'avoidRosNameSpaceConventions',
+    paramType: ParameterType.PARAMETER_BOOL,
+    toParam: (val) => val,
+    fromParam: (val) => Boolean(val),
+  },
+};
+
+/**
+ * Convert a numeric enum value to a lowercase string name.
+ * @param {number} val - enum numeric value
+ * @param {Object} enumObj - the enum object (e.g. QoS.HistoryPolicy)
+ * @returns {string}
+ */
+function _enumToString(val, enumObj) {
+  for (const [key, v] of Object.entries(enumObj)) {
+    if (v === val) {
+      // Strip the RMW prefix: "RMW_QOS_POLICY_HISTORY_KEEP_LAST" -> "keep_last"
+      const parts = key.split('_');
+      // Find the index after the policy name (HISTORY, RELIABILITY, etc.)
+      // Pattern: RMW_QOS_POLICY_<POLICY>_<VALUE>
+      const policyNames = [
+        'HISTORY',
+        'RELIABILITY',
+        'DURABILITY',
+        'LIVELINESS',
+      ];
+      let valueStart = 4; // default: skip RMW_QOS_POLICY_<X>_
+      for (let i = 3; i < parts.length; i++) {
+        if (policyNames.includes(parts[i])) {
+          valueStart = i + 1;
+          break;
+        }
+      }
+      return parts.slice(valueStart).join('_').toLowerCase();
+    }
+  }
+  return String(val);
+}
+
+/**
+ * Convert a lowercase string back to a numeric enum value.
+ * @param {string} str - the string value (e.g. "keep_last")
+ * @param {Object} enumObj - the enum object
+ * @returns {number}
+ */
+function _stringToEnum(str, enumObj) {
+  const upper = str.toUpperCase();
+  for (const [key, val] of Object.entries(enumObj)) {
+    if (key.endsWith('_' + upper)) {
+      return val;
+    }
+  }
+  throw new Error(`Unknown QoS policy value: "${str}"`);
+}
+
+/**
+ * Options for overriding QoS policies via ROS parameters.
+ *
+ * When passed to `createPublisher()` or `createSubscription()`, the node
+ * will declare read-only parameters for each specified policy kind. These
+ * parameters can be set via command-line arguments, launch files, or
+ * parameter files to override the QoS profile at startup.
+ *
+ * Parameter naming convention:
+ *   `qos_overrides.<topic>.<publisher|subscription>[_<entityId>].<policy>`
+ *
+ * @example
+ * // Override history, depth, and reliability via parameters
+ * const sub = node.createSubscription(
+ *   'std_msgs/msg/String', '/chatter',
+ *   { qos: rclnodejs.QoS.profileDefault,
+ *     qosOverridingOptions: QoSOverridingOptions.withDefaultPolicies() },
+ *   (msg) => console.log(msg.data)
+ * );
+ * // Now you can override via CLI:
+ * //   --ros-args -p "qos_overrides./chatter.subscription.depth:=20"
+ */
+class QoSOverridingOptions {
+  /**
+   * @param {Array<QoSPolicyKind>} policyKinds - Which QoS policies to expose as parameters.
+   * @param {Object} [opts]
+   * @param {function} [opts.callback] - Optional validation callback. Receives the
+   *   final QoS profile after overrides are applied. Should return
+   *   `{successful: true}` or `{successful: false, reason: '...'}`.
+   * @param {string} [opts.entityId] - Optional suffix to disambiguate multiple
+   *   publishers/subscriptions on the same topic.
+   */
+  constructor(policyKinds, opts = {}) {
+    this._policyKinds = Array.from(policyKinds);
+    this._callback = opts.callback || null;
+    this._entityId = opts.entityId || null;
+  }
+
+  get policyKinds() {
+    return this._policyKinds;
+  }
+
+  get callback() {
+    return this._callback;
+  }
+
+  get entityId() {
+    return this._entityId;
+  }
+
+  /**
+   * Create options that override history, depth, and reliability —
+   * the most commonly tuned policies.
+   * @param {Object} [opts]
+   * @param {function} [opts.callback] - Validation callback.
+   * @param {string} [opts.entityId] - Entity disambiguation suffix.
+   * @returns {QoSOverridingOptions}
+   */
+  static withDefaultPolicies(opts = {}) {
+    return new QoSOverridingOptions(
+      [QoSPolicyKind.HISTORY, QoSPolicyKind.DEPTH, QoSPolicyKind.RELIABILITY],
+      opts
+    );
+  }
+}
+
+/**
+ * Resolve QoS profile string to a mutable QoS object.
+ * If already a QoS instance, return as-is.
+ * @param {QoS|string} qos
+ * @returns {QoS}
+ */
+function _resolveQoS(qos) {
+  if (qos instanceof QoS) {
+    return qos;
+  }
+  // Profile string: create a QoS with the corresponding defaults
+  switch (qos) {
+    case QoS.profileSensorData:
+      return new QoS(
+        QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+        5,
+        QoS.ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,
+        QoS.DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE
+      );
+    case QoS.profileServicesDefault:
+      return new QoS(
+        QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+        10,
+        QoS.ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+        QoS.DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE
+      );
+    case QoS.profileDefault:
+    case QoS.profileSystemDefault:
+    default:
+      return new QoS(
+        QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+        10,
+        QoS.ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+        QoS.DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE
+      );
+  }
+}
+
+/**
+ * Declare QoS override parameters on the node and apply any overrides
+ * to the QoS profile in-place.
+ *
+ * @param {'publisher'|'subscription'} entityType
+ * @param {Node} node
+ * @param {string} topic - Fully resolved topic name.
+ * @param {QoS} qos - Mutable QoS object (will be modified in-place).
+ * @param {QoSOverridingOptions} options
+ */
+function declareQosParameters(entityType, node, topic, qos, options) {
+  if (!options || options.policyKinds.length === 0) {
+    return;
+  }
+
+  const idSuffix = options.entityId ? `_${options.entityId}` : '';
+  const namePrefix = `qos_overrides.${topic}.${entityType}${idSuffix}`;
+
+  for (const policyKind of options.policyKinds) {
+    const mapping = POLICY_MAP[policyKind];
+    if (!mapping) {
+      continue;
+    }
+
+    const paramName = `${namePrefix}.${mapping.qosProp}`;
+    const currentValue = qos[mapping.qosProp];
+    const paramValue = mapping.toParam(currentValue, mapping.enumObj);
+
+    const descriptor = new ParameterDescriptor(
+      paramName,
+      mapping.paramType,
+      `QoS override for ${mapping.qosProp}`,
+      true // readOnly
+    );
+
+    let param;
+    try {
+      param = node.declareParameter(
+        new Parameter(paramName, mapping.paramType, paramValue),
+        descriptor
+      );
+    } catch (e) {
+      // Already declared (e.g. multiple entities on same topic) — reuse
+      if (node.hasParameter(paramName)) {
+        param = node.getParameter(paramName);
+      } else {
+        throw e;
+      }
+    }
+
+    // Apply the (possibly overridden) parameter value back to QoS
+    if (param && param.value !== paramValue) {
+      qos[mapping.qosProp] = mapping.fromParam(param.value, mapping.enumObj);
+    }
+  }
+
+  // Run validation callback if provided
+  if (options.callback) {
+    const result = options.callback(qos);
+    if (result && !result.successful) {
+      throw new Error(
+        `QoS override validation failed: ${result.reason || 'unknown reason'}`
+      );
+    }
+  }
+}
+
+module.exports = {
+  QoSPolicyKind,
+  QoSOverridingOptions,
+  declareQosParameters,
+  _resolveQoS,
+};

--- a/test/test-qos-overriding-options.js
+++ b/test/test-qos-overriding-options.js
@@ -235,4 +235,56 @@ describe('QoS overriding options', function () {
 
     node.destroyPublisher(pub);
   });
+
+  it('Parameter override changes the actual QoS used', function () {
+    // Equivalent to running: node my_app.js --ros-args -p "qos_overrides./test_override_applied.subscription.depth:=1"
+    // In tests, we use NodeOptions.parameterOverrides since rclnodejs.init()
+    // (which processes --ros-args from process.argv) is already called.
+    // Both mechanisms populate the same _parameterOverrides map on the node.
+    const overrideNode = new rclnodejs.Node(
+      'qos_override_applied_node',
+      '',
+      rclnodejs.Context.defaultContext(),
+      {
+        startParameterServices: false,
+        parameterOverrides: [
+          new rclnodejs.Parameter(
+            'qos_overrides./test_override_applied.subscription.depth',
+            rclnodejs.ParameterType.PARAMETER_INTEGER,
+            1
+          ),
+        ],
+      }
+    );
+
+    const qos = new rclnodejs.QoS(
+      rclnodejs.QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+      10, // code default: depth=10
+      rclnodejs.QoS.ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      rclnodejs.QoS.DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE
+    );
+
+    const sub = overrideNode.createSubscription(
+      'std_msgs/msg/String',
+      'test_override_applied',
+      {
+        qos: qos,
+        qosOverridingOptions:
+          rclnodejs.QoSOverridingOptions.withDefaultPolicies(),
+      },
+      () => {}
+    );
+
+    // The parameter override (depth=1) should have been applied to the QoS
+    const depthParam = overrideNode.getParameter(
+      'qos_overrides./test_override_applied.subscription.depth'
+    );
+    assert.strictEqual(Number(depthParam.value), 1);
+
+    // The QoS object should have been mutated in-place
+    assert.strictEqual(qos.depth, 1);
+
+    overrideNode.destroySubscription(sub);
+    overrideNode.destroy();
+  });
 });

--- a/test/test-qos-overriding-options.js
+++ b/test/test-qos-overriding-options.js
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 The Robot Web Tools Contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const rclnodejs = require('../index.js');
+
+describe('QoS overriding options', function () {
+  let node;
+  this.timeout(60 * 1000);
+
+  before(function () {
+    return rclnodejs.init();
+  });
+
+  after(function () {
+    rclnodejs.shutdown();
+  });
+
+  beforeEach(function () {
+    node = rclnodejs.createNode('qos_override_test_node');
+  });
+
+  afterEach(function () {
+    node.destroy();
+  });
+
+  it('QoSPolicyKind enum has expected values', function () {
+    const { QoSPolicyKind } = rclnodejs;
+    assert.ok(QoSPolicyKind.HISTORY);
+    assert.ok(QoSPolicyKind.DEPTH);
+    assert.ok(QoSPolicyKind.RELIABILITY);
+    assert.ok(QoSPolicyKind.DURABILITY);
+    assert.ok(QoSPolicyKind.LIVELINESS);
+    assert.ok(QoSPolicyKind.AVOID_ROS_NAMESPACE_CONVENTIONS);
+  });
+
+  it('QoSOverridingOptions.withDefaultPolicies() creates correct policies', function () {
+    const opts = rclnodejs.QoSOverridingOptions.withDefaultPolicies();
+    assert.strictEqual(opts.policyKinds.length, 3);
+    assert.ok(opts.policyKinds.includes(rclnodejs.QoSPolicyKind.HISTORY));
+    assert.ok(opts.policyKinds.includes(rclnodejs.QoSPolicyKind.DEPTH));
+    assert.ok(opts.policyKinds.includes(rclnodejs.QoSPolicyKind.RELIABILITY));
+    assert.strictEqual(opts.callback, null);
+    assert.strictEqual(opts.entityId, null);
+  });
+
+  it('QoSOverridingOptions with custom policies and entityId', function () {
+    const opts = new rclnodejs.QoSOverridingOptions(
+      [rclnodejs.QoSPolicyKind.DURABILITY],
+      { entityId: 'sensor' }
+    );
+    assert.strictEqual(opts.policyKinds.length, 1);
+    assert.strictEqual(opts.entityId, 'sensor');
+  });
+
+  it('Publisher declares QoS override parameters', function () {
+    const pub = node.createPublisher('std_msgs/msg/String', 'test_pub_qos', {
+      qos: new rclnodejs.QoS(
+        rclnodejs.QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+        10,
+        rclnodejs.QoS.ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+        rclnodejs.QoS.DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE
+      ),
+      qosOverridingOptions:
+        rclnodejs.QoSOverridingOptions.withDefaultPolicies(),
+    });
+
+    const resolvedTopic = node.resolveTopicName('test_pub_qos');
+
+    // Check that parameters were declared
+    assert.ok(
+      node.hasParameter(`qos_overrides.${resolvedTopic}.publisher.history`)
+    );
+    assert.ok(
+      node.hasParameter(`qos_overrides.${resolvedTopic}.publisher.depth`)
+    );
+    assert.ok(
+      node.hasParameter(`qos_overrides.${resolvedTopic}.publisher.reliability`)
+    );
+
+    // Check parameter values match the QoS
+    const historyParam = node.getParameter(
+      `qos_overrides.${resolvedTopic}.publisher.history`
+    );
+    assert.strictEqual(historyParam.value, 'keep_last');
+
+    const depthParam = node.getParameter(
+      `qos_overrides.${resolvedTopic}.publisher.depth`
+    );
+    assert.strictEqual(Number(depthParam.value), 10);
+
+    const reliabilityParam = node.getParameter(
+      `qos_overrides.${resolvedTopic}.publisher.reliability`
+    );
+    assert.strictEqual(reliabilityParam.value, 'reliable');
+
+    node.destroyPublisher(pub);
+  });
+
+  it('Subscription declares QoS override parameters', function () {
+    const sub = node.createSubscription(
+      'std_msgs/msg/String',
+      'test_sub_qos',
+      {
+        qos: new rclnodejs.QoS(
+          rclnodejs.QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+          5,
+          rclnodejs.QoS.ReliabilityPolicy
+            .RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,
+          rclnodejs.QoS.DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE
+        ),
+        qosOverridingOptions:
+          rclnodejs.QoSOverridingOptions.withDefaultPolicies(),
+      },
+      () => {}
+    );
+
+    const resolvedTopic = node.resolveTopicName('test_sub_qos');
+
+    assert.ok(
+      node.hasParameter(`qos_overrides.${resolvedTopic}.subscription.depth`)
+    );
+
+    const depthParam = node.getParameter(
+      `qos_overrides.${resolvedTopic}.subscription.depth`
+    );
+    assert.strictEqual(Number(depthParam.value), 5);
+
+    const reliabilityParam = node.getParameter(
+      `qos_overrides.${resolvedTopic}.subscription.reliability`
+    );
+    assert.strictEqual(reliabilityParam.value, 'best_effort');
+
+    node.destroySubscription(sub);
+  });
+
+  it('Entity ID suffix in parameter names', function () {
+    const pub = node.createPublisher('std_msgs/msg/String', 'test_entity_id', {
+      qos: rclnodejs.QoS.profileDefault,
+      qosOverridingOptions: new rclnodejs.QoSOverridingOptions(
+        [rclnodejs.QoSPolicyKind.DEPTH],
+        { entityId: 'camera' }
+      ),
+    });
+
+    const resolvedTopic = node.resolveTopicName('test_entity_id');
+    assert.ok(
+      node.hasParameter(`qos_overrides.${resolvedTopic}.publisher_camera.depth`)
+    );
+
+    node.destroyPublisher(pub);
+  });
+
+  it('Validation callback rejects invalid QoS', function () {
+    assert.throws(() => {
+      node.createPublisher('std_msgs/msg/String', 'test_validate', {
+        qos: new rclnodejs.QoS(
+          rclnodejs.QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+          10
+        ),
+        qosOverridingOptions: new rclnodejs.QoSOverridingOptions(
+          [rclnodejs.QoSPolicyKind.DEPTH],
+          {
+            callback: () => ({
+              successful: false,
+              reason: 'Depth must be > 100',
+            }),
+          }
+        ),
+      });
+    }, /QoS override validation failed/);
+  });
+
+  it('Validation callback accepts valid QoS', function () {
+    const pub = node.createPublisher(
+      'std_msgs/msg/String',
+      'test_validate_ok',
+      {
+        qos: new rclnodejs.QoS(
+          rclnodejs.QoS.HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+          10
+        ),
+        qosOverridingOptions: new rclnodejs.QoSOverridingOptions(
+          [rclnodejs.QoSPolicyKind.DEPTH],
+          { callback: () => ({ successful: true }) }
+        ),
+      }
+    );
+
+    assert.ok(pub);
+    node.destroyPublisher(pub);
+  });
+
+  it('String QoS profiles are resolved before overriding', function () {
+    const pub = node.createPublisher('std_msgs/msg/String', 'test_string_qos', {
+      qos: rclnodejs.QoS.profileDefault,
+      qosOverridingOptions:
+        rclnodejs.QoSOverridingOptions.withDefaultPolicies(),
+    });
+
+    const resolvedTopic = node.resolveTopicName('test_string_qos');
+    assert.ok(
+      node.hasParameter(`qos_overrides.${resolvedTopic}.publisher.depth`)
+    );
+
+    node.destroyPublisher(pub);
+  });
+
+  it('No qosOverridingOptions means no parameters declared', function () {
+    const pub = node.createPublisher(
+      'std_msgs/msg/String',
+      'test_no_override',
+      {
+        qos: rclnodejs.QoS.profileDefault,
+      }
+    );
+
+    const resolvedTopic = node.resolveTopicName('test_no_override');
+    assert.ok(
+      !node.hasParameter(`qos_overrides.${resolvedTopic}.publisher.depth`)
+    );
+
+    node.destroyPublisher(pub);
+  });
+});

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -627,3 +627,35 @@ expectType<rclnodejs.action_msgs.srv.descriptor.CancelGoal_Request>(
 expectAssignable<'action_msgs/msg/GoalInfo'>(
   cancelGoalRequestDescriptor.goal_info
 );
+
+// ---- QoSOverridingOptions ----
+expectType<rclnodejs.QoSOverridingOptions>(
+  rclnodejs.QoSOverridingOptions.withDefaultPolicies()
+);
+expectType<rclnodejs.QoSOverridingOptions>(
+  new rclnodejs.QoSOverridingOptions([rclnodejs.QoSPolicyKind.DEPTH], {
+    entityId: 'camera',
+    callback: (_qos: rclnodejs.QoS) => ({ successful: true }),
+  })
+);
+
+// QoSOverridingOptions in createPublisher
+const pubWithOverrides = node.createPublisher(TYPE_CLASS, TOPIC, {
+  qos: rclnodejs.QoS.profileDefault,
+  qosOverridingOptions: rclnodejs.QoSOverridingOptions.withDefaultPolicies(),
+});
+
+// QoSOverridingOptions in createSubscription
+const subWithOverrides = node.createSubscription(
+  TYPE_CLASS,
+  TOPIC,
+  {
+    qos: new rclnodejs.QoS(),
+    qosOverridingOptions: new rclnodejs.QoSOverridingOptions([
+      rclnodejs.QoSPolicyKind.HISTORY,
+      rclnodejs.QoSPolicyKind.DEPTH,
+      rclnodejs.QoSPolicyKind.RELIABILITY,
+    ]),
+  },
+  (_msg: rclnodejs.std_msgs.msg.String) => {}
+);

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -80,6 +80,13 @@ declare module 'rclnodejs' {
      * inspect and limit messages that it accepts.
      */
     contentFilter?: SubscriptionContentFilter;
+
+    /**
+     * If provided, declares read-only ROS parameters for the specified QoS policies.
+     * These can be overridden at startup via `--ros-args -p` or `--params-file`.
+     * If qos is a profile string, it will be resolved to a mutable QoS object.
+     */
+    qosOverridingOptions?: QoSOverridingOptions;
   }
 
   /**

--- a/types/qos.d.ts
+++ b/types/qos.d.ts
@@ -134,4 +134,59 @@ declare module 'rclnodejs' {
       RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE = 5,
     }
   }
+
+  /**
+   * Enum of overridable QoS policy kinds.
+   */
+  enum QoSPolicyKind {
+    HISTORY = 1,
+    DEPTH = 2,
+    RELIABILITY = 3,
+    DURABILITY = 4,
+    LIVELINESS = 5,
+    AVOID_ROS_NAMESPACE_CONVENTIONS = 6,
+  }
+
+  /**
+   * Options for overriding QoS policies via ROS parameters.
+   *
+   * When passed to `createPublisher()` or `createSubscription()`, the node
+   * declares read-only parameters for each specified policy kind. These
+   * parameters can be overridden at startup via `--ros-args -p` or `--params-file`.
+   *
+   * Parameter naming convention:
+   *   `qos_overrides.<topic>.<publisher|subscription>[_<entityId>].<policy>`
+   */
+  class QoSOverridingOptions {
+    /**
+     * @param policyKinds - Which QoS policies to expose as parameters.
+     * @param opts - Optional callback and entityId.
+     */
+    constructor(
+      policyKinds: QoSPolicyKind[],
+      opts?: {
+        callback?: (qos: QoS) => { successful: boolean; reason?: string };
+        entityId?: string;
+      }
+    );
+
+    /** Which QoS policies are exposed as parameters. */
+    readonly policyKinds: QoSPolicyKind[];
+
+    /** Optional validation callback. */
+    readonly callback:
+      | ((qos: QoS) => { successful: boolean; reason?: string })
+      | null;
+
+    /** Optional entity disambiguation suffix. */
+    readonly entityId: string | null;
+
+    /**
+     * Create options that override history, depth, and reliability.
+     */
+    static withDefaultPolicies(opts?: {
+      callback?: (qos: QoS) => { successful: boolean; reason?: string };
+      entityId?: string;
+    }): QoSOverridingOptions;
+  }
 }


### PR DESCRIPTION
Allow QoS policies to be overridden at deployment time via ROS parameters, without changing source code. When `qosOverridingOptions` is passed to `createPublisher()` or `createSubscription()`, the node declares read-only parameters (e.g. `qos_overrides./chatter.subscription.depth`) whose values can be set at startup. Ported from rclpy's `QoSOverridingOptions` (rclpy/qos_overriding_options.py).

Usage with rclnodejs:
```bash
node my_app.js --ros-args -p "qos_overrides./chatter.subscription.depth:=1"
node my_app.js --ros-args --params-file qos.yaml
```
The `--ros-args` are received via `process.argv`, processed by `rclnodejs.init()`, and applied when `declareParameter()` finds matching overrides in `_parameterOverrides`.

**New: `lib/qos_overriding_options.js`** — `QoSPolicyKind` enum (HISTORY, DEPTH, RELIABILITY, DURABILITY, LIVELINESS, AVOID_ROS_NAMESPACE_CONVENTIONS), `QoSOverridingOptions` class with `withDefaultPolicies()` factory, `declareQosParameters()` engine that declares parameters per whitelisted policy and applies overrides to the QoS profile in-place, and enum↔string conversion helpers. Includes `_resolveQoS()` to convert string profile names to mutable QoS objects.

**Modified: `lib/node.js`** — `_createPublisher()` and `createSubscription()` check for `options.qosOverridingOptions`, resolve QoS profile strings, and call `declareQosParameters()` before creating the entity.

**Modified: `index.js`** — Exports `QoSPolicyKind` and `QoSOverridingOptions`.

**New: `test/test-qos-overriding-options.js`** — 11 tests: enum values, factory method, custom policies with entityId, publisher/subscription parameter declaration and value verification, entity ID suffix in parameter names, validation callback accept/reject, string QoS resolution, no-override baseline, and end-to-end parameter override proving the QoS object is mutated in-place.

Fix: #1467