### PR TITLE
Add GitHub Actions workflow to deploy JSDoc to GitHub

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,63 @@
+name: Deploy JSDoc to GitHub Pages
+
+on:
+  push:
+    tags:
+      - 'docs-*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build docs only (skip deploy to Pages)'
+        required: true
+        type: boolean
+        default: true
+
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    if: github.repository == 'RobotWebTools/rclnodejs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Fetch gh-pages branch
+        run: git fetch origin gh-pages:refs/remotes/origin/gh-pages
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build docs
+        run: npm run docs:gh-pages
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: build/gh-pages-docs
+
+  deploy:
+    needs: build
+    if: ${{ !(inputs.dry_run == true) }}
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,7 @@ name: NPM Publish
 on:
   push:
     tags:
-      - '*'
+      - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/tools/jsdoc/README.md
+++ b/tools/jsdoc/README.md
@@ -65,6 +65,31 @@ For a new release such as `1.9.0`:
    - `build/gh-pages-docs/.nojekyll`
 6. Publish the contents of `build/gh-pages-docs/` to the `gh-pages` branch.
 
+## GitHub Actions Deployment
+
+The `deploy-docs.yml` workflow (`.github/workflows/deploy-docs.yml`) automates
+building and deploying docs to GitHub Pages.
+
+### Triggers
+
+- **Tag push** matching `docs-*` (e.g. `git tag docs-1.9.0 && git push origin docs-1.9.0`) — builds and deploys automatically.
+- **Manual dispatch** from the Actions tab — includes a `dry_run` toggle
+  (defaults to `true`). Set it to `false` to deploy.
+
+### What it does
+
+1. Full checkout with all tags and the `origin/gh-pages` branch.
+2. Runs `npm run docs:gh-pages` to stage the docs tree.
+3. Uploads the staged output as a Pages artifact.
+4. Deploys to GitHub Pages (skipped when `dry_run` is `true`).
+
+### Testing
+
+- Run the workflow manually with `dry_run` enabled to verify the build
+  succeeds without deploying.
+- Push a `docs-test` tag to trigger a full build + deploy, then clean up:
+  `git tag -d docs-test && git push origin :refs/tags/docs-test`.
+
 ## Manual Landing Page Rebuild
 
 If the staged docs tree already exists and you only want to rebuild

--- a/tools/jsdoc/README.md
+++ b/tools/jsdoc/README.md
@@ -76,6 +76,10 @@ building and deploying docs to GitHub Pages.
 - **Manual dispatch** from the Actions tab — includes a `dry_run` toggle
   (defaults to `true`). Set it to `false` to deploy.
 
+These workflow runs only execute in the upstream `RobotWebTools/rclnodejs`
+repository. If you trigger the workflow from a fork, the build job is skipped,
+so manual dispatches and `docs-*` tag pushes there will not run the docs build.
+
 ### What it does
 
 1. Full checkout with all tags and the `origin/gh-pages` branch.
@@ -85,9 +89,11 @@ building and deploying docs to GitHub Pages.
 
 ### Testing
 
-- Run the workflow manually with `dry_run` enabled to verify the build
+- Run the workflow manually with `dry_run` enabled first to verify the build
   succeeds without deploying.
-- Push a `docs-test` tag to trigger a full build + deploy, then clean up:
+- Only push a `docs-test` tag when it is acceptable to update the published
+  GitHub Pages site: `docs-*` tags perform a real production deploy.
+  Afterward, clean up the tag with:
   `git tag -d docs-test && git push origin :refs/tags/docs-test`.
 
 ## Manual Landing Page Rebuild


### PR DESCRIPTION
Automate the JSDoc deployment that was previously a manual `npm run docs:gh-pages` + push-to-`gh-pages` process. The workflow leverages the existing `github-pages` deployment environment.

**Trigger**
- Tag push matching `docs-*` (e.g. `docs-1.9.0`) — builds and deploys
- Manual `workflow_dispatch` with a `dry_run` toggle (defaults to `true`) — build-only by default, deploy when `dry_run` is unchecked

**Build job**
- Full checkout (`fetch-depth: 0`) with tags, plus explicit `origin/gh-pages` fetch — required by `regenerate-published-docs.js` to discover and preserve previously published versions
- Runs `npm run docs:gh-pages` to stage the full docs tree under `build/gh-pages-docs/`
- Uploads the output via `upload-pages-artifact`

**Deploy job**
- Skipped when `dry_run` is `true`
- Deploys to GitHub Pages via `deploy-pages@v5`

**Changes**

| File | What changed |
|------|-------------|
| `.github/workflows/deploy-docs.yml` | New workflow |

Fix: #1489