### PR TITLE
Gate C++ Standard By ROS Distro

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,7 +12,6 @@
     'runtime%': 'node',
     'ros_lib_dir': "<!(node -p \"require('./scripts/config.js').getROSLibPath()\")",
     'ros_include_root': "<!(node -p \"require('./scripts/config.js').getROSIncludeRootPath()\")",
-    'node_major_version': '<!(node -p \"process.versions.node.split(\'.\')[0]\")',
   },
   'targets': [
     {
@@ -85,14 +84,15 @@
             ],
             'conditions': [
               [
-                'node_major_version >= 23', {
+                # Post-Kilted ROS distros require C++20.
+                'ros_version > 2505', {
                   'cflags_cc': [
                     '-std=c++20'
                   ]
                 }
               ],
               [
-                'node_major_version < 23', {
+                'ros_version <= 2505', {
                   'cflags_cc': [
                     '-std=c++17'
                   ]
@@ -108,14 +108,15 @@
             ],
             'conditions': [
               [
-                'node_major_version >= 23', {
+                # Post-Kilted ROS distros require C++20.
+                'ros_version > 2505', {
                   'cflags_cc': [
                     '-std=c++20'
                   ]
                 }
               ],
               [
-                'node_major_version < 23', {
+                'ros_version <= 2505', {
                   'cflags_cc': [
                     '-std=c++17'
                   ]

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -20,6 +20,15 @@ I install Nodejs from either:
 - Node.js official [website](https://nodejs.org/en/)
 - Node Version Manager ([nvm](https://github.com/creationix/nvm))
 
+### C++ Toolchain Requirements
+
+The native addon follows the ROS 2 distro toolchain requirement:
+
+- Humble, Jazzy, and Kilted build with C++17.
+- Post-Kilted distros, including Lyrical and newer Rolling snapshots, build with C++20.
+
+If no prebuilt binary is available for your target, make sure your local compiler matches the required C++ standard before running `npm install`.
+
 ### Get Code
 
 Open a terminal, and input:


### PR DESCRIPTION
- build: switch native addon C++ standard selection from Node.js-major gating to ROS-distro gating
  - remove `node_major_version` from `binding.gyp`
  - use C++17 for `ros_version <= 2505`
  - use C++20 for `ros_version > 2505`
  - apply the same rule on both Linux and Windows build paths

- docs(build): document source-build C++ toolchain requirements
  - add a `C++ Toolchain Requirements` section to `docs/BUILDING.md`
  - state that Humble, Jazzy, and Kilted build with C++17
  - state that post-Kilted distros, including Lyrical and newer Rolling snapshots, build with C++20

**Reference**:
- https://discourse.openrobotics.org/t/ros-2-lyrical-c-version/52551

Fix: #1458