### PR TITLE
[Docs] Surface ROS 2 Lyrical and the 2.0.0-beta.0 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 | **ROS 2 Distro** | **CI Status** |
 | :---: | :---: |
-| [![ROS 2](https://img.shields.io/badge/ROS%202-Humble%20%7C%20Jazzy%20%7C%20Kilted%20%7C%20Rolling-blue?logo=ros)](https://www.ros.org/) | [![Linux x64](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-x64-push-test.yml/badge.svg?branch=develop)](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-x64-push-test.yml?query=branch%3Adevelop)<br>[![Linux arm64](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-arm64-push-test.yml/badge.svg?branch=develop)](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-arm64-push-test.yml?query=branch%3Adevelop)<br>[![Windows](https://github.com/RobotWebTools/rclnodejs/actions/workflows/windows-push-test.yml/badge.svg?branch=develop)](https://github.com/RobotWebTools/rclnodejs/actions/workflows/windows-push-test.yml?query=branch%3Adevelop)<br>[![ASan](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-x64-asan-test.yml/badge.svg?branch=develop)](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-x64-asan-test.yml?query=branch%3Adevelop) |
+| [![ROS 2](https://img.shields.io/badge/ROS%202-Humble%20%7C%20Jazzy%20%7C%20Kilted%20%7C%20Lyrical%20%7C%20Rolling-blue?logo=ros)](https://www.ros.org/) | [![Linux x64](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-x64-push-test.yml/badge.svg?branch=develop)](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-x64-push-test.yml?query=branch%3Adevelop)<br>[![Linux arm64](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-arm64-push-test.yml/badge.svg?branch=develop)](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-arm64-push-test.yml?query=branch%3Adevelop)<br>[![Windows](https://github.com/RobotWebTools/rclnodejs/actions/workflows/windows-push-test.yml/badge.svg?branch=develop)](https://github.com/RobotWebTools/rclnodejs/actions/workflows/windows-push-test.yml?query=branch%3Adevelop)<br>[![ASan](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-x64-asan-test.yml/badge.svg?branch=develop)](https://github.com/RobotWebTools/rclnodejs/actions/workflows/linux-x64-asan-test.yml?query=branch%3Adevelop) |
 
 **rclnodejs** is a Node.js client library for [ROS 2](https://www.ros.org/) that provides comprehensive JavaScript and TypeScript APIs for developing ROS 2 solutions.
 
@@ -48,7 +48,7 @@ Choose the path that matches how you plan to use rclnodejs:
 ### Prerequisites
 
 - [Node.js](https://nodejs.org/en/) version >= 20.20.2
-- [ROS 2 SDK](https://docs.ros.org/en/jazzy/Installation.html)
+- [ROS 2 SDK](https://docs.ros.org/en/lyrical/Installation.html)
 
 Before installing, building, or running rclnodejs, source your ROS 2 environment:
 
@@ -90,6 +90,7 @@ rclnodejs ships with prebuilt native binaries for common Linux configurations si
 
 - **Ubuntu 22.04 (Jammy)** - ROS 2 Humble
 - **Ubuntu 24.04 (Noble)** - ROS 2 Jazzy, Kilted
+- **Ubuntu 26.04 (Resolute)** - ROS 2 Lyrical
 - **Architectures:** x64, arm64
 - **Node.js:** >= 20.20.2 (N-API compatible)
 
@@ -202,7 +203,7 @@ See the [Observable Subscriptions Tutorial](./tutorials/observable-subscriptions
 
 > A tiny WebSocket gateway to ROS 2 — built into `rclnodejs`.
 
-> **Availability:** experimental; currently only on the `develop` branch and not yet part of any published `rclnodejs` release.
+> **Availability:** new in `2.0.0-beta.0`.
 
 **rosocket** exposes ROS 2 topics/services as plain WebSocket URLs — a
 **lightweight** alternative to the rosbridge + roslibjs stack. Zero browser

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,7 +4,7 @@ Performance benchmarks for comparing ROS 2 client libraries: C++ (rclcpp), Pytho
 
 ## Prerequisites
 
-1. **ROS 2**: Install from [ros.org](https://docs.ros.org/en/jazzy/Installation.html)
+1. **ROS 2**: Install from [ros.org](https://docs.ros.org/en/lyrical/Installation.html)
 2. **Node.js**: v20.20.2+ for rclnodejs (from [nodejs.org](https://nodejs.org/))
 3. **rclnodejs**: Follow [installation guide](https://github.com/RobotWebTools/rclnodejs#installation)
 4. **Build Dependencies**: For C++ benchmarks: `sudo apt install libssl-dev cmake build-essential`

--- a/demo/electron/car/README.md
+++ b/demo/electron/car/README.md
@@ -29,7 +29,7 @@ This demo showcases how to use **rclnodejs** with **Electron** to create an inte
 
 Before running this demo, ensure you have:
 
-1. **ROS2 installed** (Humble, Jazzy, Kilted, or Rolling)
+1. **ROS2 installed** (Humble, Jazzy, Kilted, Lyrical, or Rolling)
 2. **Node.js** (version 20.20.2 or higher)
 3. **rclnodejs built** and working
 
@@ -319,9 +319,9 @@ console.log('Publishing command:', command, twist);
 ## 📚 Learning Resources
 
 - [rclnodejs Documentation](https://github.com/RobotWebTools/rclnodejs)
-- [ROS2 Tutorials](https://docs.ros.org/en/rolling/Tutorials.html)
+- [ROS2 Tutorials](https://docs.ros.org/en/lyrical/Tutorials.html)
 - [Electron Documentation](https://www.electronjs.org/docs)
-- [geometry_msgs/Twist Documentation](https://docs.ros.org/en/rolling/p/geometry_msgs/interfaces/msg/Twist.html)
+- [geometry_msgs/Twist Documentation](https://docs.ros.org/en/lyrical/p/geometry_msgs/interfaces/msg/Twist.html)
 
 ## 📄 License
 

--- a/demo/electron/manipulator/README.md
+++ b/demo/electron/manipulator/README.md
@@ -17,7 +17,7 @@ An interactive Electron application demonstrating a two-joint robotic manipulato
 ## 📋 Prerequisites
 
 - **Node.js** (>= 20.20.2) - JavaScript runtime
-- **ROS 2** (Humble, Jazzy, or newer) - Robot Operating System 2
+- **ROS 2** (Humble, Jazzy, Kilted, Lyrical, or Rolling) - Robot Operating System 2
 - **rclnodejs compatible environment** - Linux recommended (tested on Ubuntu/WSL)
 
 ## 🛠️ Installation
@@ -329,7 +329,7 @@ manipulator/
 
 ## 📚 Learning Resources
 
-- **ROS2 Concepts**: [ROS2 Documentation](https://docs.ros.org/en/humble/)
+- **ROS2 Concepts**: [ROS2 Documentation](https://docs.ros.org/en/lyrical/)
 - **Three.js Guide**: [Three.js Documentation](https://threejs.org/docs/)
 - **Electron Tutorials**: [Electron Documentation](https://electronjs.org/docs)
 - **rclnodejs API**: [rclnodejs Repository](https://github.com/RobotWebTools/rclnodejs)

--- a/demo/electron/topics/README.md
+++ b/demo/electron/topics/README.md
@@ -22,7 +22,7 @@ A minimal Electron application demonstrating basic ROS2 topic communication usin
 ## 📋 Prerequisites
 
 - **Node.js** (>= 20.20.2) - JavaScript runtime
-- **ROS 2** (Humble, Jazzy, or newer) - Robot Operating System 2
+- **ROS 2** (Humble, Jazzy, Kilted, Lyrical, or Rolling) - Robot Operating System 2
 - **rclnodejs compatible environment** - Linux recommended (tested on Ubuntu/WSL)
 
 ## 🛠️ Installation

--- a/demo/electron/turtle_tf2/README.md
+++ b/demo/electron/turtle_tf2/README.md
@@ -50,7 +50,7 @@ The turtle_tf2 demo showcases:
 
 ### System Requirements
 
-- **ROS2**: Humble, Iron, or Rolling distribution
+- **ROS2**: Humble, Jazzy, Kilted, Lyrical, or Rolling distribution
 - **Node.js**: Version 20.20.2 or higher
 - **turtlesim**: ROS2 turtle simulation package
 - **Electron**: For desktop application framework
@@ -404,7 +404,7 @@ turtle_tf2/
 
 ## Related Resources
 
-- [ROS2 TF2 Tutorials](https://docs.ros.org/en/humble/Tutorials/Intermediate/Tf2/Tf2-Main.html)
+- [ROS2 TF2 Tutorials](https://docs.ros.org/en/lyrical/Tutorials/Intermediate/Tf2/Tf2-Main.html)
 - [turtle_tf2_py Source](https://github.com/ros/geometry_tutorials/tree/ros2/turtle_tf2_py)
 - [Three.js Documentation](https://threejs.org/docs/)
 - [rclnodejs GitHub](https://github.com/RobotWebTools/rclnodejs)

--- a/demo/typescript/actions/README.md
+++ b/demo/typescript/actions/README.md
@@ -48,7 +48,7 @@ demo/typescript/actions/
 
 Before running this demo, ensure you have:
 
-1. **ROS2** installed (tested with ROS2 Humble/Iron/Jazzy)
+1. **ROS2** installed (tested with ROS2 Humble/Jazzy/Kilted/Lyrical)
 2. **Node.js** (version 20.20.2 or higher)
 3. **rclnodejs** built and configured in the parent directory (`../../`)
 4. **test_msgs** package available (usually included with ROS2)

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -2,13 +2,13 @@
 
 ### Get ready for ROS 2
 
-1.Install ROS 2 from binary package.
+1. Install ROS 2 from binary package.
 
-ROS 2 is a cross-platform system, which covers Linux, macOS and Windows, and the `rclnodejs` module is developed against the [`master`](https://github.com/ros2/ros2/blob/master/ros2.repos) branch of ROS 2. You can download the latest binary packages from [ROS 2 build farm](http://ci.ros2.org/view/packaging/) and follow the instructions of [Linux](https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html)/[Windows](https://docs.ros.org/en/rolling/Installation/Windows-Install-Binary.html) to setup the environment. Supported ROS 2 distributions: Rolling, Lyrical, Kilted, Jazzy, and Humble.
+   ROS 2 is a cross-platform system, which covers Linux, macOS and Windows, and the `rclnodejs` module is developed against the [`master`](https://github.com/ros2/ros2/blob/master/ros2.repos) branch of ROS 2. You can download the latest binary packages from the [ROS 2 nightly builds](https://github.com/ros2/ros2/releases/tag/release-rolling-nightlies) and follow the instructions of [Linux](https://docs.ros.org/en/lyrical/Installation/Ubuntu-Install-Debians.html)/[Windows](https://docs.ros.org/en/lyrical/Installation/Windows-Install-Binary.html) to setup the environment. Supported ROS 2 distributions: Rolling, Lyrical, Kilted, Jazzy, and Humble.
 
-2.Build ROS 2 from scratch.
+2. Build ROS 2 from scratch.
 
-Alternatively, you can build ROS 2 from scratch. Please select the platform you want to work on, then reference the instructions of [Linux](https://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Development-Setup.html#)/[Windows](https://docs.ros.org/en/rolling/Installation/Alternatives/Windows-Development-Setup.html) to build ROS 2 (please build with flag `--merge-install`).
+   Alternatively, you can build ROS 2 from scratch. Please select the platform you want to work on, then reference the instructions of [Linux](https://docs.ros.org/en/lyrical/Installation/Alternatives/Ubuntu-Development-Setup.html#)/[Windows](https://docs.ros.org/en/lyrical/Installation/Alternatives/Windows-Development-Setup.html) to build ROS 2 (please build with flag `--merge-install`).
 
 ### Install `Node.js`
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -4,7 +4,7 @@
 
 1.Install ROS 2 from binary package.
 
-ROS 2 is a cross-platform system, which covers Linux, macOS and Windows, and the `rclnodejs` module is developed against the [`master`](https://github.com/ros2/ros2/blob/master/ros2.repos) branch of ROS 2. You can download the latest binary packages from [ROS 2 build farm](http://ci.ros2.org/view/packaging/) and follow the instructions of [Linux](https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html)/[Windows](https://docs.ros.org/en/rolling/Installation/Windows-Install-Binary.html) to setup the environment. Supported ROS 2 distributions: Rolling, Kilted, Jazzy, and Humble.
+ROS 2 is a cross-platform system, which covers Linux, macOS and Windows, and the `rclnodejs` module is developed against the [`master`](https://github.com/ros2/ros2/blob/master/ros2.repos) branch of ROS 2. You can download the latest binary packages from [ROS 2 build farm](http://ci.ros2.org/view/packaging/) and follow the instructions of [Linux](https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html)/[Windows](https://docs.ros.org/en/rolling/Installation/Windows-Install-Binary.html) to setup the environment. Supported ROS 2 distributions: Rolling, Lyrical, Kilted, Jazzy, and Humble.
 
 2.Build ROS 2 from scratch.
 

--- a/scripts/npmjs-readme.md
+++ b/scripts/npmjs-readme.md
@@ -2,7 +2,7 @@
 
 `rclnodejs` is a Node.js client library for ROS 2 that provides JavaScript and TypeScript APIs for building ROS 2 applications.
 
-Supported ROS 2 distributions include Humble, Jazzy, Kilted, and Rolling.
+Supported ROS 2 distributions include Humble, Jazzy, Kilted, Lyrical, and Rolling.
 
 ```javascript
 const rclnodejs = require('rclnodejs');
@@ -21,7 +21,7 @@ This example assumes your ROS 2 environment is already sourced.
 ### Prerequisites
 
 - [Node.js](https://nodejs.org/en/) version >= 20.20.2
-- [ROS 2 SDK](https://docs.ros.org/en/jazzy/Installation.html)
+- [ROS 2 SDK](https://docs.ros.org/en/lyrical/Installation.html)
 
 Before installing or running rclnodejs, source your ROS 2 environment:
 
@@ -51,6 +51,7 @@ rclnodejs ships with prebuilt native binaries for common Linux configurations si
 
 - **Ubuntu 22.04 (Jammy)** - ROS 2 Humble
 - **Ubuntu 24.04 (Noble)** - ROS 2 Jazzy, Kilted
+- **Ubuntu 26.04 (Resolute)** - ROS 2 Lyrical
 - **Architectures:** x64, arm64
 - **Node.js:** >= 20.20.2 (N-API compatible)
 

--- a/tutorials/content-filtering-subscription.md
+++ b/tutorials/content-filtering-subscription.md
@@ -164,8 +164,8 @@ const isSupported =
 
 ## References
 
-- [ROS 2 Content Filtering Documentation](https://docs.ros.org/en/kilted/Tutorials/Demos/Content-Filtering-Subscription.html)
-- [Advanced Topic Keys Tutorial](https://docs.ros.org/en/kilted/Tutorials/Advanced/Topic-Keys/Filtered-Topic-Keys-Tutorial.html)
+- [ROS 2 Content Filtering Documentation](https://docs.ros.org/en/lyrical/Tutorials/Demos/Content-Filtering-Subscription.html)
+- [Advanced Topic Keys Tutorial](https://docs.ros.org/en/lyrical/Tutorials/Advanced/Topic-Keys/Filtered-Topic-Keys-Tutorial.html)
 - [rclnodejs GitHub Repository](https://github.com/RobotWebTools/rclnodejs)
 
 ---
@@ -488,7 +488,7 @@ Content filtering in rclnodejs provides powerful message filtering at the DDS mi
 
 For more information:
 
-- [ROS 2 Content Filtering Demo](https://docs.ros.org/en/kilted/Tutorials/Demos/Content-Filtering-Subscription.html)
+- [ROS 2 Content Filtering Demo](https://docs.ros.org/en/lyrical/Tutorials/Demos/Content-Filtering-Subscription.html)
 - [rclnodejs API Documentation](https://robotwebtools.github.io/rclnodejs/)
 - [Content filtering tests](../test/test-subscription-content-filter.js)
 - [DDS 1.4 Specification](https://www.omg.org/spec/DDS/1.4/PDF) (Annex B for filter syntax)

--- a/tutorials/service-introspection.md
+++ b/tutorials/service-introspection.md
@@ -1170,7 +1170,7 @@ Remember to use introspection judiciously in production systems, considering the
 
 For more information, see:
 
-- [ROS 2 Service Introspection Documentation](https://docs.ros.org/en/kilted/Tutorials/Demos/Service-Introspection.html)
+- [ROS 2 Service Introspection Documentation](https://docs.ros.org/en/lyrical/Tutorials/Demos/Service-Introspection.html)
 - [rclnodejs API Documentation](https://robotwebtools.github.io/rclnodejs/docs/index.html)
 - [Example service code](../example/services/service/service-example.js)
 - [Introspection test cases](../test/test-service-introspection.js)

--- a/tutorials/type-description-service.md
+++ b/tutorials/type-description-service.md
@@ -1457,7 +1457,7 @@ Remember to handle service availability gracefully and use appropriate error han
 
 For more information, see:
 
-- [ROS 2 Introspection Documentation](https://docs.ros.org/en/rolling/Concepts/About-ROS-Interfaces.html)
+- [ROS 2 Introspection Documentation](https://docs.ros.org/en/lyrical/Concepts/About-ROS-Interfaces.html)
 - [rclnodejs API Documentation](https://robotwebtools.github.io/rclnodejs/)
 - [Type Description Service implementation](../lib/type_description_service.js)
 - [Type Description Service tests](../test/test-type-description-service.js)


### PR DESCRIPTION
Roll Lyrical Luth into the user-facing docs now that 2.0.0-beta.0 ships Lyrical support and Linux x64/arm64 prebuilds for Ubuntu 26.04 (Resolute). Tracks the "After beta, before Lyrical GA" tasks in #1458.

- README.md: add Lyrical to the ROS 2 distro CI badge; add `Ubuntu 26.04 (Resolute) - ROS 2 Lyrical` to the Prebuilt Binaries supported-platforms list; flip the Prerequisites ROS 2 SDK link from `en/jazzy/` to `en/lyrical/`; replace the rosocket "experimental, develop-only" availability note with "new in 2.0.0-beta.0".
- docs/BUILDING.md: add Lyrical to the supported ROS 2 distributions list (`Rolling, Lyrical, Kilted, Jazzy, and Humble`).
- scripts/npmjs-readme.md: add Lyrical to the supported distros sentence and to the Prebuilt Platforms list; flip the ROS 2 SDK link from `en/jazzy/` to `en/lyrical/`.

Fix: #1458