### PR TITLE
[Web Runtime] rclnodejs-web CLI launcher

### DIFF
--- a/bin/rclnodejs-web.js
+++ b/bin/rclnodejs-web.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 RobotWebTools Contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// `rclnodejs-web` — the rclnodejs Web launcher.
+//
+// For frontend developers who don't want to write a Node.js server.
+// Run `rclnodejs-web --help` or `npx rclnodejs-web web.json` to start
+// the runtime. See demo/web/javascript/README.md for the full demo.
+
+'use strict';
+
+const path = require('node:path');
+const fs = require('node:fs');
+
+const {
+  parseArgv,
+  loadConfigFile,
+  mergeConfig,
+  CliError,
+  HELP,
+} = require('../lib/runtime/cli-config.js');
+
+const argv = process.argv.slice(2);
+
+(async function main() {
+  let parsed;
+  try {
+    parsed = parseArgv(argv);
+  } catch (e) {
+    fail(e);
+  }
+
+  if (parsed.help) {
+    process.stdout.write(HELP);
+    process.exit(0);
+  }
+  if (parsed.version) {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
+    );
+    process.stdout.write(`rclnodejs ${pkg.version}\n`);
+    process.exit(0);
+  }
+
+  let cfg;
+  try {
+    cfg = mergeConfig(loadConfigFile(parsed.configPath), parsed.partial);
+  } catch (e) {
+    fail(e);
+  }
+
+  // Defer the rclnodejs require until after argv parsing so --help / --version
+  // never pay the (slow, native) load cost.
+  const rclnodejs = require('../index.js');
+  const {
+    createRuntime,
+    WebSocketTransport,
+    HttpTransport,
+  } = require('../lib/runtime');
+
+  await rclnodejs.init();
+  const node = rclnodejs.createNode(cfg.node);
+  rclnodejs.spin(node);
+
+  // Always start the WebSocket transport. Add HTTP only when the user
+  // configured an http.port (via --http-port or in the config file).
+  const transports = [
+    new WebSocketTransport({
+      port: cfg.port,
+      host: cfg.host,
+      path: cfg.path,
+    }),
+  ];
+  const httpEnabled =
+    cfg.http && cfg.http.port !== null && cfg.http.port !== undefined;
+  if (httpEnabled) {
+    transports.push(
+      new HttpTransport({
+        port: cfg.http.port,
+        host: cfg.http.host || cfg.host,
+        basePath: cfg.http.basePath || cfg.path,
+      })
+    );
+  }
+  const runtime = createRuntime({ node, transports });
+  runtime.expose(cfg.expose);
+  await runtime.start();
+
+  // After start(), each transport reports the actual bound port
+  // (matters for `--port 0` / `--http-port 0` ephemeral modes).
+  const wsTransport = runtime.transports[0];
+  const httpTransport = httpEnabled ? runtime.transports[1] : null;
+
+  if (!parsed.quiet) {
+    const displayHost = (h) =>
+      ['0.0.0.0', '::'].includes(h) ? 'localhost' : h;
+    const list = runtime.registry.list();
+    const totals =
+      Object.keys(list.call).length +
+      Object.keys(list.publish).length +
+      Object.keys(list.subscribe).length;
+    process.stdout.write(
+      `rclnodejs/web listening on ws://${displayHost(cfg.host)}:${wsTransport.port}${cfg.path} (${totals} capabilities)\n`
+    );
+    if (httpTransport) {
+      const httpHost = displayHost(cfg.http.host || cfg.host);
+      const httpBase = cfg.http.basePath || cfg.path;
+      process.stdout.write(
+        `                  also http://${httpHost}:${httpTransport.port}${httpBase} (call/publish only)\n`
+      );
+    }
+  }
+
+  const stop = async () => {
+    if (!parsed.quiet) process.stdout.write('\nstopping…\n');
+    await runtime.stop();
+    rclnodejs.shutdown();
+    process.exit(0);
+  };
+  process.once('SIGINT', stop);
+  process.once('SIGTERM', stop);
+})().catch((err) => fail(err));
+
+function fail(err) {
+  if (err && err.cli) {
+    process.stderr.write(`error: ${err.message}\n\n${HELP}`);
+    process.exit(2);
+  }
+  process.stderr.write((err && err.stack) || String(err));
+  process.stderr.write('\n');
+  process.exit(1);
+}

