### PR TITLE
[Lyrical] Switch Linux CI to apt-deb install and bump Windows zip

### DIFF
--- a/.github/workflows/linux-arm64-build-and-test.yml
+++ b/.github/workflows/linux-arm64-build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
           # Kilted Kaiju (May 2025 - Dec 2026)
           - docker_image: ubuntu:noble
             ros_distribution: kilted
-          # Lyrical Luth (May 2026 - May 2031, beta)
+          # Lyrical Luth (May 2026 - May 2031)
           - docker_image: ubuntu:26.04
             ros_distribution: lyrical
 

--- a/.github/workflows/linux-arm64-build-and-test.yml
+++ b/.github/workflows/linux-arm64-build-and-test.yml
@@ -58,7 +58,7 @@ jobs:
       if: ${{ matrix.ros_distribution == 'lyrical' }}
       run: |
         apt-get update
-        apt-get install -y software-properties-common curl
+        apt-get install -y sudo software-properties-common curl
 
         # Enable required repositories per:
         # https://docs.ros.org/en/lyrical/Installation/Ubuntu-Install-Debs.html

--- a/.github/workflows/linux-arm64-build-and-test.yml
+++ b/.github/workflows/linux-arm64-build-and-test.yml
@@ -38,12 +38,8 @@ jobs:
           - docker_image: ubuntu:noble
             ros_distribution: kilted
           # Lyrical Luth (May 2026 - May 2031, beta)
-          # NOTE: the tarball URL below is a date-stamped beta snapshot and must
-          # be refreshed manually until upstream publishes a stable "latest"
-          # download (or until GA).
           - docker_image: ubuntu:26.04
             ros_distribution: lyrical
-            ros_tar_url: "https://github.com/ros2/ros2/releases/download/release-lyrical-beta-20260430/ros2-lyrical-2026-04-30-resolute-aarch64.tar.bz2"
 
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
@@ -64,26 +60,22 @@ jobs:
         apt-get update
         apt-get install -y software-properties-common curl
 
-        # Enable required repositories for the lyrical beta tarball; see:
+        # Enable required repositories per:
         # https://docs.ros.org/en/lyrical/Installation/Ubuntu-Install-Debs.html
         add-apt-repository universe
         ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
         curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
         dpkg -i /tmp/ros2-apt-source.deb
         apt-get update
-        apt-get install -y build-essential cmake tar bzip2 python3 python3-rosdep python3-colcon-common-extensions
+        apt-get install -y build-essential cmake python3 python3-colcon-common-extensions
 
-    - name: Install ROS2 from binary tarball (lyrical)
+    - name: Install ROS2 from apt (lyrical)
       if: ${{ matrix.ros_distribution == 'lyrical' }}
       run: |
-        curl -sL "${{ matrix.ros_tar_url }}" -o /tmp/ros2-lyrical.tar.bz2
-        mkdir -p /opt/ros/lyrical
-        tar xf /tmp/ros2-lyrical.tar.bz2 --strip-components=1 -C /opt/ros/lyrical
-        rm /tmp/ros2-lyrical.tar.bz2
-
-        rosdep init || true
-        rosdep update
-        rosdep install --rosdistro lyrical --from-paths /opt/ros/lyrical/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 rti-connext-dds-7.7.0 urdfdom_headers python3-pyqt6.qtsvg rosidl_buffer_py pybind11"
+        # Per https://docs.ros.org/en/lyrical/Installation/Ubuntu-Install-Debs.html
+        apt-get install -y \
+          ros-lyrical-desktop \
+          ros-lyrical-test-msgs
 
     - name: Install test-msgs and mrpt_msgs on Linux
       if: ${{ matrix.ros_distribution != 'lyrical' }}

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -38,7 +38,7 @@ jobs:
           # Kilted Kaiju (May 2025 - Dec 2026)
           - docker_image: ubuntu:noble
             ros_distribution: kilted
-          # Lyrical Luth (May 2026 - May 2031, beta)
+          # Lyrical Luth (May 2026 - May 2031)
           - docker_image: ubuntu:26.04
             ros_distribution: lyrical
           # Rolling Ridley (No End-Of-Life) - migrated to Ubuntu 26.04 (resolute)
@@ -76,7 +76,10 @@ jobs:
         curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
         dpkg -i /tmp/ros2-apt-source.deb
         apt-get update
