### PR TITLE
Add explicit LYRICAL distro identifier (2605)

### DIFF
--- a/lib/distro.js
+++ b/lib/distro.js
@@ -26,6 +26,7 @@ const DistroId = {
   IRON: 2305,
   JAZZY: 2405,
   KILTED: 2505,
+  LYRICAL: 2605,
   ROLLING: 5000,
   FUTURE: 9999, // unrecognized ROS_DISTRO assumed newer than Rolling
 };
@@ -38,6 +39,7 @@ DistroNameIdMap.set('humble', DistroId.HUMBLE);
 DistroNameIdMap.set('iron', DistroId.IRON);
 DistroNameIdMap.set('jazzy', DistroId.JAZZY);
 DistroNameIdMap.set('kilted', DistroId.KILTED);
+DistroNameIdMap.set('lyrical', DistroId.LYRICAL);
 DistroNameIdMap.set('rolling', DistroId.ROLLING);
 
 const DistroUtils = {

--- a/test/test-distro.js
+++ b/test/test-distro.js
@@ -28,7 +28,7 @@ describe('rclnodejs distro utils', function () {
     );
     assert.equal(
       distroNames.length,
-      8,
+      9,
       'Incorrect number of known distro names'
     );
 

--- a/test/test-distro.js
+++ b/test/test-distro.js
@@ -23,14 +23,27 @@ describe('rclnodejs distro utils', function () {
 
     const distroNames = DistroUtils.getKnownDistroNames();
     assert.ok(
-      distroNames,
+      distroNames && distroNames.length > 0,
       'DistroUtils.getKnownDistroNames() did not return any distro names'
     );
-    assert.equal(
-      distroNames.length,
-      9,
-      'Incorrect number of known distro names'
-    );
+
+    const expectedDistros = [
+      'eloquent',
+      'foxy',
+      'galactic',
+      'humble',
+      'iron',
+      'jazzy',
+      'kilted',
+      'lyrical',
+      'rolling',
+    ];
+    for (const name of expectedDistros) {
+      assert.ok(
+        distroNames.includes(name),
+        `Expected distro '${name}' not found in known distro names`
+      );
+    }
 
     distroNames.forEach((distroName) => {
       let id = DistroUtils.getDistroId(distroName);


### PR DESCRIPTION
Register the upcoming **ROS 2 Lyrical Luth** (May 2026) distribution so that distro-gated code paths activate correctly when `ROS_DISTRO=lyrical` is set, rather than falling through to the `FUTURE` sentinel.

**Changes**

| File | What changed |
|------|-------------|
| `lib/distro.js` | Added `LYRICAL: 2605` to `DistroId` enum and `DistroNameIdMap` |
| `test/test-distro.js` | Replaced brittle exact-count assertion with `expectedDistros` array that verifies each known distro (including `lyrical`) is present via `includes()` |

**Why 2605?** Follows the existing `YYMM` convention — Lyrical targets May 2026 GA.

Fix: #1458 