### PR TITLE
Treat unrecognized ROS_DISTRO as a future distro

### DIFF
--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -80,7 +80,7 @@ jobs:
         # Install any remaining runtime dependencies using rosdep
         rosdep init || true
         rosdep update
-        rosdep install --rosdistro rolling --from-paths /opt/ros/rolling/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 urdfdom_headers python3-pyqt6.qtsvg rosidl_buffer_py pybind11"
+        rosdep install --rosdistro rolling --from-paths /opt/ros/rolling/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 rti-connext-dds-7.7.0 urdfdom_headers python3-pyqt6.qtsvg rosidl_buffer_py pybind11"
 
     - name: Install test-msgs and mrpt_msgs on Linux
       if: ${{ matrix.ros_distribution != 'rolling' }}

--- a/lib/distro.js
+++ b/lib/distro.js
@@ -49,13 +49,14 @@ const DistroUtils = {
    * @return {number} Return the rclnodejs distro identifier
    */
   getDistroId: function (distroName) {
-    const dname = distroName ? distroName.toLowerCase() : this.getDistroName();
+    const dname =
+      (distroName || this.getDistroName() || '').toLowerCase() || undefined;
 
-    if (DistroNameIdMap.has(dname)) {
+    if (dname && DistroNameIdMap.has(dname)) {
       return DistroNameIdMap.get(dname);
     }
 
-    // Unrecognized but set ROS_DISTRO → assume future distro; unset → unknown
+    // Unrecognized but provided/resolved distro name → assume future; unset → unknown
     return dname ? DistroId.FUTURE : DistroId.UNKNOWN;
   },
 

--- a/lib/distro.js
+++ b/lib/distro.js
@@ -27,6 +27,7 @@ const DistroId = {
   JAZZY: 2405,
   KILTED: 2505,
   ROLLING: 5000,
+  FUTURE: 9999, // unrecognized ROS_DISTRO assumed newer than Rolling
 };
 
 const DistroNameIdMap = new Map();
@@ -50,9 +51,12 @@ const DistroUtils = {
   getDistroId: function (distroName) {
     const dname = distroName ? distroName.toLowerCase() : this.getDistroName();
 
-    return DistroNameIdMap.has(dname)
-      ? DistroNameIdMap.get(dname)
-      : DistroId.UNKNOWN;
+    if (DistroNameIdMap.has(dname)) {
+      return DistroNameIdMap.get(dname);
+    }
+
+    // Unrecognized but set ROS_DISTRO → assume future distro; unset → unknown
+    return dname ? DistroId.FUTURE : DistroId.UNKNOWN;
   },
 
   /**

--- a/test/test-distro.js
+++ b/test/test-distro.js
@@ -80,7 +80,9 @@ describe('rclnodejs distro utils', function () {
     delete process.env.ROS_DISTRO;
     assert.equal(DistroUtils.getDistroId(), DistroUtils.DistroId.UNKNOWN);
 
-    process.env.ROS_DISTRO = backupEnvar;
+    if (backupEnvar !== undefined) {
+      process.env.ROS_DISTRO = backupEnvar;
+    }
     done();
   });
 

--- a/test/test-distro.js
+++ b/test/test-distro.js
@@ -60,7 +60,8 @@ describe('rclnodejs distro utils', function () {
   it('unknown distro', function (done) {
     let backupEnvar = process.env.ROS_DISTRO;
 
-    // test unknown distro
+    // test unknown distro — when ROS_DISTRO is set but unrecognized,
+    // assume it is a future distro (newer than Rolling)
     process.env.ROS_DISTRO = 'xxx';
     assert.equal(
       'xxx',
@@ -68,12 +69,16 @@ describe('rclnodejs distro utils', function () {
       `Failed unknown distro name`
     );
     let id = DistroUtils.getDistroId();
-    assert.equal(id, DistroUtils.DistroId.UNKNOWN);
+    assert.equal(id, DistroUtils.DistroId.FUTURE);
     assert.equal(
-      DistroUtils.DistroId.UNKNOWN,
+      DistroUtils.DistroId.FUTURE,
       DistroUtils.getDistroId('xxx'),
       "getDistroId('xxx') failed"
     );
+
+    // test truly unknown — ROS_DISTRO unset
+    delete process.env.ROS_DISTRO;
+    assert.equal(DistroUtils.getDistroId(), DistroUtils.DistroId.UNKNOWN);
 
     process.env.ROS_DISTRO = backupEnvar;
     done();


### PR DESCRIPTION
Previously, `getDistroId()` returned `UNKNOWN (0)` for any `ROS_DISTRO` value not in the known map. This caused forward-looking feature guards (e.g., `>= ROLLING`) to fail for future distros like "lyrical", even though they would include the same ABI changes as Rolling.

Now, if `ROS_DISTRO` is set but not recognized, `getDistroId()` returns `FUTURE (9999)` instead, so feature guards pass correctly. If `ROS_DISTRO` is unset, it still returns `UNKNOWN (0)`.

### Changes

- **lib/distro.js**
  - Added `FUTURE: 9999` to `DistroId` enum
  - Updated `getDistroId()` to return `FUTURE` when `ROS_DISTRO` is set but not in the known map, `UNKNOWN` when unset

- **test/test-distro.js**
  - Updated "unknown distro" test to expect `FUTURE` for unrecognized `ROS_DISTRO` values
  - Added assertion for truly unset `ROS_DISTRO` returning `UNKNOWN`

Fix: #1484