-        apt-get install -y build-essential cmake tar bzip2 python3 python3-rosdep python3-colcon-common-extensions
+        # Common build deps for both rolling and lyrical. Rolling-only tarball
+        # tooling (tar, bzip2, python3-rosdep) is installed in the rolling step
+        # below so the lyrical lane stays minimal.
+        apt-get install -y build-essential cmake python3 python3-colcon-common-extensions
 
     - name: Install ROS2 from apt (lyrical)
       if: ${{ matrix.ros_distribution == 'lyrical' }}
@@ -89,6 +92,10 @@ jobs:
     - name: Install ROS2 from binary tarball (rolling)
       if: ${{ matrix.ros_distribution == 'rolling' }}
       run: |
+        # Tools only the rolling tarball path needs: tar/bzip2 for extraction,
+        # python3-rosdep for resolving runtime deps below.
+        apt-get install -y tar bzip2 python3-rosdep
+
         # Extract binary tarball AFTER apt packages so its newer libs overwrite apt's older ones
         curl -sL "${{ matrix.ros_tar_url }}" -o /tmp/ros2-${{ matrix.ros_distribution }}.tar.bz2
         mkdir -p /opt/ros/${{ matrix.ros_distribution }}

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -39,13 +39,8 @@ jobs:
           - docker_image: ubuntu:noble
             ros_distribution: kilted
           # Lyrical Luth (May 2026 - May 2031, beta)
-          # NOTE: the tarball URL below is a date-stamped beta snapshot and must
-          # be refreshed manually until upstream publishes a stable "latest"
-          # download (or until GA), at which point it can be replaced with the
-          # stable URL similar to the rolling nightly redirect.
           - docker_image: ubuntu:26.04
             ros_distribution: lyrical
-            ros_tar_url: "https://github.com/ros2/ros2/releases/download/release-lyrical-beta-20260430/ros2-lyrical-2026-04-30-resolute-x86_64.tar.bz2"
           # Rolling Ridley (No End-Of-Life) - migrated to Ubuntu 26.04 (resolute)
           # to follow the Lyrical Luth target platform.
           # See: https://docs.ros.org/en/jazzy/Releases/Release-Lyrical-Luth.html
@@ -72,7 +67,7 @@ jobs:
         apt-get install -y software-properties-common curl
 
         # Enable required repositories. The same setup applies to both the
-        # rolling nightly tarball and the lyrical beta tarball; see the
+        # rolling nightly tarball and the lyrical apt-deb install; see the
         # per-distro install docs for reference:
         #   rolling: https://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Install-Binary.html
         #   lyrical: https://docs.ros.org/en/lyrical/Installation/Ubuntu-Install-Debs.html
@@ -83,8 +78,16 @@ jobs:
         apt-get update
         apt-get install -y build-essential cmake tar bzip2 python3 python3-rosdep python3-colcon-common-extensions
 
-    - name: Install ROS2 from binary tarball (rolling / lyrical)
-      if: ${{ matrix.ros_distribution == 'rolling' || matrix.ros_distribution == 'lyrical' }}
+    - name: Install ROS2 from apt (lyrical)
+      if: ${{ matrix.ros_distribution == 'lyrical' }}
+      run: |
+        # Per https://docs.ros.org/en/lyrical/Installation/Ubuntu-Install-Debs.html
+        apt-get install -y \
+          ros-lyrical-desktop \
+          ros-lyrical-test-msgs
+
+    - name: Install ROS2 from binary tarball (rolling)
+      if: ${{ matrix.ros_distribution == 'rolling' }}
       run: |
         # Extract binary tarball AFTER apt packages so its newer libs overwrite apt's older ones
         curl -sL "${{ matrix.ros_tar_url }}" -o /tmp/ros2-${{ matrix.ros_distribution }}.tar.bz2

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -64,7 +64,7 @@ jobs:
       if: ${{ matrix.ros_distribution == 'rolling' || matrix.ros_distribution == 'lyrical' }}
       run: |
         apt-get update
-        apt-get install -y software-properties-common curl
+        apt-get install -y sudo software-properties-common curl
 
         # Enable required repositories. The same setup applies to both the
         # rolling nightly tarball and the lyrical apt-deb install; see the

--- a/.github/workflows/prebuild-linux-arm64.yml
+++ b/.github/workflows/prebuild-linux-arm64.yml
@@ -32,7 +32,7 @@ jobs:
           - docker_image: ubuntu:noble
             ros_distribution: kilted
             ubuntu_codename: noble
