### PR TITLE
Use `npm install` in deploy-docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: 24.x
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm install --ignore-scripts --no-audit --no-fund
 
       - name: Build docs
         run: npm run docs:gh-pages


### PR DESCRIPTION
The `deploy-docs` workflow failed when triggered manually because it relied on `npm ci`, which requires a committed `package-lock.json`. This repository intentionally gitignores `package-lock.json` (see `.gitignore`), so the install step always errored out with `EUSAGE`.

Replace `npm ci --ignore-scripts` with `npm install --ignore-scripts --no-audit --no-fund` to keep the intent (skip native build scripts, avoid noisy output) while working without a lockfile.

Fix: #1489 