### PR TITLE
Refresh Electron prebuild target and demo apps

### DIFF
--- a/electron_demo/car/package.json
+++ b/electron_demo/car/package.json
@@ -30,7 +30,7 @@
     "@electron-forge/plugin-auto-unpack-natives": "^7.11.1",
     "@electron-forge/plugin-fuses": "^7.11.1",
     "@electron/rebuild": "^4.0.3",
-    "electron": "^40.1.0"
+    "electron": "^41.0.0"
   },
   "config": {
     "forge": {

--- a/electron_demo/manipulator/package.json
+++ b/electron_demo/manipulator/package.json
@@ -34,7 +34,7 @@
     "@electron-forge/plugin-auto-unpack-natives": "^7.11.1",
     "@electron-forge/plugin-fuses": "^7.11.1",
     "@electron/rebuild": "^4.0.3",
-    "electron": "^40.1.0"
+    "electron": "^41.0.0"
   },
   "config": {
     "forge": {

--- a/electron_demo/topics/package.json
+++ b/electron_demo/topics/package.json
@@ -27,7 +27,7 @@
     "@electron-forge/plugin-auto-unpack-natives": "^7.11.1",
     "@electron-forge/plugin-fuses": "^7.11.1",
     "@electron/rebuild": "^4.0.3",
-    "electron": "^40.1.0"
+    "electron": "^41.0.0"
   },
   "config": {
     "forge": {

--- a/electron_demo/turtle_tf2/package.json
+++ b/electron_demo/turtle_tf2/package.json
@@ -33,7 +33,7 @@
     "@electron-forge/plugin-auto-unpack-natives": "^7.11.1",
     "@electron-forge/plugin-fuses": "^7.11.1",
     "@electron/rebuild": "^4.0.3",
-    "electron": "^40.1.0"
+    "electron": "^41.0.0"
   },
   "config": {
     "forge": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prepare": "husky",
     "coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "prebuild:node": "prebuildify --napi --strip --name node --target 20.20.2",
-    "prebuild:electron": "prebuildify --napi --strip --name electron --target electron@23.0.0",
+    "prebuild:electron": "prebuildify --napi --strip --name electron --target electron@34.0.0",
     "prebuild": "npm run prebuild:node && npm run prebuild:electron && node scripts/tag_prebuilds.js"
   },
   "bin": {


### PR DESCRIPTION
The `prebuild:electron` script was still pinned to `electron@23.0.0`, an EOL release from Dec 2022 that bundles Node 18.12. Bump it to `electron@34.0.0`, the most recent line whose bundled Node (20.18.1) matches the major version of our `engines.node >= 20.20.2` floor.

The four `electron_demo/*` apps were pinned to `^40.1.0`, which goes EOL on Jun 30, 2026. Bump them to `^41.0.0` (supported through Aug 25, 2026) so demos stay on a maintained, security-patched Electron line ahead of the Lyrical GA window.

N-API ABI stability means binaries built against Electron 34 continue to load cleanly in 41+, so the prebuild-target / demo-target split is intentional and safe.

Fix: #1458