### PR TITLE
Fix SIGSEGV on ROS 2 Rolling caused by rosidl sequence ABI change

### DIFF
--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -80,7 +80,7 @@ jobs:
         # Install any remaining runtime dependencies using rosdep
         rosdep init || true
         rosdep update
-        rosdep install --rosdistro rolling --from-paths /opt/ros/rolling/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 urdfdom_headers python3-pyqt6.qtsvg"
+        rosdep install --rosdistro rolling --from-paths /opt/ros/rolling/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 urdfdom_headers python3-pyqt6.qtsvg rosidl_buffer_py pybind11"
 
     - name: Install test-msgs and mrpt_msgs on Linux
       if: ${{ matrix.ros_distribution != 'rolling' }}

--- a/rosidl_gen/templates/message-template.js
+++ b/rosidl_gen/templates/message-template.js
@@ -268,7 +268,7 @@ function generateMessage(data) {
   // ROS 2 Rolling (ros2/rosidl#941) added is_rosidl_buffer / owns_rosidl_buffer
   // to every primitive sequence struct.  Emit the extra fields only for
   // primitive-package types on Rolling+.
-  const DistroUtils = require('../lib/distro.js');
+  const DistroUtils = require('../../lib/distro.js');
   const needsRosidlBufferFields =
     isPrimitivePackage(spec.baseType) &&
     DistroUtils.getDistroId() >= DistroUtils.getDistroId('rolling');

--- a/rosidl_gen/templates/message-template.js
+++ b/rosidl_gen/templates/message-template.js
@@ -265,6 +265,14 @@ function generateMessage(data) {
   const currentTypedArray = getTypedArrayName(spec.baseType);
   const currentTypedArrayElementType = getTypedArrayElementName(spec.baseType);
 
+  // ROS 2 Rolling (ros2/rosidl#941) added is_rosidl_buffer / owns_rosidl_buffer
+  // to every primitive sequence struct.  Emit the extra fields only for
+  // primitive-package types on Rolling+.
+  const DistroUtils = require('../lib/distro.js');
+  const needsRosidlBufferFields =
+    isPrimitivePackage(spec.baseType) &&
+    DistroUtils.getDistroId() >= DistroUtils.getDistroId('rolling');
+
   // Track required modules
   let existedModules = [];
   function shouldRequire(baseType, fieldType) {
@@ -349,10 +357,9 @@ ${
   size: ref.types.size_t,
   capacity: ref.types.size_t,
 ${
-  isPrimitivePackage(spec.baseType)
-    ? `  ...require('../../lib/distro.js').getDistroId() >= require('../../lib/distro.js').getDistroId('rolling')
-    ? { is_rosidl_buffer: ref.types.bool, owns_rosidl_buffer: ref.types.bool }
-    : {}`
+  needsRosidlBufferFields
+    ? `  is_rosidl_buffer: ref.types.bool,
+  owns_rosidl_buffer: ref.types.bool,`
     : ''
 }
 });

--- a/rosidl_gen/templates/message-template.js
+++ b/rosidl_gen/templates/message-template.js
@@ -347,7 +347,14 @@ ${
     : `  data: ${refArrayType},`
 }
   size: ref.types.size_t,
-  capacity: ref.types.size_t
+  capacity: ref.types.size_t,
+${
+  isPrimitivePackage(spec.baseType)
+    ? `  ...require('../../lib/distro.js').getDistroId() >= require('../../lib/distro.js').getDistroId('rolling')
+    ? { is_rosidl_buffer: ref.types.bool, owns_rosidl_buffer: ref.types.bool }
+    : {}`
+    : ''
+}
 });
 
 ${generateWrapperClass()}


### PR DESCRIPTION
ROS 2 Rolling merged ros2/rosidl#941 and ros2/rosidl#942 as part of the native buffer feature. The ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE macro now emits two extra boolean fields (is_rosidl_buffer, owns_rosidl_buffer) in every primitive sequence struct, growing them from 24 to 32 bytes. Non-primitive sequences (e.g. Parameter__Sequence) are unchanged at 24 bytes.

The rclnodejs code generator produces ref-struct-di definitions for these sequence types. Because the generated layout lacked the new fields, every message containing a primitive sequence had misaligned field offsets when serialized, causing Fast DDS to segfault in get_serialized_size_* during rcl_publish.

Changes:

1. rosidl_gen/templates/message-template.js — Detect Rolling+ at generation time via DistroUtils.getDistroId() and compute needsRosidlBufferFields once per message. Conditionally emit is_rosidl_buffer and owns_rosidl_buffer in the generated sequence struct only for primitive-package types (Bool, Byte, Int8, …, Float64, String) on Rolling+. Generated files get clean, static struct definitions with no runtime require() or ternary.

2. .github/workflows/linux-x64-build-and-test.yml — Add rosidl_buffer_py and pybind11 to rosdep --skip-keys for the Rolling nightly install, since these new packages from the native buffer feature have unresolvable rosdep keys in the tarball context.

Verified: Rolling: test-parameters (33), test-parameter-service (9), test-action-client (19) — all pass. Jazzy: test-parameters (33), test-parameter-service (9), test-action-client (18+1 pending) — all pass.

Fix: #1481