### PR TITLE
Align WS and HTTP transports on a default `/capability` path

### DIFF
--- a/test/test-type-description-service.js
+++ b/test/test-type-description-service.js
@@ -89,28 +89,17 @@ describe('type description service test suite', function () {
       this.skip();
     }
 
-    setTimeout(() => {
-      exec(
-        'ros2 param list /test_type_description_service',
-        (error, stdout, stderr) => {
-          if (error || stderr) {
-            done(
-              new Error(
-                `Test type description service configured by parameter failed. Error: ${error}, Stderr: ${stderr}`
-              )
-            );
-            return;
-          }
-          if (stdout.includes('start_type_description_service')) {
-            done();
-          } else {
-            done(
-              new Error("'start_type_description_service' not found in stdout.")
-            );
-          }
-        }
-      );
-    }, 1000);
+    // ROS 2 graph discovery is asynchronous: there is no guarantee
+    // that an external `ros2` CLI process will see this node
+    // immediately after rclnodejs.spin() returns. A fixed setTimeout
+    // is racy on slower runners (notably the Rolling lane). Poll
+    // instead, with a generous overall budget.
+    waitForRos2Cli(
+      'ros2 param list /test_type_description_service',
+      (stdout) => stdout.includes('start_type_description_service'),
+      done,
+      "'start_type_description_service' not found in stdout."
+    );
   });
 
   it('Test start_type_description_service parameter value', function (done) {
@@ -118,30 +107,59 @@ describe('type description service test suite', function () {
       this.skip();
     }
 
-    setTimeout(() => {
-      exec(
-        'ros2 param get /test_type_description_service start_type_description_service',
-        (error, stdout, stderr) => {
-          if (error || stderr) {
-            done(
-              new Error(
-                `Test type description service configured by parameter failed. Error: ${error}, Stderr: ${stderr}`
-              )
-            );
-            return;
-          }
-          if (stdout.includes('Boolean value is: True')) {
-            done();
-          } else {
-            console.log(stdout);
-            done(
-              new Error(
-                "'start_type_description_service param value' not found in stdout."
-              )
-            );
-          }
-        }
-      );
-    }, 1000);
+    waitForRos2Cli(
+      'ros2 param get /test_type_description_service start_type_description_service',
+      (stdout) => stdout.includes('Boolean value is: True'),
+      done,
+      "'start_type_description_service param value' not found in stdout."
+    );
   });
 });
+
+// Run a `ros2 ...` CLI command repeatedly until either `predicate(stdout)`
+// returns true (success) or the overall budget runs out. Treats
+// `Node not found` and other transient failures as retryable while the
+// graph is still propagating; surfaces the last error otherwise.
+function waitForRos2Cli(
+  cmd,
+  predicate,
+  done,
+  notFoundMessage,
+  { timeoutMs = 15000, intervalMs = 500 } = {}
+) {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr = null;
+  let lastStdout = '';
+  let lastStderr = '';
+
+  const tick = () => {
+    exec(cmd, (error, stdout, stderr) => {
+      lastErr = error;
+      lastStdout = stdout || '';
+      lastStderr = stderr || '';
+
+      if (!error && !stderr && predicate(lastStdout)) {
+        return done();
+      }
+
+      if (Date.now() < deadline) {
+        return setTimeout(tick, intervalMs);
+      }
+
+      // Timed out. Prefer the most informative failure: the predicate
+      // mismatch (we got a CLI response but the wrong content) wins
+      // over a transient discovery error.
+      if (!error && !stderr) {
+        return done(new Error(`${notFoundMessage}\nstdout: ${lastStdout}`));
+      }
+      done(
+        new Error(
+          `\`${cmd}\` did not succeed within ${timeoutMs}ms. ` +
+            `Last error: ${lastErr}, last stderr: ${lastStderr}`
+        )
+      );
+    });
+  };
+
+  tick();
+}

--- a/test/test-web-http.js
+++ b/test/test-web-http.js
@@ -238,6 +238,33 @@ describe('rclnodejs/web — HTTP transport (call + publish)', function () {
         await ros.close();
       }
     });
