### PR TITLE
Pump to Node 26.x

### DIFF
--- a/.github/workflows/linux-arm64-build-and-test.yml
+++ b/.github/workflows/linux-arm64-build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.20.2]
+        node-version: [20.X]
         architecture: [arm64]
         ros_distribution:
           - humble

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [24.X, 25.X]
+        node-version: [24.X, 26.X]
         architecture: [x64]
         ros_distribution:
           - humble


### PR DESCRIPTION
Updates CI workflow matrices to adjust the Node.js versions used for Linux builds/tests, aligning (at least partially) with a move toward newer Node majors.

**Changes:**
- Linux x64 CI matrix: replaces Node 25.x testing with Node 26.x (keeps Node 24.x).
- Linux arm64 CI matrix: switches from a pinned Node 20.20.2 to a floating Node 20.x range.

Fix: #1458 