### PR TITLE
Add rmw_zenoh_cpp as RMW vendor and update dist

### DIFF
--- a/lib/rmw.js
+++ b/lib/rmw.js
@@ -27,6 +27,7 @@ DefaultRosRMWNameMap.set('eloquent', RMWNames.FASTRTPS);
 DefaultRosRMWNameMap.set('foxy', RMWNames.FASTRTPS);
 DefaultRosRMWNameMap.set('galactic', RMWNames.CYCLONEDDS);
 DefaultRosRMWNameMap.set('humble', RMWNames.FASTRTPS);
+DefaultRosRMWNameMap.set('iron', RMWNames.FASTRTPS);
 DefaultRosRMWNameMap.set('jazzy', RMWNames.FASTRTPS);
 DefaultRosRMWNameMap.set('kilted', RMWNames.FASTRTPS);
 DefaultRosRMWNameMap.set('rolling', RMWNames.FASTRTPS);
@@ -37,7 +38,8 @@ const RMWUtils = {
   getRMWName: function () {
     return process.env.RMW_IMPLEMENTATION
       ? process.env.RMW_IMPLEMENTATION
-      : DefaultRosRMWNameMap.get(DistroUtils.getDistroName());
+      : DefaultRosRMWNameMap.get(DistroUtils.getDistroName()) ||
+          RMWNames.FASTRTPS;
   },
 };
 

--- a/lib/rmw.js
+++ b/lib/rmw.js
@@ -19,6 +19,7 @@ const RMWNames = {
   CONNEXT: 'rmw_connext_cpp',
   CYCLONEDDS: 'rmw_cyclonedds_cpp',
   GURUMDDS: 'rmw_gurumdds_cpp',
+  ZENOH: 'rmw_zenoh_cpp',
 };
 
 const DefaultRosRMWNameMap = new Map();
@@ -26,6 +27,8 @@ DefaultRosRMWNameMap.set('eloquent', RMWNames.FASTRTPS);
 DefaultRosRMWNameMap.set('foxy', RMWNames.FASTRTPS);
 DefaultRosRMWNameMap.set('galactic', RMWNames.CYCLONEDDS);
 DefaultRosRMWNameMap.set('humble', RMWNames.FASTRTPS);
+DefaultRosRMWNameMap.set('jazzy', RMWNames.FASTRTPS);
+DefaultRosRMWNameMap.set('kilted', RMWNames.FASTRTPS);
 DefaultRosRMWNameMap.set('rolling', RMWNames.FASTRTPS);
 
 const RMWUtils = {

--- a/test/test-subscription-content-filter.js
+++ b/test/test-subscription-content-filter.js
@@ -15,7 +15,8 @@ const SUBSCRIBER_WAIT_TIME = 1000;
 function isContentFilteringSupported() {
   return (
     DistroUtils.getDistroId() >= DistroUtils.getDistroId('humble') &&
-    RMWUtils.getRMWName() != RMWUtils.RMWNames.CYCLONEDDS
+    RMWUtils.getRMWName() != RMWUtils.RMWNames.CYCLONEDDS &&
+    RMWUtils.getRMWName() != RMWUtils.RMWNames.ZENOH
   );
 }
 


### PR DESCRIPTION
**Changes:**

- **`lib/rmw.js`**
  - Added `ZENOH: 'rmw_zenoh_cpp'` to `RMWNames` constants
  - Added missing `iron`, `jazzy`, and `kilted` distro entries to `DefaultRosRMWNameMap` (all default to `rmw_fastrtps_cpp`)
  - Added safe fallback to `getRMWName()` — returns `rmw_fastrtps_cpp` when the distro is not in the map and `RMW_IMPLEMENTATION` is unset, preventing `undefined` from causing incorrect feature gating

- **`test/test-subscription-content-filter.js`**
  - Updated `isContentFilteringSupported()` to exclude `rmw_zenoh_cpp`, which does not support content filtering

**Context:**

`rmw_zenoh_cpp` was promoted to Tier 1 in ROS 2 Kilted Kaiju and is actively referenced in `rclpy` tests for conditional behavior. rclnodejs was missing it entirely from its RMW vendor registry. The `DefaultRosRMWNameMap` was also missing entries for multiple known distros (`iron`, `jazzy`, `kilted`), and `getRMWName()` had no fallback for unmapped distros.

Fix: #1486