### PR TITLE
Run tests on Lyrical instead of Jazzy

### DIFF
--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -23,7 +23,7 @@ jobs:
         include:
           - ros_distribution: jazzy
             ros_zip_url: "https://github.com/ros2/ros2/releases/download/release-jazzy-20260128/ros2-jazzy-20260128-windows-release-amd64.zip"
-            run_tests: true
+            run_tests: false
           - ros_distribution: kilted
             ros_zip_url: "https://github.com/ros2/ros2/releases/download/release-kilted-20250728/ros2-kilted-20250728-windows-release-amd64.zip"
             run_tests: false
@@ -31,7 +31,7 @@ jobs:
           # Reference: https://docs.ros.org/en/lyrical/Installation/Windows-Install-Binary.html
           - ros_distribution: lyrical
             ros_zip_url: "https://github.com/ros2/ros2/releases/download/release-lyrical-beta-20260430/ros2-lyrical-2026-04-30-windows-AMD64.zip"
-            run_tests: false
+            run_tests: true
           - ros_distribution: rolling
             ros_zip_url: "https://github.com/ros2/ros2/releases/download/release-rolling-nightlies/ros2-rolling-nightly-windows-amd64.zip"
             run_tests: false


### PR DESCRIPTION
Lyrical Luth will be the next ROS 2 LTS, so make it the test target on the Windows pixi job. Flip `run_tests: true` from `jazzy` to `lyrical`; Jazzy, Kilted, and Rolling remain build-only.

Fix: #1458