### PR TITLE
Add ParameterEventHandler node filtering support

### DIFF
--- a/lib/parameter_event_handler.js
+++ b/lib/parameter_event_handler.js
@@ -16,6 +16,7 @@
 
 const { TypeValidationError, OperationError } = require('./errors');
 const { normalizeNodeName } = require('./utils');
+const validator = require('./validator');
 const debug = require('debug')('rclnodejs:parameter_event_handler');
 
 const PARAMETER_EVENT_MSG_TYPE = 'rcl_interfaces/msg/ParameterEvent';
@@ -251,7 +252,10 @@ class ParameterEventHandler {
           }
         );
       }
-      return this.#resolvePath(nodeName.trim());
+
+      const resolvedNodeName = this.#resolvePath(nodeName.trim());
+      this.#validateFullyQualifiedNodePath(resolvedNodeName);
+      return resolvedNodeName;
     });
 
     const contentFilter = {
@@ -510,10 +514,6 @@ class ParameterEventHandler {
    * @private
    */
   #resolvePath(nodePath) {
-    if (!nodePath) {
-      return this.#node.getFullyQualifiedName();
-    }
-
     if (nodePath.startsWith('/')) {
       return nodePath;
     }
@@ -521,6 +521,22 @@ class ParameterEventHandler {
     const nodeNamespace = this.#node.namespace().replace(/\/+$/, '');
     const resolvedPath = `${nodeNamespace}/${nodePath}`.replace(/\/+/g, '/');
     return resolvedPath.startsWith('/') ? resolvedPath : `/${resolvedPath}`;
+  }
+
+  /**
+   * Validate a fully qualified node path before using it in a content filter.
+   * @private
+   */
+  #validateFullyQualifiedNodePath(nodePath) {
+    const normalizedPath =
+      nodePath.length > 1 ? nodePath.replace(/\/+$/, '') : nodePath;
+    const separatorIndex = normalizedPath.lastIndexOf('/');
+    const nodeNamespace =
+      separatorIndex === 0 ? '/' : normalizedPath.slice(0, separatorIndex);
+    const nodeName = normalizedPath.slice(separatorIndex + 1);
+
+    validator.validateNamespace(nodeNamespace);
+    validator.validateNodeName(nodeName);
   }
 
   /**

--- a/lib/parameter_event_handler.js
+++ b/lib/parameter_event_handler.js
@@ -211,6 +211,61 @@ class ParameterEventHandler {
   }
 
   /**
+   * Configure which node parameter events will be received.
+   *
+   * If nodeNames is omitted or empty, the current node filter is cleared.
+   * When a filter is active, parameter and event callbacks only receive
+   * events from the specified nodes.
+   *
+   * @param {string[]} [nodeNames] - Node names to filter parameter events from.
+   *   Relative names are resolved against the handler node namespace.
+   * @returns {boolean} True if the filter is active or was successfully cleared.
+   */
+  configureNodesFilter(nodeNames) {
+    this.#checkNotDestroyed();
+
+    if (nodeNames === undefined || nodeNames === null) {
+      this.#subscription.clearContentFilter();
+      return !this.#subscription.hasContentFilter();
+    }
+
+    if (!Array.isArray(nodeNames)) {
+      throw new TypeValidationError('nodeNames', nodeNames, 'string[]', {
+        entityType: 'parameter event handler',
+      });
+    }
+
+    if (nodeNames.length === 0) {
+      this.#subscription.clearContentFilter();
+      return !this.#subscription.hasContentFilter();
+    }
+
+    const resolvedNodeNames = nodeNames.map((nodeName, index) => {
+      if (typeof nodeName !== 'string' || nodeName.trim() === '') {
+        throw new TypeValidationError(
+          `nodeNames[${index}]`,
+          nodeName,
+          'non-empty string',
+          {
+            entityType: 'parameter event handler',
+          }
+        );
+      }
+      return this.#resolvePath(nodeName.trim());
+    });
+
+    const contentFilter = {
+      expression: resolvedNodeNames
+        .map((_, index) => `node = %${index}`)
+        .join(' OR '),
+      parameters: resolvedNodeNames.map((nodeName) => `'${nodeName}'`),
+    };
+
+    this.#subscription.setContentFilter(contentFilter);
+    return this.#subscription.hasContentFilter();
+  }
+
+  /**
    * Remove a previously added parameter callback.
    *
    * @param {ParameterCallbackHandle} handle - The handle returned by addParameterCallback
@@ -448,6 +503,24 @@ class ParameterEventHandler {
    */
   #makeKey(paramName, nodeName) {
     return `${paramName}\0${nodeName}`;
+  }
+
+  /**
+   * Resolve a node path to the fully qualified name used in ParameterEvent.node.
+   * @private
+   */
+  #resolvePath(nodePath) {
+    if (!nodePath) {
+      return this.#node.getFullyQualifiedName();
+    }
+
+    if (nodePath.startsWith('/')) {
+      return nodePath;
+    }
+
+    const nodeNamespace = this.#node.namespace().replace(/\/+$/, '');
+    const resolvedPath = `${nodeNamespace}/${nodePath}`.replace(/\/+/g, '/');
+    return resolvedPath.startsWith('/') ? resolvedPath : `/${resolvedPath}`;
   }
 
   /**

--- a/lib/parameter_event_handler.js
+++ b/lib/parameter_event_handler.js
@@ -514,13 +514,22 @@ class ParameterEventHandler {
    * @private
    */
   #resolvePath(nodePath) {
