### PR TITLE
Add pre-set and post-set parameter callbacks

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2059,22 +2059,25 @@ class Node extends rclnodejs.ShadowNode {
    * @return {SetParameterResult} - A single collective result.
    */
   _setParametersAtomically(parameters = [], declareParameterMode = false) {
-    // 1) PRE callbacks — can transform the parameter list
+    // 1) PRE callbacks — pipeline: each callback receives the output of the previous
     if (this._preSetParametersCallbacks.length > 0) {
-      let modified = [];
       for (const callback of this._preSetParametersCallbacks) {
         const result = callback(parameters);
-        if (Array.isArray(result)) {
-          modified.push(...result);
+        if (!Array.isArray(result)) {
+          return {
+            successful: false,
+            reason:
+              'pre-set parameters callback must return an array of Parameters',
+          };
         }
-      }
-      parameters = modified;
-      if (parameters.length === 0) {
-        return {
-          successful: false,
-          reason:
-            'parameter list is empty after pre-set callbacks; set rejected',
-        };
+        parameters = result;
+        if (parameters.length === 0) {
+          return {
+            successful: false,
+            reason:
+              'parameter list is empty after pre-set callback; set rejected',
+          };
+        }
       }
     }
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -161,7 +161,9 @@ class Node extends rclnodejs.ShadowNode {
     this._parameterService = null;
     this._typeDescriptionService = null;
     this._parameterEventPublisher = null;
+    this._preSetParametersCallbacks = [];
     this._setParametersCallbacks = [];
+    this._postSetParametersCallbacks = [];
     this._logger = new Logging(rclnodejs.getNodeLoggerName(this.handle));
     this._spinning = false;
     this._enableRosout = options.enableRosout;
@@ -2057,6 +2059,26 @@ class Node extends rclnodejs.ShadowNode {
    * @return {SetParameterResult} - A single collective result.
    */
   _setParametersAtomically(parameters = [], declareParameterMode = false) {
+    // 1) PRE callbacks — can transform the parameter list
+    if (this._preSetParametersCallbacks.length > 0) {
+      let modified = [];
+      for (const callback of this._preSetParametersCallbacks) {
+        const result = callback(parameters);
+        if (Array.isArray(result)) {
+          modified.push(...result);
+        }
+      }
+      parameters = modified;
+      if (parameters.length === 0) {
+        return {
+          successful: false,
+          reason:
+            'parameter list is empty after pre-set callbacks; set rejected',
+        };
+      }
+    }
+
+    // 2) Validate
     let result = this._validateParameters(parameters, declareParameterMode);
     if (!result.successful) {
       return result;
@@ -2126,6 +2148,11 @@ class Node extends rclnodejs.ShadowNode {
     // Publish ParameterEvent.
     this._parameterEventPublisher.publish(parameterEvent);
 
+    // POST callbacks — for side effects after successful set
+    for (const callback of this._postSetParametersCallbacks) {
+      callback(parameters);
+    }
+
     return {
       successful: true,
       reason: '',
@@ -2167,6 +2194,82 @@ class Node extends rclnodejs.ShadowNode {
     const idx = this._setParametersCallbacks.indexOf(callback);
     if (idx > -1) {
       this._setParametersCallbacks.splice(idx, 1);
+    }
+  }
+
+  /**
+   * A callback invoked before parameter validation and setting.
+   * It receives the parameter list and must return a (possibly modified) parameter list.
+   *
+   * @callback PreSetParametersCallback
+   * @param {Parameter[]} parameters - The parameters about to be set.
+   * @returns {Parameter[]} - The modified parameter list to proceed with.
+   *
+   * @see [Node.addPreSetParametersCallback]{@link Node#addPreSetParametersCallback}
+   * @see [Node.removePreSetParametersCallback]{@link Node#removePreSetParametersCallback}
+   */
+
+  /**
+   * Add a callback invoked before parameter validation.
+   * The callback receives the parameter list and must return a (possibly modified)
+   * parameter list. This can be used to coerce, add, or remove parameters before
+   * they are validated and applied. If any pre-set callback returns an empty list,
+   * the set is rejected.
+   *
+   * @param {PreSetParametersCallback} callback - The callback to add.
+   * @returns {undefined}
+   */
+  addPreSetParametersCallback(callback) {
+    this._preSetParametersCallbacks.unshift(callback);
+  }
+
+  /**
+   * Remove a pre-set parameters callback.
+   *
+   * @param {PreSetParametersCallback} callback - The callback to remove.
+   * @returns {undefined}
+   */
+  removePreSetParametersCallback(callback) {
+    const idx = this._preSetParametersCallbacks.indexOf(callback);
+    if (idx > -1) {
+      this._preSetParametersCallbacks.splice(idx, 1);
+    }
+  }
+
+  /**
+   * A callback invoked after parameters have been successfully set.
+   * It receives the final parameter list. For side effects only (return value is ignored).
+   *
+   * @callback PostSetParametersCallback
+   * @param {Parameter[]} parameters - The parameters that were set.
+   * @returns {undefined}
+   *
+   * @see [Node.addPostSetParametersCallback]{@link Node#addPostSetParametersCallback}
+   * @see [Node.removePostSetParametersCallback]{@link Node#removePostSetParametersCallback}
+   */
+
+  /**
+   * Add a callback invoked after parameters are successfully set.
+   * The callback receives the final parameter list. Useful for triggering
+   * side effects (e.g., reconfiguring a component when a parameter changes).
+   *
+   * @param {PostSetParametersCallback} callback - The callback to add.
+   * @returns {undefined}
+   */
+  addPostSetParametersCallback(callback) {
+    this._postSetParametersCallbacks.unshift(callback);
+  }
+
+  /**
+   * Remove a post-set parameters callback.
+   *
+   * @param {PostSetParametersCallback} callback - The callback to remove.
+   * @returns {undefined}
+   */
+  removePostSetParametersCallback(callback) {
+    const idx = this._postSetParametersCallbacks.indexOf(callback);
+    if (idx > -1) {
+      this._postSetParametersCallbacks.splice(idx, 1);
     }
   }
 

--- a/test/test-pre-post-param-callbacks.js
+++ b/test/test-pre-post-param-callbacks.js
@@ -1,0 +1,291 @@
+// Copyright (c) 2026 The Robot Web Tools Contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const rclnodejs = require('../index.js');
+
+describe('Pre/Post set parameters callbacks', function () {
+  let node;
+  this.timeout(60 * 1000);
+
+  before(function () {
+    return rclnodejs.init();
+  });
+
+  after(function () {
+    rclnodejs.shutdown();
+  });
+
+  beforeEach(function () {
+    node = rclnodejs.createNode('pre_post_param_test_node');
+    node.declareParameter(
+      new rclnodejs.Parameter(
+        'test_param',
+        rclnodejs.ParameterType.PARAMETER_INTEGER,
+        10
+      )
+    );
+  });
+
+  afterEach(function () {
+    node.destroy();
+  });
+
+  describe('PreSetParametersCallback', function () {
+    it('pre-set callback can modify parameter values', function () {
+      // Coerce: double any integer value before it's set
+      const preCallback = (params) =>
+        params.map(
+          (p) => new rclnodejs.Parameter(p.name, p.type, Number(p.value) * 2)
+        );
+
+      node.addPreSetParametersCallback(preCallback);
+      node.setParameter(
+        new rclnodejs.Parameter(
+          'test_param',
+          rclnodejs.ParameterType.PARAMETER_INTEGER,
+          5
+        )
+      );
+
+      const param = node.getParameter('test_param');
+      assert.strictEqual(Number(param.value), 10); // 5 * 2 = 10
+    });
+
+    it('pre-set callback returning empty list rejects the set', function () {
+      node.addPreSetParametersCallback(() => []);
+
+      const result = node.setParameter(
+        new rclnodejs.Parameter(
+          'test_param',
+          rclnodejs.ParameterType.PARAMETER_INTEGER,
+          99
+        )
+      );
+
+      assert.strictEqual(result.successful, false);
+      assert.ok(result.reason.includes('empty'));
+
+      // Value should remain unchanged
+      const param = node.getParameter('test_param');
+      assert.strictEqual(Number(param.value), 10);
+    });
+
+    it('multiple pre-set callbacks all contribute to the list', function () {
+      let callOrder = [];
+      node.addPreSetParametersCallback((params) => {
+        callOrder.push('first');
+        return params;
+      });
+      node.addPreSetParametersCallback((params) => {
+        callOrder.push('second');
+        return params;
+      });
+
+      node.setParameter(
+        new rclnodejs.Parameter(
+          'test_param',
+          rclnodejs.ParameterType.PARAMETER_INTEGER,
+          42
+        )
+      );
+
+      // Newest callback runs first (LIFO via unshift)
+      assert.deepStrictEqual(callOrder, ['second', 'first']);
+    });
+
+    it('removePreSetParametersCallback removes the callback', function () {
+      const preCallback = () => [];
+      node.addPreSetParametersCallback(preCallback);
+      node.removePreSetParametersCallback(preCallback);
+
+      const result = node.setParameter(
+        new rclnodejs.Parameter(
+          'test_param',
+          rclnodejs.ParameterType.PARAMETER_INTEGER,
+          42
+        )
+      );
+
+      assert.strictEqual(result.successful, true);
+      assert.strictEqual(Number(node.getParameter('test_param').value), 42);
+    });
+  });
+
+  describe('PostSetParametersCallback', function () {
+    it('post-set callback is called after successful set', function () {
+      let postCalled = false;
+      let receivedParams = null;
+
+      node.addPostSetParametersCallback((params) => {
+        postCalled = true;
+        receivedParams = params;
+      });
+
+      node.setParameter(
+        new rclnodejs.Parameter(
+          'test_param',
+          rclnodejs.ParameterType.PARAMETER_INTEGER,
+          42
+        )
+      );
+
+      assert.ok(postCalled);
+      assert.strictEqual(receivedParams.length, 1);
+      assert.strictEqual(receivedParams[0].name, 'test_param');
+      assert.strictEqual(Number(receivedParams[0].value), 42);
+    });
+
+    it('post-set callback is NOT called when on-set rejects', function () {
+      let postCalled = false;
+
+      node.addOnSetParametersCallback(() => ({
+        successful: false,
+        reason: 'rejected',
+      }));
+      node.addPostSetParametersCallback(() => {
+        postCalled = true;
+      });
+
+      node.setParameter(
+        new rclnodejs.Parameter(
+          'test_param',
+          rclnodejs.ParameterType.PARAMETER_INTEGER,
+          99
+        )
+      );
+
+      assert.strictEqual(postCalled, false);
+    });
+
+    it('multiple post-set callbacks all run', function () {
+      let callOrder = [];
+      node.addPostSetParametersCallback(() => callOrder.push('first'));
+      node.addPostSetParametersCallback(() => callOrder.push('second'));
+
+      node.setParameter(
+        new rclnodejs.Parameter(
+          'test_param',
+          rclnodejs.ParameterType.PARAMETER_INTEGER,
+          42
+        )
+      );
+
+      // LIFO order
+      assert.deepStrictEqual(callOrder, ['second', 'first']);
+    });
+
+    it('removePostSetParametersCallback removes the callback', function () {
+      let postCalled = false;
+      const postCallback = () => {
+        postCalled = true;
+      };
+
+      node.addPostSetParametersCallback(postCallback);
+      node.removePostSetParametersCallback(postCallback);
+
+      node.setParameter(
+        new rclnodejs.Parameter(
+          'test_param',
+          rclnodejs.ParameterType.PARAMETER_INTEGER,
+          42
+        )
+      );
+
+      assert.strictEqual(postCalled, false);
+    });
+  });
+
+  describe('Full callback chain', function () {
+    it('pre → on → post runs in order', function () {
+      let callOrder = [];
+
+      node.addPreSetParametersCallback((params) => {
+        callOrder.push('pre');
+        return params;
+      });
+      node.addOnSetParametersCallback((params) => {
+        callOrder.push('on');
+        return { successful: true };
+      });
+      node.addPostSetParametersCallback(() => {
+        callOrder.push('post');
+      });
+
+      node.setParameter(
+        new rclnodejs.Parameter(
+          'test_param',
+          rclnodejs.ParameterType.PARAMETER_INTEGER,
+          42
+        )
+      );
+
+      assert.deepStrictEqual(callOrder, ['pre', 'on', 'post']);
+    });
+
+    it('pre rejection stops on and post from running', function () {
+      let callOrder = [];
+
+      node.addPreSetParametersCallback(() => {
+        callOrder.push('pre');
+        return []; // reject
+      });
+      node.addOnSetParametersCallback(() => {
+        callOrder.push('on');
+        return { successful: true };
+      });
+      node.addPostSetParametersCallback(() => {
+        callOrder.push('post');
+      });
+
+      node.setParameter(
+        new rclnodejs.Parameter(
+          'test_param',
+          rclnodejs.ParameterType.PARAMETER_INTEGER,
+          42
+        )
+      );
+
+      assert.deepStrictEqual(callOrder, ['pre']);
+    });
+
+    it('on rejection stops post from running', function () {
+      let callOrder = [];
+
+      node.addPreSetParametersCallback((params) => {
+        callOrder.push('pre');
+        return params;
+      });
+      node.addOnSetParametersCallback(() => {
+        callOrder.push('on');
+        return { successful: false, reason: 'nope' };
+      });
+      node.addPostSetParametersCallback(() => {
+        callOrder.push('post');
+      });
+
+      node.setParameter(
+        new rclnodejs.Parameter(
+          'test_param',
+          rclnodejs.ParameterType.PARAMETER_INTEGER,
+          42
+        )
+      );
+
+      assert.deepStrictEqual(callOrder, ['pre', 'on']);
+    });
+  });
+});

--- a/test/test-pre-post-param-callbacks.js
+++ b/test/test-pre-post-param-callbacks.js
@@ -84,27 +84,39 @@ describe('Pre/Post set parameters callbacks', function () {
       assert.strictEqual(Number(param.value), 10);
     });
 
-    it('multiple pre-set callbacks all contribute to the list', function () {
+    it('multiple pre-set callbacks chain as a pipeline', function () {
       let callOrder = [];
+
+      // First registered: multiply value by 3
       node.addPreSetParametersCallback((params) => {
         callOrder.push('first');
-        return params;
+        return params.map(
+          (p) => new rclnodejs.Parameter(p.name, p.type, Number(p.value) * 3)
+        );
       });
+
+      // Second registered (runs first due to LIFO): add 1 to value
       node.addPreSetParametersCallback((params) => {
         callOrder.push('second');
-        return params;
+        return params.map(
+          (p) => new rclnodejs.Parameter(p.name, p.type, Number(p.value) + 1)
+        );
       });
 
       node.setParameter(
         new rclnodejs.Parameter(
           'test_param',
           rclnodejs.ParameterType.PARAMETER_INTEGER,
-          42
+          5
         )
       );
 
-      // Newest callback runs first (LIFO via unshift)
+      // LIFO order: second runs first, then first
       assert.deepStrictEqual(callOrder, ['second', 'first']);
+
+      // Pipeline: input=5 → second: 5+1=6 → first: 6*3=18
+      const param = node.getParameter('test_param');
+      assert.strictEqual(Number(param.value), 18);
     });
 
     it('removePreSetParametersCallback removes the callback', function () {

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -659,3 +659,16 @@ const subWithOverrides = node.createSubscription(
   },
   (_msg: rclnodejs.std_msgs.msg.String) => {}
 );
+
+// ---- Pre/Post Set Parameters Callbacks ----
+const preCallback: rclnodejs.PreSetParametersCallback = (
+  _params: rclnodejs.Parameter[]
+) => _params;
+const postCallback: rclnodejs.PostSetParametersCallback = (
+  _params: rclnodejs.Parameter[]
+) => {};
+
+node.addPreSetParametersCallback(preCallback);
+node.removePreSetParametersCallback(preCallback);
+node.addPostSetParametersCallback(postCallback);
+node.removePostSetParametersCallback(postCallback);

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -131,6 +131,19 @@ declare module 'rclnodejs' {
   ) => rcl_interfaces.msg.SetParametersResult;
 
   /**
+   * Callback invoked before parameter validation and setting.
+   * Receives the parameter list, must return a (possibly modified) parameter list.
+   * Returning an empty list rejects the set.
+   */
+  type PreSetParametersCallback = (parameters: Parameter[]) => Parameter[];
+
+  /**
+   * Callback invoked after parameters have been successfully set.
+   * For side effects only (return value is ignored).
+   */
+  type PostSetParametersCallback = (parameters: Parameter[]) => void;
+
+  /**
    * Standard result of Node.getXXXNamesAndTypes() queries
    *
    * @example
@@ -755,6 +768,37 @@ declare module 'rclnodejs' {
      * @param callback - The callback to be removed
      */
     removeOnSetParametersCallback(call: SetParametersCallback): void;
+
+    /**
+     * Add a callback invoked before parameter validation.
+     * The callback receives the parameter list and must return a (possibly modified)
+     * parameter list. Returning an empty list rejects the set.
+     *
+     * @param callback - The callback to add.
+     */
+    addPreSetParametersCallback(callback: PreSetParametersCallback): void;
+
+    /**
+     * Remove a pre-set parameters callback.
+     *
+     * @param callback - The callback to remove.
+     */
+    removePreSetParametersCallback(callback: PreSetParametersCallback): void;
+
+    /**
+     * Add a callback invoked after parameters are successfully set.
+     * Useful for triggering side effects (e.g., reconfiguring a component).
+     *
+     * @param callback - The callback to add.
+     */
+    addPostSetParametersCallback(callback: PostSetParametersCallback): void;
+
+    /**
+     * Remove a post-set parameters callback.
+     *
+     * @param callback - The callback to remove.
+     */
+    removePostSetParametersCallback(callback: PostSetParametersCallback): void;
 
     /**
      * Get a remote node's published topics.


### PR DESCRIPTION
Add `addPreSetParametersCallback()` / `removePreSetParametersCallback()` and `addPostSetParametersCallback()` / `removePostSetParametersCallback()` to the Node class. Pre-set callbacks run before validation and can transform the parameter list (e.g. coerce values); returning an empty list rejects the set. Post-set callbacks run after parameters are successfully applied, for side effects (e.g. reconfiguring a component). Both follow LIFO ordering (newest callback runs first), matching rclpy's `add_pre_set_parameters_callback` / `add_post_set_parameters_callback` behavior.

**Modified: `lib/node.js`** — Added `_preSetParametersCallbacks` and `_postSetParametersCallbacks` arrays. Modified `_setParametersAtomically()` to invoke pre callbacks before validation (merging all returned lists, rejecting on empty) and post callbacks after successful set and ParameterEvent publishing. Added 4 new public methods with JSDoc.

**Modified: `types/node.d.ts`** — Added `PreSetParametersCallback` and `PostSetParametersCallback` type aliases, and all 4 new methods to the Node interface.

**New: `test/test-pre-post-param-callbacks.js`** — 11 tests covering pre (value modification, empty-list rejection, LIFO ordering, removal), post (called on success, skipped on rejection, LIFO ordering, removal), and full chain (pre→on→post order, pre rejection stops chain, on rejection stops post).

Fix : #1469