### PR TITLE
Pump to 2.0.0-beta.0 pre-release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,9 +12,10 @@ cpplint.py
 suppr.txt
 generated/
 build/
+__pycache__/
+*.pyc
 coverage/
 dist/
-electron_demo/
 log/
 install/
 test/
@@ -22,6 +23,9 @@ docs/
 example/
 benchmark/
 tutorials/
+electron_demo/
+ts_demo/
+tools/
 .github/
 .nyc_output/
 .vscode/
@@ -30,4 +34,3 @@ scripts/cpplint.js
 scripts/npm-pack.sh
 scripts/npmjs-readme.md
 scripts/run_test.js
-ts_demo/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rclnodejs",
-  "version": "1.9.0",
+  "version": "2.0.0-beta.0",
   "description": "ROS2.0 JavaScript client with Node.js",
   "main": "index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
- Bump version from `1.9.0` to `2.0.0-beta.0` in package.json.
- .npmignore: exclude Python bytecode artifacts (`__pycache__/`, `*.pyc`) so `rosidl_parser/__pycache__/*.pyc` is no longer shipped in the tarball.
- .npmignore: exclude `tools/` (jsdoc templates, maintainer-only).
- .npmignore: regroup `electron_demo/` and `ts_demo/` alongside the other demo/example directories for readability (no functional change).

Fix: #1458