-    if (nodePath.startsWith('/')) {
-      return nodePath;
+    // Absolute node paths are already rooted. Relative names are resolved
+    // against the handler node namespace before building the content filter.
+    const unresolvedPath = nodePath.startsWith('/')
+      ? nodePath
+      : `${this.#node.namespace().replace(/\/+$/, '')}/${nodePath}`;
+
+    // Collapse repeated separators for inputs like '/ns//node/' or 'nested//node'.
+    const resolvedPath = unresolvedPath.replace(/\/+/g, '/');
+
+    // Preserve the root namespace as '/' and strip trailing slashes everywhere
+    // else so the filter matches the canonical ParameterEvent.node format.
+    if (resolvedPath === '/') {
+      return resolvedPath;
     }
 
-    const nodeNamespace = this.#node.namespace().replace(/\/+$/, '');
-    const resolvedPath = `${nodeNamespace}/${nodePath}`.replace(/\/+/g, '/');
-    return resolvedPath.startsWith('/') ? resolvedPath : `/${resolvedPath}`;
+    return resolvedPath.replace(/\/+$/, '');
   }
 
   /**

--- a/test/test-parameter-event-handler.js
+++ b/test/test-parameter-event-handler.js
@@ -418,6 +418,12 @@ describe('ParameterEventHandler tests', function () {
       assert.throws(() => {
         handler.configureNodesFilter([1]);
       });
+      assert.throws(() => {
+        handler.configureNodesFilter(["bad'node"]);
+      });
+      assert.throws(() => {
+        handler.configureNodesFilter(['/invalid_node?']);
+      });
     });
   });
 

--- a/test/test-parameter-event-handler.js
+++ b/test/test-parameter-event-handler.js
@@ -360,6 +360,34 @@ describe('ParameterEventHandler tests', function () {
       });
     });
 
+    it('should normalize repeated and trailing slashes in node names', function () {
+      let lastFilter;
+      const subscription = {
+        setContentFilter: (filter) => {
+          lastFilter = filter;
+          return true;
+        },
+        clearContentFilter: () => true,
+        hasContentFilter: () => true,
+      };
+
+      handler = new rclnodejs.ParameterEventHandler(
+        createFakeHandlerNode(subscription)
+      );
+
+      assert.strictEqual(
+        handler.configureNodesFilter([
+          '/test_ns//remote_node/',
+          'nested//node/',
+        ]),
+        true
+      );
+      assert.deepStrictEqual(lastFilter, {
+        expression: 'node = %0 OR node = %1',
+        parameters: ["'/test_ns/remote_node'", "'/test_ns/nested/node'"],
+      });
+    });
+
     it('should clear the content filter when nodeNames is omitted', function () {
       let hasFilter = true;
       const subscription = {

--- a/test/test-parameter-event-handler.js
+++ b/test/test-parameter-event-handler.js
@@ -17,6 +17,16 @@
 const assert = require('assert');
 const rclnodejs = require('../index.js');
 
+function createFakeHandlerNode(subscription) {
+  return {
+    createSubscription: () => subscription,
+    destroySubscription: () => {},
+    getFullyQualifiedName: () => '/test_ns/peh_handler_node',
+    name: () => 'peh_handler_node',
+    namespace: () => '/test_ns',
+  };
+}
+
 describe('ParameterEventHandler tests', function () {
   this.timeout(60 * 1000);
 
@@ -293,6 +303,120 @@ describe('ParameterEventHandler tests', function () {
 
       assert.throws(() => {
         handler.removeParameterEventCallback(handle);
+      });
+    });
+  });
+
+  describe('configureNodesFilter', function () {
+    it('should apply a content filter for absolute node names', function () {
+      let hasFilter = false;
+      let lastFilter;
+      const subscription = {
+        setContentFilter: (filter) => {
+          lastFilter = filter;
+          hasFilter = true;
+          return true;
+        },
+        clearContentFilter: () => {
+          hasFilter = false;
+          return true;
+        },
+        hasContentFilter: () => hasFilter,
+      };
+
+      handler = new rclnodejs.ParameterEventHandler(
+        createFakeHandlerNode(subscription)
+      );
+
+      assert.strictEqual(
+        handler.configureNodesFilter(['/remote_node_1', '/remote_node_2']),
+        true
+      );
+      assert.deepStrictEqual(lastFilter, {
+        expression: 'node = %0 OR node = %1',
+        parameters: ["'/remote_node_1'", "'/remote_node_2'"],
+      });
+    });
+
+    it('should resolve relative node names against the handler namespace', function () {
+      let lastFilter;
+      const subscription = {
+        setContentFilter: (filter) => {
+          lastFilter = filter;
+          return true;
+        },
+        clearContentFilter: () => true,
+        hasContentFilter: () => true,
+      };
+
+      handler = new rclnodejs.ParameterEventHandler(
+        createFakeHandlerNode(subscription)
+      );
+
+      assert.strictEqual(handler.configureNodesFilter(['remote_node']), true);
+      assert.deepStrictEqual(lastFilter, {
+        expression: 'node = %0',
+        parameters: ["'/test_ns/remote_node'"],
+      });
+    });
+
+    it('should clear the content filter when nodeNames is omitted', function () {
+      let hasFilter = true;
+      const subscription = {
+        setContentFilter: () => true,
+        clearContentFilter: () => {
+          hasFilter = false;
+          return true;
+        },
+        hasContentFilter: () => hasFilter,
+      };
+
+      handler = new rclnodejs.ParameterEventHandler(
+        createFakeHandlerNode(subscription)
+      );
+
+      assert.strictEqual(handler.configureNodesFilter(), true);
+      assert.strictEqual(hasFilter, false);
+    });
+
+    it('should clear the content filter when nodeNames is empty', function () {
+      let hasFilter = true;
+      const subscription = {
+        setContentFilter: () => true,
+        clearContentFilter: () => {
+          hasFilter = false;
+          return true;
+        },
+        hasContentFilter: () => hasFilter,
+      };
+
+      handler = new rclnodejs.ParameterEventHandler(
+        createFakeHandlerNode(subscription)
+      );
+
+      assert.strictEqual(handler.configureNodesFilter([]), true);
+      assert.strictEqual(hasFilter, false);
+    });
+
+    it('should throw for invalid nodeNames', function () {
+      const subscription = {
+        setContentFilter: () => true,
+        clearContentFilter: () => true,
+        hasContentFilter: () => false,
+      };
+
+      handler = new rclnodejs.ParameterEventHandler(
+        createFakeHandlerNode(subscription)
+      );
+
+      assert.throws(() => {
+        handler.configureNodesFilter('not-an-array');
+      });
+      assert.throws(() => {
+        handler.configureNodesFilter(['']);
+      });
+      assert.throws(() => {
+        handler.configureNodesFilter([1]);
       });
     });
   });

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -111,6 +111,28 @@ expectType<rclnodejs.Options<string | rclnodejs.QoS>>(
 );
 expectType<string>(node.getFullyQualifiedName());
 expectType<string>(node.getRMWImplementationIdentifier());
+const parameterEventHandler = node.createParameterEventHandler();
+expectType<rclnodejs.ParameterEventHandler>(parameterEventHandler);
+expectType<boolean>(parameterEventHandler.configureNodesFilter());
+expectType<boolean>(parameterEventHandler.configureNodesFilter(['/test_node']));
+
+const parameterCallbackHandle = parameterEventHandler.addParameterCallback(
+  'test_param',
+  '/test_node',
+  (parameter: any) => {
+    const receivedParameter = parameter;
+  }
+);
+expectType<rclnodejs.ParameterCallbackHandle>(parameterCallbackHandle);
+
+const parameterEventCallbackHandle =
+  parameterEventHandler.addParameterEventCallback((event: any) => {
+    const receivedEvent = event;
+  });
+expectType<rclnodejs.ParameterEventCallbackHandle>(
+  parameterEventCallbackHandle
+);
+
 const nodeWithArgs = rclnodejs.createNode(
   NODE_NAME,
   'topic',

--- a/types/parameter_event_handler.d.ts
+++ b/types/parameter_event_handler.d.ts
@@ -98,6 +98,17 @@ declare module 'rclnodejs' {
     ): ParameterEventCallbackHandle;
 
     /**
+     * Configure which node parameter events will be received.
+     *
+     * If nodeNames is omitted or empty, the node filter is cleared.
+     * Relative names are resolved against the handler node namespace.
+     *
+     * @param nodeNames - Node names to filter parameter events from.
+     * @returns True if the filter is active or was successfully cleared.
+     */
+    configureNodesFilter(nodeNames?: string[]): boolean;
+
+    /**
      * Remove a previously added parameter event callback.
      *
      * @param handle - The handle returned by addParameterEventCallback.


### PR DESCRIPTION
- add `ParameterEventHandler.configureNodesFilter(nodeNames?)` to apply or clear `/parameter_events` subscription content filters for selected nodes
- resolve relative node names against the handler node namespace
- reuse `Node.getFullyQualifiedName()` for handler node fully qualified name resolution instead of duplicating that logic
- add TypeScript declarations for `configureNodesFilter()`
- add focused `ParameterEventHandler` tests for:
  - absolute node filters
  - relative node name resolution
  - clearing filters when `nodeNames` is omitted
  - clearing filters when `nodeNames` is empty
  - invalid `nodeNames` validation

Testing:
- `npx mocha test/test-parameter-event-handler.js`
- `npx tsd`

Fix: #1473 