### PR TITLE
Remove compatibility and custom utility code

### DIFF
--- a/lib/action/uuid.js
+++ b/lib/action/uuid.js
@@ -40,7 +40,7 @@ class ActionUuid {
       this._bytes = bytes;
     } else {
       // Generate random UUID.
-      let uuid = randomUUID().replace(/-/g, '');
+      let uuid = randomUUID().replaceAll('-', '');
       this._bytes = Uint8Array.from(Buffer.from(uuid, 'hex'));
     }
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -25,51 +25,6 @@ const {
 const { assertValidMessage } = require('./message_validation.js');
 const debug = require('debug')('rclnodejs:client');
 
-// Polyfill for AbortSignal.any() for Node.js <= 20.3.0
-// AbortSignal.any() was added in Node.js 20.3.0
-// See https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static
-if (!AbortSignal.any) {
-  AbortSignal.any = function (signals) {
-    // Filter out null/undefined values and validate inputs
-    const validSignals = Array.isArray(signals)
-      ? signals.filter((signal) => signal != null)
-      : [];
-
-    // If no valid signals, return a never-aborting signal
-    if (validSignals.length === 0) {
-      return new AbortController().signal;
-    }
-
-    const controller = new AbortController();
-    const listeners = [];
-
-    // Cleanup function to remove all event listeners
-    const cleanup = () => {
-      listeners.forEach(({ signal, listener }) => {
-        signal.removeEventListener('abort', listener);
-      });
-    };
-
-    for (const signal of validSignals) {
-      if (signal.aborted) {
-        cleanup();
-        controller.abort(signal.reason);
-        return controller.signal;
-      }
-
-      const listener = () => {
-        cleanup();
-        controller.abort(signal.reason);
-      };
-
-      signal.addEventListener('abort', listener);
-      listeners.push({ signal, listener });
-    }
-
-    return controller.signal;
-  };
-}
-
 /**
  * @class - Class representing a Client in ROS
  * @hideconstructor

--- a/lib/interface_loader.js
+++ b/lib/interface_loader.js
@@ -57,7 +57,7 @@ let interfaceLoader = {
     }
 
     // TODO(Kenny): more checks of the string argument
-    if (name.indexOf('/') !== -1) {
+    if (name.includes('/')) {
       let [packageName, type, messageName] = name.split('/');
       return this.loadInterface(packageName, type, messageName);
     }

--- a/lib/message_introspector.js
+++ b/lib/message_introspector.js
@@ -88,35 +88,7 @@ class MessageIntrospector {
       const instance = new this.#typeClass();
       this.#defaultsCache = toPlainObject(instance);
     }
-    return this.#deepClone(this.#defaultsCache);
-  }
-
-  /**
-   * Deep clone an object.
-   * @param {any} obj - Object to clone
-   * @returns {any} Cloned object
-   * @private
-   */
-  #deepClone(obj) {
-    if (obj === null || typeof obj !== 'object') {
-      return obj;
-    }
-
-    if (Array.isArray(obj)) {
-      return obj.map((item) => this.#deepClone(item));
-    }
-
-    if (ArrayBuffer.isView(obj) && !(obj instanceof DataView)) {
-      return obj.slice();
-    }
-
-    const cloned = {};
-    for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        cloned[key] = this.#deepClone(obj[key]);
-      }
-    }
-    return cloned;
+    return structuredClone(this.#defaultsCache);
   }
 }
 