+
+    // The HTTP transport's default basePath is `/capability`. Callers
+    // should be able to spell that out explicitly without the SDK
+    // double-prefixing it on every fetch — `'http://host:port'` and
+    // `'http://host:port/capability'` must produce the same request
+    // URLs.
+    it('accepts URLs with explicit /capability suffix without double-prefixing', async function () {
+      const ros = await connect(httpBase + '/capability');
+      try {
+        const reply = await ros.call('/http_add', { a: '5n', b: '7n' });
+        assert.strictEqual(reply.sum, '12n');
+      } finally {
+        await ros.close();
+      }
+    });
+
+    it('idempotent under { http } form too', async function () {
+      const ros = await connect({ http: httpBase + '/capability' });
+      try {
+        const ret = await ros.publish('/http_chatter', {
+          data: 'explicit-base',
+        });
+        assert.strictEqual(ret, undefined);
+      } finally {
+        await ros.close();
+      }
+    });
   });
 
   // -----------------------------------------------------------------

--- a/test/test-web-ws.js
+++ b/test/test-web-ws.js
@@ -133,6 +133,31 @@ describe('rclnodejs/web (Browser SDK)', function () {
       await ros.close();
     }
   });
+
+  // The runtime listens on `/capability` by default. Callers should be
+  // able to omit that path from the URL and still connect — the SDK
+  // appends it automatically when the user-supplied URL has no path.
+  it('appends the default /capability path when the URL has none', async function () {
+    const port = runtime.transports[0].port;
+    const ros = await connect(`ws://127.0.0.1:${port}`);
+    try {
+      const sub = await ros.subscribe('/rt_chatter', () => {});
+      await sub.close();
+    } finally {
+      await ros.close();
+    }
+  });
+
+  it('appends the default /capability path inside { ws } form', async function () {
+    const port = runtime.transports[0].port;
+    const ros = await connect({ ws: `ws://127.0.0.1:${port}` });
+    try {
+      const sub = await ros.subscribe('/rt_chatter', () => {});
+      await sub.close();
+    } finally {
+      await ros.close();
+    }
+  });
 });
 
 function waitFor(predicate, timeoutMs) {

--- a/web/client.js
+++ b/web/client.js
@@ -238,8 +238,16 @@ class _WsLink {
  */
 class _HttpLink {
   constructor(baseUrl) {
-    // Normalise: strip trailing slash so we can append `/capability/<kind>/<name>`
-    this.baseUrl = baseUrl.replace(/\/+$/, '');
+    // Normalise: strip trailing slash so we can append the path. If
+    // the user URL already ends with `/capability` (e.g. they spelled
+    // it out explicitly, mirroring the WS form), don't double-prefix
+    // it on every fetch. The default-runtime layout still works for
+    // the bare-host form `'http://host:9001'` — we just append the
+    // default path ourselves below.
+    const trimmed = baseUrl.replace(/\/+$/, '');
+    this.baseUrl = trimmed.endsWith('/capability')
+      ? trimmed
+      : trimmed + '/capability';
   }
 
   async connect() {
@@ -261,8 +269,7 @@ class _HttpLink {
   }
 
   async _fetch(kind, capability, payload, expectBody) {
-    const url =
-      this.baseUrl + '/capability/' + kind + '/' + _encodeRosName(capability);
+    const url = this.baseUrl + '/' + kind + '/' + _encodeRosName(capability);
     let res;
     try {
       res = await fetch(url, {

--- a/web/client.js
+++ b/web/client.js
@@ -328,17 +328,18 @@ function _encodeRosName(name) {
  *     same host with `/capability` appended.
  *   - object `{http, ws}`    → both URLs spelled out explicitly.
  *
- * **Path conventions.** The single-URL forms assume the server uses
- * the default `/capability` layout for both transports. If you change
- * `--path` / `--http-base-path` on the server (or sit it behind a
- * path-rewriting proxy), pass the full URLs via `{http, ws}` so the
- * SDK does not have to guess.
+ * **Path conventions.** When a `ws://` / `wss://` URL is passed
+ * without a path (or with just `/`), the SDK appends the runtime's
+ * default `/capability` path automatically — `'ws://host:9000'` and
+ * `'ws://host:9000/capability'` therefore behave identically. Pass
+ * an explicit non-default path if your server changed `--path` /
+ * `--http-base-path` or sits behind a path-rewriting proxy.
  *
  * @example
  *   import { connect } from 'rclnodejs/web';
  *
- *   // WebSocket-only
- *   const ros = await connect('ws://robot.local:9000/capability');
+ *   // WebSocket-only (path defaults to /capability)
+ *   const ros = await connect('ws://robot.local:9000');
  *
  *   // HTTP for call/publish, automatic WS sibling for subscribe
  *   const ros = await connect('http://robot.local:9001');
@@ -473,7 +474,7 @@ function _resolveUrls(url) {
   // Form 1: explicit { http, ws } pair.
   if (url && typeof url === 'object' && !Array.isArray(url)) {
     const httpUrl = _validateEndpoint(url.http, 'http');
-    const wsUrl = _validateEndpoint(url.ws, 'ws');
+    const wsUrl = _normaliseWsPath(_validateEndpoint(url.ws, 'ws'));
     if (!httpUrl && !wsUrl) {
       throw new TypeError(
         'connect({http, ws}): at least one of http or ws must be provided'
@@ -489,7 +490,7 @@ function _resolveUrls(url) {
     );
   }
   if (/^wss?:\/\//i.test(url)) {
-    return { httpUrl: null, wsUrl: url, wsExplicit: true };
+    return { httpUrl: null, wsUrl: _normaliseWsPath(url), wsExplicit: true };
   }
   if (/^https?:\/\//i.test(url)) {
     // HTTP base URL: derive a sibling WS URL lazily — we don't open
@@ -499,6 +500,26 @@ function _resolveUrls(url) {
   throw new TypeError(
     `connect(url): unrecognised URL scheme: ${url} (expected ws://, wss://, http://, or https://)`
   );
+}
+
+// Append the runtime's default `/capability` path when the caller
+// passed a bare host (`ws://host:9000` or `ws://host:9000/`). Leave
+// any explicit non-empty path untouched so users behind a
+// path-rewriting proxy or with a non-default `WebSocketTransport({
+// path })` keep working. Returns the input unchanged on parse error
+// (let the underlying WebSocket constructor surface the bad URL).
+function _normaliseWsPath(wsUrl) {
+  if (!wsUrl) return wsUrl;
+  try {
+    const u = new URL(wsUrl);
+    if (u.pathname === '' || u.pathname === '/') {
+      u.pathname = '/capability';
+      return u.toString();
+    }
+    return wsUrl;
+  } catch (_) {
+    return wsUrl;
+  }
 }
 
 // Swap http(s) → ws(s) and append the default `/capability` path.

--- a/web/index.d.ts
+++ b/web/index.d.ts
@@ -143,12 +143,12 @@ declare module 'rclnodejs/web' {
    *     host with `/capability` appended.
    *   - {@link ConnectEndpoints} — both URLs spelled out.
    *
-   * **Path conventions.** The single-URL forms assume the server uses
-   * the default `rclnodejs-web` path layout: `/capability` for both
-   * transports. If you change `--http-base-path` or `--path` on the
-   * server (or sit it behind a path-rewriting proxy), pass the full
-   * URLs via {@link ConnectEndpoints} instead so the SDK does not
-   * have to guess.
+   * **Path conventions.** When a `ws://` / `wss://` URL is passed
+   * without a path (or with just `/`), the SDK appends the runtime's
+   * default `/capability` path automatically — so `'ws://host:9000'`
+   * and `'ws://host:9000/capability'` behave identically. Pass an
+   * explicit non-default path if your server changed `--path` /
+   * `--http-base-path` or sits behind a path-rewriting proxy.
    */
   export class RosClient {
     readonly url: string;


### PR DESCRIPTION
Both transports now apply the default path when (and only when) the caller didn't supply one. Before this commit WS required the caller to spell `/capability` out (`connect('ws://host:9000')` silently failed against a default server) and HTTP did the opposite (it hardcoded `/capability/<kind>/<name>` so `connect('http://host:9001/capability')` silently double-prefixed and 404'd). Pure addition: existing `connect('ws://host:9000/capability')` and `connect('http://host:9001')` callers see byte-identical request URLs.

- `web/client.js`: new `_normaliseWsPath()` wired into `_resolveUrls()` for both URL forms; `_HttpLink.constructor` only appends `/capability` when the URL doesn't already end with it; `_fetch()` builds URLs from the normalised baseUrl with no hardcoded literal. `RosClient` JSDoc + matching `web/index.d.ts` updated to drop the spell-it-out examples and document the "pass an explicit non-default path" escape hatch for path-rewriting proxies.
- `test/test-web-ws.js`: +2 cases (`ws://host:port` and `{ ws: 'ws://host:port' }` against a live runtime).
- `test/test-web-http.js`: +2 cases (`httpBase + '/capability'` under both single-string and `{ http }` forms).

Out of scope: custom server `basePath` / `path` configurations behind a reverse proxy. Same "user URL is authoritative when non-default" model could extend to support them, but that deserves its own PR with proxy-deployment docs and tests.

Fix: #1510 