-          # Lyrical Luth (May 2026 - May 2031, beta)
+          # Lyrical Luth (May 2026 - May 2031)
           - docker_image: ubuntu:26.04
             ros_distribution: lyrical
             ubuntu_codename: resolute

--- a/.github/workflows/prebuild-linux-arm64.yml
+++ b/.github/workflows/prebuild-linux-arm64.yml
@@ -33,13 +33,9 @@ jobs:
             ros_distribution: kilted
             ubuntu_codename: noble
           # Lyrical Luth (May 2026 - May 2031, beta)
-          # NOTE: the tarball URL below is a date-stamped beta snapshot and
-          # must be refreshed manually until upstream publishes a stable
-          # "latest" download (or until GA).
           - docker_image: ubuntu:26.04
             ros_distribution: lyrical
             ubuntu_codename: resolute
-            ros_tar_url: "https://github.com/ros2/ros2/releases/download/release-lyrical-beta-20260430/ros2-lyrical-2026-04-30-resolute-aarch64.tar.bz2"
 
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
@@ -59,23 +55,18 @@ jobs:
       run: |
         apt-get update
         apt-get install -y software-properties-common curl
+        # Per https://docs.ros.org/en/lyrical/Installation/Ubuntu-Install-Debs.html
         add-apt-repository universe
         ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
         curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
         dpkg -i /tmp/ros2-apt-source.deb
         apt-get update
-        apt-get install -y build-essential cmake tar bzip2 python3 python3-rosdep python3-colcon-common-extensions
+        apt-get install -y build-essential cmake python3
 
-    - name: Install ROS2 from binary tarball (lyrical)
+    - name: Install ROS2 from apt (lyrical)
       if: ${{ matrix.ros_distribution == 'lyrical' }}
       run: |
-        curl -sL "${{ matrix.ros_tar_url }}" -o /tmp/ros2-${{ matrix.ros_distribution }}.tar.bz2
-        mkdir -p /opt/ros/${{ matrix.ros_distribution }}
-        tar xf /tmp/ros2-${{ matrix.ros_distribution }}.tar.bz2 --strip-components=1 -C /opt/ros/${{ matrix.ros_distribution }}
-        rm /tmp/ros2-${{ matrix.ros_distribution }}.tar.bz2
-        rosdep init || true
-        rosdep update
-        rosdep install --rosdistro ${{ matrix.ros_distribution }} --from-paths /opt/ros/${{ matrix.ros_distribution }}/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 rti-connext-dds-7.7.0 urdfdom_headers python3-pyqt6.qtsvg rosidl_buffer_py pybind11"
+        apt-get install -y ros-lyrical-desktop
 
     - uses: actions/checkout@v6
 

--- a/.github/workflows/prebuild-linux-x64.yml
+++ b/.github/workflows/prebuild-linux-x64.yml
@@ -33,13 +33,9 @@ jobs:
             ros_distribution: kilted
             ubuntu_codename: noble
           # Lyrical Luth (May 2026 - May 2031, beta)
-          # NOTE: the tarball URL below is a date-stamped beta snapshot and
-          # must be refreshed manually until upstream publishes a stable
-          # "latest" download (or until GA).
           - docker_image: ubuntu:26.04
             ros_distribution: lyrical
             ubuntu_codename: resolute
-            ros_tar_url: "https://github.com/ros2/ros2/releases/download/release-lyrical-beta-20260430/ros2-lyrical-2026-04-30-resolute-x86_64.tar.bz2"
 
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
@@ -59,23 +55,18 @@ jobs:
       run: |
         apt-get update
         apt-get install -y software-properties-common curl
+        # Per https://docs.ros.org/en/lyrical/Installation/Ubuntu-Install-Debs.html
         add-apt-repository universe
         ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
         curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
         dpkg -i /tmp/ros2-apt-source.deb
         apt-get update
-        apt-get install -y build-essential cmake tar bzip2 python3 python3-rosdep python3-colcon-common-extensions
+        apt-get install -y build-essential cmake python3
 
-    - name: Install ROS2 from binary tarball (lyrical)
+    - name: Install ROS2 from apt (lyrical)
       if: ${{ matrix.ros_distribution == 'lyrical' }}
       run: |