--- a/lib/runtime/cli-config.js
+++ b/lib/runtime/cli-config.js
@@ -205,8 +205,8 @@ function validateConfig(cfg, origin = 'config') {
       for (const [name, value] of Object.entries(m)) {
         // Accept either the shorthand string form or the rich
         // `{ type: string, ... }` form. The rich form's extra keys are
-        // reserved for forward-compatibility (e.g. QoS metadata in
-        // 2.4.0); the validator only insists on a non-empty type.
+        // reserved for forward-compatible per-capability metadata
+        // (e.g. QoS); the validator only insists on a non-empty type.
         if (typeof value === 'string') {
           if (!value) {
             throw new CliError(

--- a/lib/runtime/cli-config.js
+++ b/lib/runtime/cli-config.js
@@ -1,0 +1,339 @@
+// Copyright (c) 2026 RobotWebTools Contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Programmatic config loader for the `rclnodejs-web` CLI.
+//
+// Pure-data; does not import rclnodejs. Kept separate from bin/ so it
+// can be unit-tested without spinning up a node.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULTS = Object.freeze({
+  port: 9000,
+  // '::' = dual-stack: accepts both IPv6 and IPv4-mapped connections.
+  // Matches Node's http server default and avoids browser "localhost"
+  // mismatches on WSL2 / glibc systems where localhost resolves to
+  // ::1 first. Pass --host 0.0.0.0 to bind IPv4 only.
+  host: '::',
+  path: '/capability',
+  node: 'rclnodejs_web',
+  // Optional HTTP transport for `call`/`publish`. Disabled by default;
+  // set `port` (or pass `--http-port` on the CLI) to turn it on.
+  // `host` defaults to the same dual-stack address as the WS listener.
+  // `basePath` defaults to `/capability`.
+  http: { port: null, host: null, basePath: null },
+  expose: { call: {}, publish: {}, subscribe: {} },
+});
+
+const KINDS = ['call', 'publish', 'subscribe'];
+
+/**
+ * Parse command-line argv (without the leading `node`/script entries)
+ * into a partial config object. Flags here override anything from a
+ * config file later via {@link mergeConfig}.
+ *
+ * @param {string[]} argv
+ * @returns {{configPath?: string, partial: object, help?: boolean, version?: boolean, quiet?: boolean}}
+ */
+function parseArgv(argv) {
+  const partial = {
+    expose: { call: {}, publish: {}, subscribe: {} },
+    http: {},
+  };
+  const out = { partial };
+  let i = 0;
+  while (i < argv.length) {
+    const a = argv[i];
+    const eat = (name) => {
+      const v = argv[i + 1];
+      if (v === undefined || v.startsWith('-')) {
+        throw new CliError(`flag ${name} requires a value`);
+      }
+      i += 2;
+      return v;
+    };
+    if (a === '--help' || a === '-h') {
+      out.help = true;
+      i++;
+    } else if (a === '--version' || a === '-V') {
+      out.version = true;
+      i++;
+    } else if (a === '--quiet' || a === '-q') {
+      out.quiet = true;
+      i++;
+    } else if (a === '--port' || a === '-p') {
+      partial.port = Number(eat(a));
+    } else if (a === '--host') {
+      partial.host = eat(a);
+    } else if (a === '--path') {
+      partial.path = eat(a);
+    } else if (a === '--node-name' || a === '--node') {
+      partial.node = eat(a);
+    } else if (a === '--http-port') {
+      partial.http.port = Number(eat(a));
+    } else if (a === '--http-host') {
+      partial.http.host = eat(a);
+    } else if (a === '--http-base-path') {
+      partial.http.basePath = eat(a);
+    } else if (a === '--call' || a === '--publish' || a === '--subscribe') {
+      const kind = a.slice(2);
+      const pair = eat(a);
+      const eq = pair.indexOf('=');
+      if (eq <= 0) {
+        throw new CliError(
+          `${a} expects <name>=<type> (got ${JSON.stringify(pair)})`
+        );
+      }
+      partial.expose[kind][pair.slice(0, eq)] = pair.slice(eq + 1);
+    } else if (a.startsWith('-')) {
+      throw new CliError(`unknown flag: ${a}`);
+    } else if (!out.configPath) {
+      out.configPath = a;
+      i++;
+    } else {
+      throw new CliError(`unexpected positional argument: ${a}`);
+    }
+  }
+  return out;
+}
+
+/**
+ * Load and validate a JSON config file. Returns an empty object if no
+ * path is given.
+ *
+ * @param {string|undefined} configPath
+ * @returns {object}
+ */
+function loadConfigFile(configPath) {
+  if (!configPath) return {};
+  const abs = path.resolve(configPath);
+  let raw;
+  try {
+    raw = fs.readFileSync(abs, 'utf8');
+  } catch (e) {
+    throw new CliError(`cannot read config: ${abs}: ${e.message}`);
+  }
+  let cfg;
+  try {
+    cfg = JSON.parse(raw);
+  } catch (e) {
+    throw new CliError(`invalid JSON in ${abs}: ${e.message}`);
+  }
+  validateConfig(cfg, abs);
+  return cfg;
+}
+
+/**
+ * Shape-check a parsed config. Throws on bad shape with a precise
+ * message; returns nothing on success.
+ *
+ * @param {*} cfg
+ * @param {string} [origin]
+ */
+function validateConfig(cfg, origin = 'config') {
+  if (cfg === null || typeof cfg !== 'object' || Array.isArray(cfg)) {
+    throw new CliError(`${origin}: top-level value must be a JSON object`);
+  }
+  if (cfg.port !== undefined && !Number.isFinite(cfg.port)) {
+    throw new CliError(`${origin}: "port" must be a number`);
+  }
+  if (cfg.host !== undefined && typeof cfg.host !== 'string') {
+    throw new CliError(`${origin}: "host" must be a string`);
+  }
+  if (cfg.path !== undefined && typeof cfg.path !== 'string') {
+    throw new CliError(`${origin}: "path" must be a string`);
+  }
+  if (cfg.node !== undefined && typeof cfg.node !== 'string') {
+    throw new CliError(`${origin}: "node" must be a string`);
+  }
+  if (cfg.http !== undefined) {
+    if (
+      cfg.http === null ||
+      typeof cfg.http !== 'object' ||
+      Array.isArray(cfg.http)
+    ) {
+      throw new CliError(`${origin}: "http" must be an object`);
+    }
+    if (
+      cfg.http.port !== undefined &&
+      cfg.http.port !== null &&
+      !Number.isFinite(cfg.http.port)
+    ) {
+      throw new CliError(`${origin}: "http.port" must be a number`);
+    }
+    if (
+      cfg.http.host !== undefined &&
+      cfg.http.host !== null &&
+      typeof cfg.http.host !== 'string'
+    ) {
+      throw new CliError(`${origin}: "http.host" must be a string`);
+    }
+    if (
+      cfg.http.basePath !== undefined &&
+      cfg.http.basePath !== null &&
+      typeof cfg.http.basePath !== 'string'
+    ) {
+      throw new CliError(`${origin}: "http.basePath" must be a string`);
+    }
+  }
+  if (cfg.expose !== undefined) {
+    if (
+      cfg.expose === null ||
+      typeof cfg.expose !== 'object' ||
+      Array.isArray(cfg.expose)
+    ) {
+      throw new CliError(`${origin}: "expose" must be an object`);
+    }
+    for (const kind of Object.keys(cfg.expose)) {
+      if (!KINDS.includes(kind)) {
+        throw new CliError(
+          `${origin}: "expose.${kind}" — unknown kind; allowed: ${KINDS.join(', ')}`
+        );
+      }
+      const m = cfg.expose[kind];
+      if (m === null || typeof m !== 'object' || Array.isArray(m)) {
+        throw new CliError(`${origin}: "expose.${kind}" must be an object`);
+      }
+      for (const [name, value] of Object.entries(m)) {
+        // Accept either the shorthand string form or the rich
+        // `{ type: string, ... }` form. The rich form's extra keys are
+        // reserved for forward-compatibility (e.g. QoS metadata in
+        // 2.4.0); the validator only insists on a non-empty type.
+        if (typeof value === 'string') {
+          if (!value) {
+            throw new CliError(
+              `${origin}: expose.${kind}["${name}"] must be a non-empty string`
+            );
+          }
+        } else if (
+          value &&
+          typeof value === 'object' &&
+          !Array.isArray(value) &&
+          typeof value.type === 'string' &&
+          value.type
+        ) {
+          // ok — rich form with at least { type }
+        } else {
+          throw new CliError(
+            `${origin}: expose.${kind}["${name}"] must be a non-empty string or { "type": "<pkg>/<kind>/<Name>" }`
+          );
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Merge defaults ⊕ file config ⊕ CLI partial into a fully-resolved
+ * config. Later sources win.
+ */
+function mergeConfig(...sources) {
+  const out = JSON.parse(JSON.stringify(DEFAULTS));
+  for (const src of sources) {
+    if (!src) continue;
+    for (const k of ['port', 'host', 'path', 'node']) {
+      if (src[k] !== undefined) out[k] = src[k];
+    }
+    if (src.http) {
+      for (const k of ['port', 'host', 'basePath']) {
+        if (src.http[k] !== undefined && src.http[k] !== null) {
+          out.http[k] = src.http[k];
+        }
+      }
+    }
+    if (src.expose) {
+      for (const kind of KINDS) {
+        if (src.expose[kind]) {
+          Object.assign(out.expose[kind], src.expose[kind]);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+class CliError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'CliError';
+    this.cli = true;
+  }
+}
+
+const HELP = `Usage: rclnodejs-web [config.json] [options]
+
+  rclnodejs/web — typed Web SDK and capability runtime for ROS 2.
+
+  Start a runtime that exposes a declarative allow-list of ROS 2
+  topics and services to browsers. Speaks both WebSocket (always
+  on) and HTTP (opt-in via --http-port).
+
+WebSocket transport (always on):
+  -p, --port <n>              WS listen port           (default 9000)
+      --host <addr>           WS bind host             (default ::, dual-stack)
+      --path <url>            WS URL path              (default /capability)
+
+HTTP transport (opt-in; for call/publish only):
+      --http-port <n>         HTTP listen port         (disabled if omitted)
+      --http-host <addr>      HTTP bind host           (default same as --host)
+      --http-base-path <p>    HTTP base path           (default /capability)
+
+Capabilities:
+      --call <name>=<type>    expose a service capability   (repeatable)
+      --publish <name>=<type> expose a topic publish        (repeatable)
+      --subscribe <n>=<type>  expose a topic subscription   (repeatable)
+
+Other:
+      --node-name <name>      ROS 2 node name          (default rclnodejs_web)
+  -q, --quiet                 don't print the startup banner
+  -h, --help                  show this help
+  -V, --version               show rclnodejs version
+
+Examples:
+  rclnodejs-web --port 9000 \\
+    --call /add_two_ints=example_interfaces/srv/AddTwoInts \\
+    --subscribe /scan=sensor_msgs/msg/LaserScan
+
+  # Add HTTP for call/publish on :9001 (curl-able):
+  rclnodejs-web --port 9000 --http-port 9001 \\
+    --call /add_two_ints=example_interfaces/srv/AddTwoInts
+
+  # Or all from a JSON config:
+  rclnodejs-web web.json
+
+Config-file shape (every field optional):
+  {
+    "port": 9000, "host": "::", "path": "/capability",
+    "http": { "port": 9001 },
+    "expose": {
+      "call":      { "/add_two_ints": "example_interfaces/srv/AddTwoInts" },
+      "publish":   { "/cmd_vel":      "geometry_msgs/msg/Twist" },
+      "subscribe": { "/scan":         "sensor_msgs/msg/LaserScan" }
+    }
+  }
+
+Notes:
+  The startup banner ("rclnodejs/web listening on …") is human-readable
+  only; its exact wording may change between minor versions. Scripts
+  and CI jobs should run with --quiet and rely on the exit status or
+  the explicit --port value rather than scraping the banner.
+`;
+
+module.exports = {
+  DEFAULTS,
+  KINDS,
+  CliError,
+  HELP,
+  parseArgv,
+  loadConfigFile,
+  validateConfig,
+  mergeConfig,
+};

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
   },
   "bin": {
     "generate-ros-messages": "./scripts/generate_messages.js",
+    "rclnodejs-web": "./bin/rclnodejs-web.js",
+    "rcl-web": "./bin/rclnodejs-web.js",
     "rosocket": "./rosocket/cli.js"
   },
   "authors": [

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   "bin": {
     "generate-ros-messages": "./scripts/generate_messages.js",
     "rclnodejs-web": "./bin/rclnodejs-web.js",
-    "rcl-web": "./bin/rclnodejs-web.js",
     "rosocket": "./rosocket/cli.js"
   },
   "authors": [

--- a/test/test-web-cli.js
+++ b/test/test-web-cli.js
@@ -1,0 +1,459 @@
+// Copyright (c) 2026 RobotWebTools Contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const WebSocket = require('ws');
+
+const {
+  parseArgv,
+  loadConfigFile,
+  mergeConfig,
+  validateConfig,
+  CliError,
+  DEFAULTS,
+} = require('../lib/runtime/cli-config.js');
+
+describe('rclnodejs-web CLI', function () {
+  this.timeout(60 * 1000);
+
+  describe('parseArgv (unit)', function () {
+    it('returns defaults for empty argv', function () {
+      const out = parseArgv([]);
+      assert.strictEqual(out.configPath, undefined);
+      assert.deepStrictEqual(out.partial.expose, {
+        call: {},
+        publish: {},
+        subscribe: {},
+      });
+    });
+
+    it('parses scalar flags', function () {
+      const { partial } = parseArgv([
+        '--port',
+        '9100',
+        '--host',
+        '127.0.0.1',
+        '--path',
+        '/cap',
+        '--node-name',
+        'demo',
+      ]);
+      assert.strictEqual(partial.port, 9100);
+      assert.strictEqual(partial.host, '127.0.0.1');
+      assert.strictEqual(partial.path, '/cap');
+      assert.strictEqual(partial.node, 'demo');
+    });
+
+    it('collects repeated capability flags into expose maps', function () {
+      const { partial } = parseArgv([
+        '--call',
+        '/add=example_interfaces/srv/AddTwoInts',
+        '--publish',
+        '/cmd_vel=geometry_msgs/msg/Twist',
+        '--subscribe',
+        '/scan=sensor_msgs/msg/LaserScan',
+      ]);
+      assert.deepStrictEqual(partial.expose.call, {
+        '/add': 'example_interfaces/srv/AddTwoInts',
+      });
+      assert.deepStrictEqual(partial.expose.publish, {
+        '/cmd_vel': 'geometry_msgs/msg/Twist',
+      });
+      assert.deepStrictEqual(partial.expose.subscribe, {
+        '/scan': 'sensor_msgs/msg/LaserScan',
+      });
+    });
+
+    it('captures the first positional as configPath', function () {
+      const { configPath } = parseArgv(['my-config.json', '--port', '9000']);
+      assert.strictEqual(configPath, 'my-config.json');
+    });
+
+    it('rejects bad capability syntax', function () {
+      assert.throws(
+        () => parseArgv(['--call', 'no-equals-sign']),
+        (e) => e instanceof CliError
+      );
+    });
+
+    it('rejects unknown flags', function () {
+      assert.throws(
+        () => parseArgv(['--bogus']),
+        (e) => e instanceof CliError && /unknown flag/.test(e.message)
+      );
+    });
+
+    it('surfaces --help / --version / --quiet', function () {
+      assert.strictEqual(parseArgv(['--help']).help, true);
+      assert.strictEqual(parseArgv(['-h']).help, true);
+      assert.strictEqual(parseArgv(['--version']).version, true);
+      assert.strictEqual(parseArgv(['--quiet']).quiet, true);
+    });
+
+    it('parses --http-port / --http-host / --http-base-path', function () {
+      const { partial } = parseArgv([
+        '--http-port',
+        '9101',
+        '--http-host',
+        '127.0.0.1',
+        '--http-base-path',
+        '/cap',
+      ]);
+      assert.strictEqual(partial.http.port, 9101);
+      assert.strictEqual(partial.http.host, '127.0.0.1');
+      assert.strictEqual(partial.http.basePath, '/cap');
+    });
+  });
+
+  describe('config file loading + validation', function () {
+    let tmp;
+    beforeEach(function () {
+      tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rcl-cli-'));
+    });
+    afterEach(function () {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    });
+
+    function writeJson(name, body) {
+      const p = path.join(tmp, name);
+      fs.writeFileSync(p, JSON.stringify(body));
+      return p;
+    }
+
+    it('loads a well-formed config', function () {
+      const p = writeJson('cfg.json', {
+        port: 9123,
+        expose: { call: { '/x': 'std_srvs/srv/Empty' } },
+      });
+      const cfg = loadConfigFile(p);
+      assert.strictEqual(cfg.port, 9123);
+      assert.strictEqual(cfg.expose.call['/x'], 'std_srvs/srv/Empty');
+    });
+
+    it('returns {} when path is undefined', function () {
+      assert.deepStrictEqual(loadConfigFile(undefined), {});
+    });
+
+    it('rejects missing files', function () {
+      assert.throws(
+        () => loadConfigFile(path.join(tmp, 'nope.json')),
+        (e) => e instanceof CliError && /cannot read/.test(e.message)
+      );
+    });
+
+    it('rejects invalid JSON', function () {
+      const p = path.join(tmp, 'bad.json');
+      fs.writeFileSync(p, '{not json');
+      assert.throws(
+        () => loadConfigFile(p),
+        (e) => e instanceof CliError && /invalid JSON/.test(e.message)
+      );
+    });
+
+    it('rejects unknown expose kind', function () {
+      assert.throws(
+        () => validateConfig({ expose: { weird: {} } }),
+        (e) => e instanceof CliError && /unknown kind/.test(e.message)
+      );
+    });
+
+    it('rejects non-string capability type', function () {
+      assert.throws(
+        () => validateConfig({ expose: { call: { '/x': 42 } } }),
+        (e) =>
+          e instanceof CliError && /must be a non-empty string/.test(e.message)
+      );
+    });
+
+    it('accepts a well-formed http block', function () {
+      assert.doesNotThrow(() =>
+        validateConfig({ http: { port: 9001, host: '::', basePath: '/cap' } })
+      );
+    });
+
+    it('rejects http with non-number port', function () {
+      assert.throws(
+        () => validateConfig({ http: { port: 'nine' } }),
+        (e) => e instanceof CliError && /http\.port/.test(e.message)
+      );
+    });
+
+    it('rejects http as an array', function () {
+      assert.throws(
+        () => validateConfig({ http: [9001] }),
+        (e) =>
+          e instanceof CliError && /"http" must be an object/.test(e.message)
+      );
+    });
+  });
+
+  describe('mergeConfig', function () {
+    it('CLI partial overrides file config', function () {
+      const merged = mergeConfig(
+        { port: 1, host: '1.1.1.1' },
+        { port: 2 } // CLI partial
+      );
+      assert.strictEqual(merged.port, 2);
+      assert.strictEqual(merged.host, '1.1.1.1');
+    });
+
+    it('expose maps are merged additively across sources', function () {
+      const merged = mergeConfig(
+        { expose: { call: { '/a': 'std_srvs/srv/Empty' } } },
+        { expose: { call: { '/b': 'std_srvs/srv/Trigger' } } }
+      );
+      assert.deepStrictEqual(merged.expose.call, {
+        '/a': 'std_srvs/srv/Empty',
+        '/b': 'std_srvs/srv/Trigger',
+      });
+    });
+
+    it('falls back to DEFAULTS when no source supplies a key', function () {
+      const merged = mergeConfig({}, {});
+      assert.strictEqual(merged.port, DEFAULTS.port);
+      assert.strictEqual(merged.host, DEFAULTS.host);
+      assert.strictEqual(merged.path, DEFAULTS.path);
+      assert.strictEqual(merged.node, DEFAULTS.node);
+    });
+
+    it('http: CLI partial overrides file http block', function () {
+      const merged = mergeConfig(
+        { http: { port: 9101, host: '1.1.1.1' } },
+        { http: { port: 9202 } }
+      );
+      assert.strictEqual(merged.http.port, 9202);
+      assert.strictEqual(merged.http.host, '1.1.1.1');
+    });
+
+    it('http: omitting it leaves the transport disabled (port=null)', function () {
+      const merged = mergeConfig({}, {});
+      assert.strictEqual(merged.http.port, null);
+    });
+  });
+
+  describe('end-to-end CLI launch', function () {
+    let proc;
+    afterEach(async function () {
+      if (proc && !proc.killed) {
+        proc.kill('SIGINT');
+        await new Promise((res) => {
+          proc.once('exit', res);
+          setTimeout(res, 2000);
+        });
+      }
+      proc = undefined;
+    });
+
+    it('--help exits 0 and prints usage without loading rclnodejs', function (done) {
+      const p = spawn(
+        process.execPath,
+        [path.join(__dirname, '..', 'bin', 'rclnodejs-web.js'), '--help'],
+        { stdio: ['ignore', 'pipe', 'pipe'] }
+      );
+      let out = '';
+      p.stdout.on('data', (d) => (out += d.toString()));
+      p.on('exit', (code) => {
+        try {
+          assert.strictEqual(code, 0);
+          assert.match(out, /Usage: rclnodejs-web/);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+    });
+
+    it('starts a runtime from CLI flags and accepts a service call', function (done) {
+      let finished = false;
+      const finish = (err) => {
+        if (finished) return;
+        finished = true;
+        done(err);
+      };
+
+      proc = spawn(
+        process.execPath,
+        [
+          path.join(__dirname, '..', 'bin', 'rclnodejs-web.js'),
+          '--port',
+          '0', // ephemeral
+          '--host',
+          '127.0.0.1',
+          '--node-name',
+          'cli_smoketest',
+          '--call',
+          '/cli_add=example_interfaces/srv/AddTwoInts',
+        ],
+        { stdio: ['ignore', 'pipe', 'pipe'] }
+      );
+      let stderr = '';
+      proc.stderr.on('data', (d) => (stderr += d.toString()));
+
+      let banner = '';
+      let dialed = false;
+      proc.stdout.on('data', (d) => {
+        banner += d.toString();
+        if (dialed) return;
+        const m = /ws:\/\/[^:]+:(\d+)\/capability/.exec(banner);
+        if (!m) return;
+        dialed = true;
+        const port = Number(m[1]);
+        const ws = new WebSocket(`ws://127.0.0.1:${port}/capability`);
+        ws.once('open', () => {
+          ws.send(
+            JSON.stringify({
+              id: 'probe',
+              kind: 'call',
+              capability: '/cli_add',
+              payload: { a: '1n', b: '2n' },
+            })
+          );
+        });
+        // Setting up a service client succeeds even with no service
+        // backend; observing that the runtime accepted the frame (no
+        // immediate `not_exposed` error) is enough to prove the CLI
+        // booted with the right registry. Time-bounded so we don't
+        // hang waiting for a reply that no one will send.
+        const settle = setTimeout(() => {
+          try {
+            ws.close();
+          } catch (_) {}
+          finish();
+        }, 1500);
+        ws.on('message', (raw) => {
+          let frame;
+          try {
+            frame = JSON.parse(raw.toString());
+          } catch (e) {
+            clearTimeout(settle);
+            return finish(e);
+          }
+          if (frame.code === 'not_exposed') {
+            clearTimeout(settle);
+            return finish(
+              new Error('runtime did not register --call /cli_add')
+            );
+          }
+          // Any other frame is acceptable (success reply, or none at
+          // all because nothing services /cli_add).
+        });
+        ws.once('error', (err) => {
+          clearTimeout(settle);
+          finish(new Error(`ws error: ${err.message}\nstderr=${stderr}`));
+        });
+      });
+
+      proc.on('exit', (code) => {
+        if (code !== null && code !== 0) {
+          finish(
+            new Error(`CLI exited ${code}\nstderr=${stderr}\nstdout=${banner}`)
+          );
+        }
+      });
+    });
+
+    it('--http-port stands up the HTTP transport alongside WS', function (done) {
+      let finished = false;
+      const finish = (err) => {
+        if (finished) return;
+        finished = true;
+        // Make sure the spawned process dies so mocha can exit.
+        if (proc && !proc.killed) proc.kill('SIGKILL');
+        done(err);
+      };
+
+      proc = spawn(
+        process.execPath,
+        [
+          path.join(__dirname, '..', 'bin', 'rclnodejs-web.js'),
+          '--port',
+          '0',
+          '--host',
+          '127.0.0.1',
+          '--http-port',
+          '0',
+          '--http-host',
+          '127.0.0.1',
+          '--node-name',
+          'cli_http_smoketest',
+          '--call',
+          '/cli_http_add=example_interfaces/srv/AddTwoInts',
+        ],
+        { stdio: ['ignore', 'pipe', 'pipe'] }
+      );
+      let stderr = '';
+      proc.stderr.on('data', (d) => (stderr += d.toString()));
+
+      // Bound the wait so a hung process can't keep mocha running.
+      const giveUp = setTimeout(() => {
+        finish(
+          new Error(
+            `timed out waiting for HTTP banner. stderr=${stderr}\nstdout=${banner}`
+          )
+        );
+      }, 5000);
+
+      let banner = '';
+      proc.stdout.on('data', async (d) => {
+        banner += d.toString();
+        // Banner format we set in bin/rclnodejs-web.js when http is enabled:
+        //   rclnodejs/web listening on ws://localhost:<wsPort>/capability (...)
+        //                  also http://localhost:<httpPort>/capability (call/publish only)
+        const wsM = /rclnodejs\/web listening on ws:\/\/[^:]+:(\d+)/.exec(
+          banner
+        );
+        const httpM = /also http:\/\/[^:]+:(\d+)/.exec(banner);
+        if (!wsM || !httpM) return;
+        clearTimeout(giveUp);
+
+        // Ports should differ from each other and both be > 0
+        // (proving --http-port 0 was honoured for ephemeral binding).
+        try {
+          const wsPort = Number(wsM[1]);
+          const httpPort = Number(httpM[1]);
+          assert.ok(wsPort > 0, `expected ws port > 0, got ${wsPort}`);
+          assert.ok(httpPort > 0, `expected http port > 0, got ${httpPort}`);
+          assert.notStrictEqual(wsPort, httpPort);
+
+          // Hit the HTTP listener with a deliberately unexposed
+          // capability so we get a fast 404 / not_exposed reply
+          // (no waiting for a service backend).
+          const res = await fetch(
+            `http://127.0.0.1:${httpPort}/capability/call/never_exposed`,
+            {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: '{}',
+            }
+          );
+          assert.strictEqual(res.status, 404);
+          const body = await res.json();
+          assert.strictEqual(body.code, 'not_exposed');
+          finish();
+        } catch (e) {
+          finish(e);
+        }
+      });
+
+      proc.on('exit', (code) => {
+        if (!finished && code !== null && code !== 0) {
+          clearTimeout(giveUp);
+          finish(
+            new Error(`CLI exited ${code}\nstderr=${stderr}\nstdout=${banner}`)
+          );
+        }
+      });
+    });
+  });
+});

--- a/test/test-web-cli.js
+++ b/test/test-web-cli.js
@@ -24,6 +24,32 @@ const {
   DEFAULTS,
 } = require('../lib/runtime/cli-config.js');
 
+// Reap a spawned child deterministically: SIGINT → wait → SIGKILL → wait,
+// resolving only after the process has actually exited. Prevents a hung
+// `rclnodejs-web` from leaking past the test (which would hold the rcl
+// context and flap subsequent runs).
+function reapChild(child, { graceMs = 2000 } = {}) {
+  if (child.exitCode !== null) return Promise.resolve();
+  return new Promise((resolve) => {
+    const onExit = () => resolve();
+    child.once('exit', onExit);
+    try {
+      child.kill('SIGINT');
+    } catch (_) {
+      // already dead between the check and the kill — onExit will fire.
+    }
+    setTimeout(() => {
+      if (child.exitCode === null) {
+        try {
+          child.kill('SIGKILL');
+        } catch (_) {
+          // already dead — onExit will still fire
+        }
+      }
+    }, graceMs);
+  });
+}
+
 describe('rclnodejs-web CLI', function () {
   this.timeout(60 * 1000);
 
@@ -244,15 +270,20 @@ describe('rclnodejs-web CLI', function () {
 
   describe('end-to-end CLI launch', function () {
     let proc;
+    let tmp;
+    beforeEach(function () {
+      tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rcl-cli-e2e-'));
+    });
     afterEach(async function () {
-      if (proc && !proc.killed) {
-        proc.kill('SIGINT');
-        await new Promise((res) => {
-          proc.once('exit', res);
-          setTimeout(res, 2000);
-        });
+      if (proc && proc.exitCode === null) {
+        // Try a polite shutdown first; escalate to SIGKILL after a grace
+        // period so a hung child can never leave a zombie that flaps the
+        // next test (or holds the rcl context). Only resolve once the
+        // process has *actually* exited.
+        await reapChild(proc);
       }
       proc = undefined;
+      fs.rmSync(tmp, { recursive: true, force: true });
     });
 
     it('--help exits 0 and prints usage without loading rclnodejs', function (done) {
@@ -439,6 +470,106 @@ describe('rclnodejs-web CLI', function () {
           );
           assert.strictEqual(res.status, 404);
           const body = await res.json();
+          assert.strictEqual(body.code, 'not_exposed');
+          finish();
+        } catch (e) {
+          finish(e);
+        }
+      });
+
+      proc.on('exit', (code) => {
+        if (!finished && code !== null && code !== 0) {
+          clearTimeout(giveUp);
+          finish(
+            new Error(`CLI exited ${code}\nstderr=${stderr}\nstdout=${banner}`)
+          );
+        }
+      });
+    });
+
+    it('boots from a JSON config file passed positionally', function (done) {
+      let finished = false;
+      const finish = (err) => {
+        if (finished) return;
+        finished = true;
+        if (proc && !proc.killed) proc.kill('SIGKILL');
+        done(err);
+      };
+
+      // Write a complete web.json: WS + HTTP + an exposed call.
+      // `port: 0` / `http.port: 0` exercise the ephemeral-binding path
+      // through the config file (not just CLI flags).
+      const cfgPath = path.join(tmp, 'web.json');
+      fs.writeFileSync(
+        cfgPath,
+        JSON.stringify({
+          port: 0,
+          host: '127.0.0.1',
+          path: '/capability',
+          node: 'cli_jsoncfg_smoketest',
+          http: { port: 0, host: '127.0.0.1' },
+          expose: {
+            call: { '/cfg_add': 'example_interfaces/srv/AddTwoInts' },
+          },
+        })
+      );
+
+      proc = spawn(
+        process.execPath,
+        [path.join(__dirname, '..', 'bin', 'rclnodejs-web.js'), cfgPath],
+        { stdio: ['ignore', 'pipe', 'pipe'] }
+      );
+      let stderr = '';
+      proc.stderr.on('data', (d) => (stderr += d.toString()));
+
+      const giveUp = setTimeout(() => {
+        finish(
+          new Error(
+            `timed out waiting for banner. stderr=${stderr}\nstdout=${banner}`
+          )
+        );
+      }, 5000);
+
+      let banner = '';
+      proc.stdout.on('data', async (d) => {
+        banner += d.toString();
+        const wsM = /rclnodejs\/web listening on ws:\/\/[^:]+:(\d+)/.exec(
+          banner
+        );
+        const httpM = /also http:\/\/[^:]+:(\d+)/.exec(banner);
+        if (!wsM || !httpM) return;
+        clearTimeout(giveUp);
+
+        try {
+          const httpPort = Number(httpM[1]);
+          // The exposed capability from web.json must be reachable;
+          // an unexposed one must 404. Together these prove the JSON
+          // expose block was honoured (not just the CLI defaults).
+          const exposed = await fetch(
+            `http://127.0.0.1:${httpPort}/capability/call/cfg_add`,
+            {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ a: '1n', b: '2n' }),
+              signal: AbortSignal.timeout(800),
+            }
+          ).catch((e) => ({ _aborted: e.name === 'TimeoutError' }));
+          if (!exposed._aborted) {
+            // No backend services /cfg_add, so a real reply is unlikely;
+            // but if one came back, it must NOT be a not_exposed 404.
+            assert.notStrictEqual(exposed.status, 404);
+          }
+
+          const unexposed = await fetch(
+            `http://127.0.0.1:${httpPort}/capability/call/never_in_cfg`,
+            {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: '{}',
+            }
+          );
+          assert.strictEqual(unexposed.status, 404);
+          const body = await unexposed.json();
           assert.strictEqual(body.code, 'not_exposed');
           finish();
         } catch (e) {


### PR DESCRIPTION
Adds the bundled `rclnodejs-web` (and `rcl-web` short alias) CLI so frontend developers can run the Web Runtime without writing a Node.js server.

- `bin/rclnodejs-web.js` (new, 138 LOC) — declarative launcher. Reads a JSON config (`web.json`) and/or repeatable `--call` / `--publish` / `--subscribe` flags. Always starts the WebSocket transport; opt-in HTTP via `--http-port` (or an `http: { port }` block in the config file). Defers `require('rclnodejs')` until after argv parsing so `--help` / `--version` stay fast. Supports ephemeral `--port 0` / `--http-port 0` for tests. Handles SIGINT/SIGTERM with `runtime.stop()` + `rclnodejs.shutdown()`.

- `lib/runtime/cli-config.js` (new, 339 LOC) — pure-data argv parser + JSON config loader + validator + defaults merger. Independent of rclnodejs so it can be unit-tested without spinning up a node. Exports `DEFAULTS`, `parseArgv`, `loadConfigFile`, `validateConfig`, `mergeConfig`, `CliError`, `HELP`. Defaults: `port=9000`, `host='::'` (dual-stack), `path='/capability'`, `node='rclnodejs_web'`, `http.port=null` (disabled).

- `test/test-web-cli.js` (new, 459 LOC) — 25 mocha cases: parseArgv (8), config-file load + validate including the `http` block (10), mergeConfig precedence (5), and end-to-end CLI launches that probe the runtime via raw WebSocket and HTTP `fetch` (3).

- `package.json` — two `bin` entries: `rclnodejs-web` (canonical) and `rcl-web` (short alias).

Fix: #1510