### PR TITLE
Install test-msgs and mrpt-msgs uniformly across all ROS 2 distros

### DIFF
--- a/.github/workflows/linux-arm64-build-and-test.yml
+++ b/.github/workflows/linux-arm64-build-and-test.yml
@@ -73,12 +73,9 @@ jobs:
       if: ${{ matrix.ros_distribution == 'lyrical' }}
       run: |
         # Per https://docs.ros.org/en/lyrical/Installation/Ubuntu-Install-Debs.html
-        apt-get install -y \
-          ros-lyrical-desktop \
-          ros-lyrical-test-msgs
+        apt-get install -y ros-lyrical-desktop
 
     - name: Install test-msgs and mrpt_msgs on Linux
-      if: ${{ matrix.ros_distribution != 'lyrical' }}
       run: |
         sudo apt install -y ros-${{ matrix.ros_distribution }}-test-msgs ros-${{ matrix.ros_distribution }}-mrpt-msgs
 

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -106,6 +106,7 @@ jobs:
         rosdep install --rosdistro ${{ matrix.ros_distribution }} --from-paths /opt/ros/${{ matrix.ros_distribution }}/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 rti-connext-dds-7.7.0 urdfdom_headers python3-pyqt6.qtsvg rosidl_buffer_py pybind11"
 
     - name: Install test-msgs and mrpt_msgs on Linux
+      if: ${{ matrix.ros_distribution != 'rolling' }}
       run: |
         sudo apt install -y ros-${{ matrix.ros_distribution }}-test-msgs ros-${{ matrix.ros_distribution }}-mrpt-msgs
 

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -85,9 +85,7 @@ jobs:
       if: ${{ matrix.ros_distribution == 'lyrical' }}
       run: |
         # Per https://docs.ros.org/en/lyrical/Installation/Ubuntu-Install-Debs.html
-        apt-get install -y \
-          ros-lyrical-desktop \
-          ros-lyrical-test-msgs
+        apt-get install -y ros-lyrical-desktop
 
     - name: Install ROS2 from binary tarball (rolling)
       if: ${{ matrix.ros_distribution == 'rolling' }}
@@ -108,7 +106,6 @@ jobs:
         rosdep install --rosdistro ${{ matrix.ros_distribution }} --from-paths /opt/ros/${{ matrix.ros_distribution }}/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 rti-connext-dds-7.7.0 urdfdom_headers python3-pyqt6.qtsvg rosidl_buffer_py pybind11"
 
     - name: Install test-msgs and mrpt_msgs on Linux
-      if: ${{ matrix.ros_distribution != 'rolling' && matrix.ros_distribution != 'lyrical' }}
       run: |
         sudo apt install -y ros-${{ matrix.ros_distribution }}-test-msgs ros-${{ matrix.ros_distribution }}-mrpt-msgs
 


### PR DESCRIPTION
Drop the lyrical-specific `ros-lyrical-test-msgs` / `ros-lyrical-mrpt-msgs` lines from the "Install ROS2 from apt (lyrical)" step and instead let the shared "Install test-msgs and mrpt_msgs on Linux" step handle them, the same way it already does for humble / jazzy / kilted. Keep the `!= 'rolling'` gate on the shared step because `packages.ros.org` does not publish `ros-rolling-*` debs for the `resolute` (Ubuntu 26.04) codename — Rolling remains tarball-only there.

- `.github/workflows/linux-x64-build-and-test.yml` — extend the shared step to lyrical; trim the lyrical apt step to `ros-lyrical-desktop` only.
- `.github/workflows/linux-arm64-build-and-test.yml` — same trim; the shared step has no `if:` here because arm64 has no rolling lane.

Refs: a3bb702 ("Add ROS 2 Lyrical Luth (#1496)")

Fix: #1458