-        curl -sL "${{ matrix.ros_tar_url }}" -o /tmp/ros2-${{ matrix.ros_distribution }}.tar.bz2
-        mkdir -p /opt/ros/${{ matrix.ros_distribution }}
-        tar xf /tmp/ros2-${{ matrix.ros_distribution }}.tar.bz2 --strip-components=1 -C /opt/ros/${{ matrix.ros_distribution }}
-        rm /tmp/ros2-${{ matrix.ros_distribution }}.tar.bz2
-        rosdep init || true
-        rosdep update
-        rosdep install --rosdistro ${{ matrix.ros_distribution }} --from-paths /opt/ros/${{ matrix.ros_distribution }}/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 rti-connext-dds-7.7.0 urdfdom_headers python3-pyqt6.qtsvg rosidl_buffer_py pybind11"
+        apt-get install -y ros-lyrical-desktop
 
     - uses: actions/checkout@v6
 

--- a/.github/workflows/prebuild-linux-x64.yml
+++ b/.github/workflows/prebuild-linux-x64.yml
@@ -32,7 +32,7 @@ jobs:
           - docker_image: ubuntu:noble
             ros_distribution: kilted
             ubuntu_codename: noble
-          # Lyrical Luth (May 2026 - May 2031, beta)
+          # Lyrical Luth (May 2026 - May 2031)
           - docker_image: ubuntu:26.04
             ros_distribution: lyrical
             ubuntu_codename: resolute

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -27,7 +27,7 @@ jobs:
           - ros_distribution: kilted
             ros_zip_url: "https://github.com/ros2/ros2/releases/download/release-kilted-20250728/ros2-kilted-20250728-windows-release-amd64.zip"
             run_tests: false
-          # Lyrical Luth (May 2026 - May 2031, beta)
+          # Lyrical Luth (May 2026 - May 2031)
           # Reference: https://docs.ros.org/en/lyrical/Installation/Windows-Install-Binary.html
           - ros_distribution: lyrical
             ros_zip_url: "https://github.com/ros2/ros2/releases/download/release-lyrical-20260522/ros2-lyrical-2026-05-22-windows-AMD64.zip"

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
           # Lyrical Luth (May 2026 - May 2031, beta)
           # Reference: https://docs.ros.org/en/lyrical/Installation/Windows-Install-Binary.html
           - ros_distribution: lyrical
-            ros_zip_url: "https://github.com/ros2/ros2/releases/download/release-lyrical-beta-20260430/ros2-lyrical-2026-04-30-windows-AMD64.zip"
+            ros_zip_url: "https://github.com/ros2/ros2/releases/download/release-lyrical-20260522/ros2-lyrical-2026-05-22-windows-AMD64.zip"
             run_tests: true
           - ros_distribution: rolling
             ros_zip_url: "https://github.com/ros2/ros2/releases/download/release-rolling-nightlies/ros2-rolling-nightly-windows-amd64.zip"


### PR DESCRIPTION
Per the official Lyrical install guide (https://docs.ros.org/en/lyrical/Installation/Ubuntu-Install-Debs.html), ROS 2 Lyrical is now available as Debian packages on Ubuntu 26.04. Switch all four Linux workflows to `apt-get install -y ros-lyrical-desktop` and drop the date-stamped beta tarball that had to be hand-refreshed every time upstream produced a new snapshot. The test workflows also install `ros-lyrical-test-msgs`; `ros-lyrical-mrpt-msgs` is omitted because it is not yet published for lyrical (the previous tarball path skipped both packages on lyrical too, so the test suite already tolerates its absence). Removes the `curl | tar xf` extract step, the `rosdep init/update/install` chain with its long `--skip-keys` list, and the `tar`, `bzip2`, `python3-rosdep` packages they required. Rolling continues to use the nightly tarball; humble/jazzy/kilted continue to use `ros-tooling/setup-ros@v0.7`, which does not yet recognize lyrical.

On `linux-arm64-build-and-test.yml`, `sudo` is also added to the lyrical apt prerequisites: the job runs in a bare `ubuntu:26.04` container, and the downstream "Install Electron test dependencies" and "Fix permissions" steps shell out to `sudo apt …` / `sudo chown …`. The other distros get `sudo` implicitly via `ros-tooling/setup-ros`; lyrical takes the manual apt path, so it needs to be installed explicitly. Without this, the lyrical arm64 job failed with `sudo: command not found` (exit code 127).

Windows still has no apt equivalent and continues to use the binary zip, but its lyrical URL is bumped from the `release-lyrical-beta-20260430` snapshot to `release-lyrical-20260522`.

Fix: #1458