### PR TITLE
Trigger npm-publish on prerelease tags

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,10 @@ name: NPM Publish
 on:
   push:
     tags:
+      # Match release tags (e.g. 1.9.0, 2.0.0) and prerelease tags
+      # (e.g. 2.0.0-beta.0, 1.9.0-alpha.0, 2.0.0-rc.1).
       - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
Commit e54a991 (#1490) tightened the tag filter from `'*'` to `'[0-9]+.[0-9]+.[0-9]+'`, which only matches plain `MAJOR.MINOR.PATCH` tags. Prerelease tags such as `2.0.0-beta.0` no longer trigger the workflow, even though `1.9.0-alpha.0` published successfully under the previous pattern.

Restore prerelease support by adding a second pattern `'[0-9]+.[0-9]+.[0-9]+-*'` alongside the existing one, so tags like `2.0.0-beta.0`, `1.9.0-alpha.0`, and `2.0.0-rc.1` trigger the workflow while unrelated tags (e.g. `docs-*`) remain excluded.

Fix: #1500