--- a/lib/message_serialization.js
+++ b/lib/message_serialization.js
@@ -62,7 +62,7 @@ function toPlainArrays(obj) {
   if (typeof obj === 'object' && obj !== null) {
     const result = {};
     for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      if (Object.hasOwn(obj, key)) {
         result[key] = toPlainArrays(obj[key]);
       }
     }
@@ -105,7 +105,7 @@ function toJSONSafe(obj) {
   if (typeof obj === 'object' && obj !== null) {
     const result = {};
     for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      if (Object.hasOwn(obj, key)) {
         result[key] = toJSONSafe(obj[key]);
       }
     }

--- a/rosidl_gen/packages.js
+++ b/rosidl_gen/packages.js
@@ -61,7 +61,7 @@ function getSubFolder(filePath, amentExecuted) {
   }
   // If the |amentExecuted| equals to false, the file's extension will be assigned as
   // the name of sub folder.
-  return path.parse(filePath).ext.substr(1);
+  return path.parse(filePath).ext.substring(1);
 }
 
 function grabInterfaceInfo(filePath, amentExecuted) {

--- a/rosidl_gen/packages.js
+++ b/rosidl_gen/packages.js
@@ -29,7 +29,7 @@ const serviceMsgPath = path.join(generatedRoot, 'srv_msg');
 
 function getPackageName(filePath, amentExecuted) {
   if (os.type() === 'Windows_NT') {
-    filePath = filePath.replace(/\\/g, '/');
+    filePath = filePath.replaceAll('\\', '/');
   }
 
   if (amentExecuted) {
@@ -41,14 +41,14 @@ function getPackageName(filePath, amentExecuted) {
 
   // If |packageName| equals to the file's extension, e.g. msg/srv, one level
   // up directory will be used as the package name.
-  return packageName === path.parse(filePath).ext.substr(1)
+  return packageName === path.parse(filePath).ext.substring(1)
     ? folders.pop()
     : packageName;
 }
 
 function getSubFolder(filePath, amentExecuted) {
   if (os.type() === 'Windows_NT') {
-    filePath = filePath.replace(/\\/g, '/');
+    filePath = filePath.replaceAll('\\', '/');
   }
 
   if (amentExecuted) {

--- a/rosidl_gen/templates/message-template.js
+++ b/rosidl_gen/templates/message-template.js
@@ -164,7 +164,7 @@ function isTypedArrayType(type) {
 }
 
 function isBigInt(type) {
-  return ['int64', 'uint64'].indexOf(type.type.toLowerCase()) !== -1;
+  return ['int64', 'uint64'].includes(type.type.toLowerCase());
 }
 
 function getWrapperNameByType(type) {
@@ -283,7 +283,7 @@ function generateMessage(data) {
         !fieldType.isPrimitiveType ||
         fieldType.type === 'string');
 
-    if (shouldReq && existedModules.indexOf(requiredModule) === -1) {
+    if (shouldReq && !existedModules.includes(requiredModule)) {
       existedModules.push(requiredModule);
       return true;
     } else {
@@ -692,7 +692,7 @@ ${spec.fields
 
   hasMember(name) {
     let memberNames = ${extractMemberNames(spec.fields)};
-    return memberNames.indexOf(name) !== -1;
+    return memberNames.includes(name);
   }
 }`;
   }

--- a/rosidl_gen/templates/message-template.js
+++ b/rosidl_gen/templates/message-template.js
@@ -156,11 +156,11 @@ const typedArrayType = [
 ];
 
 function isPrimitivePackage(baseType) {
-  return primitiveBaseType.indexOf(baseType.type) !== -1;
+  return primitiveBaseType.includes(baseType.type);
 }
 
 function isTypedArrayType(type) {
-  return typedArrayType.indexOf(type.type.toLowerCase()) !== -1;
+  return typedArrayType.includes(type.type.toLowerCase());
 }
 
 function isBigInt(type) {

--- a/scripts/run_test.js
+++ b/scripts/run_test.js
@@ -27,7 +27,7 @@ utils
     const testDir = path.join(__dirname, '../test/');
     // eslint-disable-next-line
     const tests = fs.readdirSync(testDir).filter((file) => {
-      return file.substr(0, 5) === 'test-';
+      return file.startsWith('test-');
     });
 
     // eslint-disable-next-line
@@ -37,7 +37,7 @@ utils
     let ignoredCases = blocklist[os.type()];
 
     tests.forEach((test) => {
-      if (ignoredCases.indexOf(test) === -1) {
+      if (!ignoredCases.includes(test)) {
         mocha.addFile(path.join(testDir, test));
       }
     });


### PR DESCRIPTION
## Changed Files

- [lib/client.js](lib/client.js)
  - Removed the `AbortSignal.any()` polyfill for older Node.js versions.
  - Net effect: the code now relies on native `AbortSignal.any()` support from the runtime.

- [lib/message_introspector.js](lib/message_introspector.js)
  - Replaced the custom private `#deepClone()` implementation with `structuredClone(this.#defaultsCache)`.
  - Net effect: simpler default-message cloning logic with less handwritten recursion.

- [lib/message_serialization.js](lib/message_serialization.js)
  - Replaced `Object.prototype.hasOwnProperty.call(obj, key)` with `Object.hasOwn(obj, key)` in two object-walk helpers.
  - Net effect: minor modernization with no intended behavior change.

- [lib/action/uuid.js](lib/action/uuid.js)
  - Replaced `.replace(/-/g, '')` with `.replaceAll('-', '')`.

- [rosidl_gen/packages.js](rosidl_gen/packages.js)
  - Replaced `.replace(/\\\\/g, '/')` with `.replaceAll('\\', '/')` in two path-normalization helpers.
  - Replaced deprecated `.substr(1)` with `.substring(1)`.

- [rosidl_gen/templates/message-template.js](rosidl_gen/templates/message-template.js)
  - Replaced `.indexOf(...) !== -1` with `.includes(...)` in `isPrimitivePackage()` and `isTypedArrayType()`.

- [scripts/run_test.js](scripts/run_test.js)
  - Replaced `.substr(0, 5) === 'test-'` with `.startsWith('test-')`.
  - Replaced `.indexOf(test) === -1` with `!...includes(test)`.

## Overall Impact

- Removes legacy compatibility code (`AbortSignal.any()` polyfill, custom `#deepClone()`).
- Replaces deprecated APIs (`substr`) and verbose patterns (regex `.replace`, `indexOf`, `hasOwnProperty.call`) with modern equivalents (`substring`, `replaceAll`, `includes`, `startsWith`, `Object.hasOwn`, `structuredClone`).
- All replacements are safe, drop-in substitutions available since Node.js 16–20, well within the 20.20.2 minimum.

Fix: #1458
