### PR TITLE
 Infer concrete types from constructor TypeClass forms

### DIFF
--- a/demo/electron/manipulator/README.md
+++ b/demo/electron/manipulator/README.md
@@ -64,7 +64,7 @@ npm start
 1. **Source your ROS2 environment**:
 
    ```bash
-   source /opt/ros/humble/setup.bash  # or your ROS2 installation path
+   source /opt/ros/$ROS_DISTRO/setup.bash  # or your ROS2 installation path
    ```
 
 2. **Run the demo**:
@@ -140,7 +140,7 @@ To verify the demo is working correctly, you can monitor the published topics:
 
 ```bash
 # In a separate terminal, source ROS2 environment
-source /opt/ros/humble/setup.bash  # or your ROS2 installation
+source /opt/ros/$ROS_DISTRO/setup.bash  # or your ROS2 installation
 
 # List all available topics
 ros2 topic list
@@ -199,7 +199,7 @@ Even as a standalone application, **ROS 2 must be installed and sourced on the t
 
 ```bash
 # Source ROS2 environment
-source /opt/ros/humble/setup.bash
+source /opt/ros/$ROS_DISTRO/setup.bash
 
 # Run the packaged executable
 ./out/rclnodejs-manipulator-demo-linux-x64/rclnodejs-manipulator-demo
@@ -301,7 +301,7 @@ manipulator/
 
    ```bash
    # Source ROS2 environment manually
-   source /opt/ros/humble/setup.bash  # or your ROS2 installation path
+   source /opt/ros/$ROS_DISTRO/setup.bash  # or your ROS2 installation path
    npm start
    ```
 

--- a/demo/typescript/README.md
+++ b/demo/typescript/README.md
@@ -35,6 +35,10 @@ Asynchronous actions with progress feedback and cancellation
 - **Full typing** for all ROS2 messages, services, and actions
 - **Compile-time validation** of message structures
 - **IntelliSense support** in VS Code and other TypeScript editors
+- **Two equivalent forms**: identify a type by its **string name**
+  (e.g. `'std_msgs/msg/String'`) or by its **class/constructor** obtained from
+  `rclnodejs.require(...)`. With the class form, TypeScript infers the concrete
+  message/service/action types automatically\u2014no explicit annotations needed.
 
 ### Modern Development
 

--- a/demo/typescript/actions/README.md
+++ b/demo/typescript/actions/README.md
@@ -60,7 +60,7 @@ Before running this demo, ensure you have:
 1. **Ensure ROS2 is sourced**:
 
    ```bash
-   source /opt/ros/humble/setup.bash  # or your ROS2 distribution
+   source /opt/ros/lyrical/setup.bash  # or your ROS2 distribution
    ```
 
 2. **Build the main rclnodejs package** (if not already done):
@@ -79,8 +79,13 @@ Before running this demo, ensure you have:
 
 4. **Install dependencies**:
 
+   This demo depends on the **local rclnodejs** in this repository
+   (`"rclnodejs": "file:../../.."`). Install with `--ignore-scripts` so npm
+   links the local package without trying to rebuild its native addon (the
+   prebuilt binary in the repo is reused):
+
    ```bash
-   npm install
+   npm install --ignore-scripts
    ```
 
 5. **Build the TypeScript code**:
@@ -194,29 +199,52 @@ You can also test the action server using ROS2 command-line tools:
 
 ## Understanding the Code
 
+Both the server and client show the **two equivalent, fully type-safe ways**
+to identify an action type:
+
+- **String name**: pass the type string, e.g. `'test_msgs/action/Fibonacci'`.
+- **Action class**: obtain the constructor with `rclnodejs.require(...)` and
+  pass it directly. TypeScript then infers the goal, feedback and result types
+  from the constructor, so no explicit `any` annotations are needed.
+
+This demo uses the **action class** form. The constructor is loaded once at
+module scope and reused for the type annotations via `typeof Fibonacci`:
+
+```typescript
+const Fibonacci = rclnodejs.require('test_msgs/action/Fibonacci');
+```
+
 ### Action Server (`server.ts`)
 
-The action server implements three main callbacks:
+The action server implements three main callbacks, all typed from
+`typeof Fibonacci`:
 
 1. **Goal Callback**: Decides whether to accept or reject incoming goals
 
    ```typescript
-   goalCallback(goalHandle: any): rclnodejs.GoalResponse {
-     // Validate the goal and return ACCEPT or REJECT
+   goalCallback(
+     goal: rclnodejs.ActionGoal<typeof Fibonacci>
+   ): rclnodejs.GoalResponse {
+     // Validate the goal (goal.order is typed) and return ACCEPT or REJECT
    }
    ```
 
 2. **Execute Callback**: Performs the actual work (Fibonacci calculation)
 
    ```typescript
-   async executeCallback(goalHandle: any): Promise<any> {
-     // Calculate Fibonacci sequence and provide feedback
+   async executeCallback(
+     goalHandle: rclnodejs.ServerGoalHandle<typeof Fibonacci>
+   ): Promise<rclnodejs.ActionResult<typeof Fibonacci>> {
+     // Calculate the sequence and publish typed feedback
    }
    ```
 
 3. **Cancel Callback**: Handles goal cancellation requests
+
    ```typescript
-   cancelCallback(goalHandle: any): rclnodejs.CancelResponse {
+   cancelCallback(
+     goalHandle: rclnodejs.ServerGoalHandle<typeof Fibonacci> | undefined
+   ): rclnodejs.CancelResponse {
      // Return ACCEPT to allow cancellation
    }
    ```
@@ -226,14 +254,23 @@ The action server implements three main callbacks:
 The action client:
 
 1. Waits for the action server to be available
-2. Creates and sends a goal
-3. Handles feedback during execution
+2. Creates and sends a goal (`new Fibonacci.Goal()`)
+3. Handles typed feedback during execution
 4. Processes the final result
 
 ```typescript
+const goal = new Fibonacci.Goal();
+goal.order = FIBONACCI_ORDER;
+
 const goalHandle = await this.actionClient.sendGoal(goal, (feedback) =>
   this.feedbackCallback(feedback)
 );
+
+private feedbackCallback(
+  feedback: rclnodejs.ActionFeedback<typeof Fibonacci>
+): void {
+  // feedback.sequence is typed
+}
 ```
 
 ## Customization
@@ -263,7 +300,7 @@ You can modify the demo to:
 
 4. **ROS2 environment not sourced**:
    ```bash
-   source /opt/ros/humble/setup.bash  # or your ROS2 distribution
+   source /opt/ros/lyrical/setup.bash  # or your ROS2 distribution
    ```
 
 ### Debugging

--- a/demo/typescript/actions/package.json
+++ b/demo/typescript/actions/package.json
@@ -33,12 +33,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   },
-  "peerDependencies": {
-    "rclnodejs": "^2.0.0"
-  },
-  "peerDependenciesMeta": {
-    "rclnodejs": {
-      "optional": false
-    }
+  "dependencies": {
+    "rclnodejs": "file:../../.."
   }
 }

--- a/demo/typescript/actions/src/client.ts
+++ b/demo/typescript/actions/src/client.ts
@@ -3,6 +3,15 @@
  *
  * This demo shows how to create a ROS2 action client using TypeScript
  * with rclnodejs. It sends Fibonacci calculation goals to an action server.
+ *
+ * It also demonstrates the two equivalent, fully type-safe ways to
+ * identify an action type:
+ *   - String name:  new rclnodejs.ActionClient(node, 'test_msgs/action/Fibonacci', ...)
+ *   - Action class: new rclnodejs.ActionClient(node, Fibonacci, ...)
+ *
+ * This demo uses the class form (obtained from `rclnodejs.require(...)`):
+ * TypeScript infers the goal, feedback and result types directly from the
+ * constructor, so the feedback callback needs no explicit `any` annotation.
  */
 
 import * as rclnodejs from 'rclnodejs';
@@ -10,12 +19,17 @@ import * as rclnodejs from 'rclnodejs';
 const ACTION_NAME = 'fibonacci';
 const FIBONACCI_ORDER = 10;
 
+// The Fibonacci action class (type-based form). Passing this constructor to
+// ActionClient lets TypeScript infer the goal/feedback/result types. The
+// string form 'test_msgs/action/Fibonacci' works identically.
+const Fibonacci = rclnodejs.require('test_msgs/action/Fibonacci');
+
 /**
  * Fibonacci Action Client Class
  */
 class FibonacciActionClient {
   private node: rclnodejs.Node;
-  private actionClient: rclnodejs.ActionClient<'test_msgs/action/Fibonacci'>;
+  private actionClient: rclnodejs.ActionClient<typeof Fibonacci>;
 
   constructor(node: rclnodejs.Node) {
     this.node = node;
@@ -23,10 +37,10 @@ class FibonacciActionClient {
     // Start spinning the node to handle callbacks
     rclnodejs.spin(node);
 
-    // Create action client for Fibonacci action
+    // Create action client for Fibonacci action using the action class
     this.actionClient = new rclnodejs.ActionClient(
       node,
-      'test_msgs/action/Fibonacci',
+      Fibonacci,
       ACTION_NAME
     );
   }
@@ -41,10 +55,7 @@ class FibonacciActionClient {
     await this.actionClient.waitForServer();
     this.node.getLogger().info('✓ Action server is available');
 
-    // Get the Fibonacci action interface
-    const Fibonacci = rclnodejs.require('test_msgs/action/Fibonacci');
-
-    // Create a new goal
+    // Create a new goal (goal.order is typed from the inferred goal type)
     const goal = new Fibonacci.Goal();
     goal.order = FIBONACCI_ORDER;
 
@@ -53,10 +64,9 @@ class FibonacciActionClient {
       .info(`Sending goal request for Fibonacci(${goal.order})...`);
 
     try {
-      // Send the goal with feedback callback
-      const goalHandle = await this.actionClient.sendGoal(
-        goal,
-        (feedback: any) => this.feedbackCallback(feedback)
+      // Send the goal with feedback callback (feedback is typed)
+      const goalHandle = await this.actionClient.sendGoal(goal, (feedback) =>
+        this.feedbackCallback(feedback)
       );
 
       if (!goalHandle.isAccepted()) {
@@ -91,7 +101,9 @@ class FibonacciActionClient {
   /**
    * Callback function for receiving feedback from the action server
    */
-  private feedbackCallback(feedback: any): void {
+  private feedbackCallback(
+    feedback: rclnodejs.ActionFeedback<typeof Fibonacci>
+  ): void {
     this.node
       .getLogger()
       .info(`📊 Received feedback: [${feedback.sequence.join(', ')}]`);

--- a/demo/typescript/actions/src/server.ts
+++ b/demo/typescript/actions/src/server.ts
@@ -3,26 +3,40 @@
  *
  * This demo shows how to create a ROS2 action server using TypeScript
  * with rclnodejs. It provides a Fibonacci calculation service.
+ *
+ * It also demonstrates the two equivalent, fully type-safe ways to
+ * identify an action type:
+ *   - String name:  new rclnodejs.ActionServer(node, 'test_msgs/action/Fibonacci', ...)
+ *   - Action class: new rclnodejs.ActionServer(node, Fibonacci, ...)
+ *
+ * This demo uses the class form (obtained from `rclnodejs.require(...)`):
+ * TypeScript infers the goal, feedback and result types directly from the
+ * constructor, so the callbacks need no explicit `any` annotations.
  */
 
 import * as rclnodejs from 'rclnodejs';
 
 const ACTION_NAME = 'fibonacci';
 
+// The Fibonacci action class (type-based form). Passing this constructor to
+// ActionServer lets TypeScript infer the goal/feedback/result types. The
+// string form 'test_msgs/action/Fibonacci' works identically.
+const Fibonacci = rclnodejs.require('test_msgs/action/Fibonacci');
+
 /**
  * Fibonacci Action Server Class
  */
 class FibonacciActionServer {
   private node: rclnodejs.Node;
-  private actionServer: rclnodejs.ActionServer<'test_msgs/action/Fibonacci'>;
+  private actionServer: rclnodejs.ActionServer<typeof Fibonacci>;
 
   constructor(node: rclnodejs.Node) {
     this.node = node;
 
-    // Create action server for Fibonacci action
+    // Create action server for Fibonacci action using the action class
     this.actionServer = new rclnodejs.ActionServer(
       node,
-      'test_msgs/action/Fibonacci',
+      Fibonacci,
       ACTION_NAME,
       this.executeCallback.bind(this),
       this.goalCallback.bind(this),
@@ -39,13 +53,12 @@ class FibonacciActionServer {
    * Execute callback - performs the Fibonacci calculation
    */
   async executeCallback(
-    goalHandle: rclnodejs.ServerGoalHandle<'test_msgs/action/Fibonacci'>
-  ): Promise<any> {
+    goalHandle: rclnodejs.ServerGoalHandle<typeof Fibonacci>
+  ): Promise<rclnodejs.ActionResult<typeof Fibonacci>> {
     this.node
       .getLogger()
       .info(`🚀 Executing goal for Fibonacci(${goalHandle.request.order})`);
 
-    const Fibonacci = rclnodejs.require('test_msgs/action/Fibonacci');
     const feedbackMessage = new Fibonacci.Feedback();
     const sequence: number[] = [0, 1];
 
@@ -110,13 +123,12 @@ class FibonacciActionServer {
   }
 
   /**
-   * Goal callback - decides whether to accept or reject incoming goals
-   *
-   * Note: According to the type definition, this should receive ActionGoal<T>,
-   * but the actual implementation may pass different types. Using 'any' to handle
-   * this inconsistency and support ActionGoal<T>.
+   * Goal callback - decides whether to accept or reject incoming goals.
+   * The goal type is inferred from the action constructor.
    */
-  goalCallback(goal: any): rclnodejs.GoalResponse {
+  goalCallback(
+    goal: rclnodejs.ActionGoal<typeof Fibonacci>
+  ): rclnodejs.GoalResponse {
     const order = goal.order;
 
     this.node
@@ -146,9 +158,7 @@ class FibonacciActionServer {
    * Cancel callback - handles goal cancellation requests
    */
   cancelCallback(
-    goalHandle:
-      | rclnodejs.ServerGoalHandle<'test_msgs/action/Fibonacci'>
-      | undefined
+    goalHandle: rclnodejs.ServerGoalHandle<typeof Fibonacci> | undefined
   ): rclnodejs.CancelResponse {
     this.node.getLogger().info('📥 Received cancel request');
     return rclnodejs.CancelResponse.ACCEPT;

--- a/demo/typescript/services/README.md
+++ b/demo/typescript/services/README.md
@@ -26,8 +26,8 @@ Before running this demo, ensure you have:
 Make sure your ROS 2 environment is properly sourced before running the demo:
 
 ```bash
-# For example, if using ROS 2 Jazzy
-source /opt/ros/jazzy/setup.bash
+# For example, if using ROS 2 Lyrical
+source /opt/ros/lyrical/setup.bash
 
 # Or if you have a custom workspace
 source /path/to/your/ros2_ws/install/setup.bash
@@ -45,11 +45,15 @@ npm run build
 
 ## Installation
 
-Navigate to this demo directory and install dependencies:
+This demo depends on the **local rclnodejs** in this repository
+(`"rclnodejs": "file:../../.."`) so it always builds against the in-tree
+TypeScript types. Install with `--ignore-scripts` so npm links the local
+package without trying to rebuild its native addon (the prebuilt binary in the
+repo is reused):
 
 ```bash
 cd demo/typescript/services
-npm install
+npm install --ignore-scripts
 ```
 
 ## Usage
@@ -101,6 +105,40 @@ For development, you can run TypeScript files directly with ts-node:
    ```
 
 ## How It Works
+
+Both the server and client show the **two equivalent, fully type-safe ways**
+to identify a service type:
+
+- **String name**: pass the type string, e.g. `'example_interfaces/srv/AddTwoInts'`.
+- **Service class**: obtain the constructor with `rclnodejs.require(...)` and
+  pass it directly. TypeScript then infers the request and response types from
+  the constructor, so no explicit `any` annotations are needed.
+
+This demo uses the **service class** form:
+
+```typescript
+const AddTwoInts = rclnodejs.require('example_interfaces/srv/AddTwoInts');
+
+// Server — request/response are inferred from the constructor
+const service = node.createService(
+  AddTwoInts,
+  SERVICE_NAME,
+  (request, response) => {
+    const result = response.template;
+    result.sum = request.a + request.b; // request.a / request.b are typed
+    response.send(result);
+  }
+);
+
+// Client — request built by instantiating the request class
+const client = node.createClient(AddTwoInts, SERVICE_NAME);
+const request = new AddTwoInts.Request();
+request.a = 42n;
+request.b = 17n;
+client.sendRequest(request, (response) => {
+  console.log(`sum=${response.sum}`); // response is typed
+});
+```
 
 ### Service Server (`server.ts`)
 
@@ -204,15 +242,19 @@ const REQUEST_INTERVAL = 1000; // Send requests every 1 second
 
 ### Use Different Service Types
 
-To use a different service type, update the type string and interface:
+To use a different service type, update the type string or service class:
 
 ```typescript
-// For example, using a custom service
+// Style A — string name
 const service = node.createService(
   'your_package/srv/YourService',
   'service_name',
   callback
 );
+
+// Style B — service class (request/response inferred from the constructor)
+const YourService = rclnodejs.require('your_package/srv/YourService');
+const service2 = node.createService(YourService, 'service_name', callback);
 ```
 
 ### Add Custom Logic

--- a/demo/typescript/services/package.json
+++ b/demo/typescript/services/package.json
@@ -33,6 +33,6 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "rclnodejs": "file:../../"
+    "rclnodejs": "file:../../.."
   }
 }

--- a/demo/typescript/services/src/client.ts
+++ b/demo/typescript/services/src/client.ts
@@ -3,6 +3,15 @@
  *
  * This demo shows how to create a ROS2 service client using TypeScript
  * with rclnodejs. It calls the AddTwoInts service with random numbers.
+ *
+ * It also demonstrates the two equivalent, fully type-safe ways to
+ * identify a service type:
+ *   - String name:   node.createClient('example_interfaces/srv/AddTwoInts', ...)
+ *   - Service class: node.createClient(AddTwoInts, ...)
+ *
+ * This demo uses the class form (obtained from `rclnodejs.require(...)`):
+ * TypeScript infers the request and the response-callback types directly
+ * from the constructor, so no explicit `any` annotations are needed.
  */
 
 import * as rclnodejs from 'rclnodejs';
@@ -25,11 +34,13 @@ async function main(): Promise<void> {
     const node = new rclnodejs.Node('ts_client_demo');
     console.log(`✓ Created node: ${node.getFullyQualifiedName()}`);
 
-    // Create a client for AddTwoInts service
-    const client = node.createClient(
-      'example_interfaces/srv/AddTwoInts',
-      SERVICE_NAME
-    );
+    // Create a client for AddTwoInts using the service class (type-based
+    // form). Obtain the constructor with `rclnodejs.require(...)` and pass it
+    // directly; the request and response types are inferred from it. The
+    // string form `node.createClient('example_interfaces/srv/AddTwoInts', ...)`
+    // works identically and is equally type-safe.
+    const AddTwoInts = rclnodejs.require('example_interfaces/srv/AddTwoInts');
+    const client = node.createClient(AddTwoInts, SERVICE_NAME);
     console.log(`✓ Created service client: ${SERVICE_NAME}`);
 
     // Wait for the service to be available
@@ -57,17 +68,17 @@ async function main(): Promise<void> {
         const a = Math.floor(Math.random() * 100);
         const b = Math.floor(Math.random() * 100);
 
-        // Create request message
-        const request = {
-          a: BigInt(a),
-          b: BigInt(b),
-        };
+        // Create a typed request message by instantiating the class.
+        // `a` and `b` are typed (bigint) from the inferred request type.
+        const request = new AddTwoInts.Request();
+        request.a = BigInt(a);
+        request.b = BigInt(b);
 
         console.log(`📞 [${requestCount}] Sending request: a=${a}, b=${b}`);
         console.log(`    Timestamp: ${new Date().toISOString()}`);
 
-        // Send the request and wait for response
-        client.sendRequest(request, (response: any) => {
+        // Send the request and wait for response (response is typed)
+        client.sendRequest(request, (response) => {
           console.log(
             `📨 [${requestCount}] Received response: sum=${response.sum}`
           );

--- a/demo/typescript/services/src/server.ts
+++ b/demo/typescript/services/src/server.ts
@@ -3,6 +3,15 @@
  *
  * This demo shows how to create a ROS2 service server using TypeScript
  * with rclnodejs. It provides an AddTwoInts service that adds two integers.
+ *
+ * It also demonstrates the two equivalent, fully type-safe ways to
+ * identify a service type:
+ *   - String name:   node.createService('example_interfaces/srv/AddTwoInts', ...)
+ *   - Service class: node.createService(AddTwoInts, ...)
+ *
+ * This demo uses the class form (obtained from `rclnodejs.require(...)`):
+ * TypeScript infers the callback's request and response types directly from
+ * the constructor, so no explicit `any` annotations are needed.
  */
 
 import * as rclnodejs from 'rclnodejs';
@@ -27,19 +36,25 @@ async function main(): Promise<void> {
     // Request counter
     let requestCount = 0;
 
-    // Create a service server for AddTwoInts
+    // Create a service server for AddTwoInts using the service class
+    // (type-based form). Obtain the constructor with `rclnodejs.require(...)`
+    // and pass it directly; the `request` and `response` parameters are
+    // inferred from it. The string form
+    // `node.createService('example_interfaces/srv/AddTwoInts', ...)` works
+    // identically and is equally type-safe.
+    const AddTwoInts = rclnodejs.require('example_interfaces/srv/AddTwoInts');
     const service = node.createService(
-      'example_interfaces/srv/AddTwoInts',
+      AddTwoInts,
       SERVICE_NAME,
-      (request: any, response: any) => {
+      (request, response) => {
         requestCount++;
 
-        // Log the incoming request
+        // Log the incoming request (request.a / request.b are typed)
         console.log(
           `🔢 [${requestCount}] Received request: a=${request.a}, b=${request.b}`
         );
 
-        // Calculate the sum using response.template
+        // Calculate the sum using response.template (typed response message)
         let result = response.template;
         result.sum = request.a + request.b;
 

--- a/demo/typescript/topics/README.md
+++ b/demo/typescript/topics/README.md
@@ -25,8 +25,8 @@ Before running this demo, ensure you have:
 Make sure your ROS 2 environment is properly sourced before running the demo:
 
 ```bash
-# For example, if using ROS 2 Jazzy
-source /opt/ros/jazzy/setup.bash
+# For example, if using ROS 2 Lyrical
+source /opt/ros/lyrical/setup.bash
 
 # Or if you have a custom workspace
 source /path/to/your/ros2_ws/install/setup.bash
@@ -44,11 +44,15 @@ npm run build
 
 ## Installation
 
-Navigate to this demo directory and install dependencies:
+This demo depends on the **local rclnodejs** in this repository
+(`"rclnodejs": "file:../../.."`) so it always builds against the in-tree
+TypeScript types. Install with `--ignore-scripts` so npm links the local
+package without trying to rebuild its native addon (the prebuilt binary in the
+repo is reused):
 
 ```bash
 cd demo/typescript/topics
-npm install
+npm install --ignore-scripts
 ```
 
 ## Usage
@@ -137,9 +141,10 @@ Starting TypeScript Publisher Demo...
 ✓ Created timer with 1000ms interval
 🚀 Publisher is running. Press Ctrl+C to stop...
 
-📤 Published: "Hello from TypeScript publisher! Message #1 at 2025-07-16T10:30:00.123Z"
-📤 Published: "Hello from TypeScript publisher! Message #2 at 2025-07-16T10:30:01.125Z"
-📤 Published: "Hello from TypeScript publisher! Message #3 at 2025-07-16T10:30:02.127Z"
+📤 [A/string] Published: "Hello from TypeScript publisher! Message #1 at 2025-07-16T10:30:00.123Z"
+📤 [B/class] Published: "Hello from typed publisher! Message #1"
+📤 [A/string] Published: "Hello from TypeScript publisher! Message #2 at 2025-07-16T10:30:01.125Z"
+📤 [B/class] Published: "Hello from typed publisher! Message #2"
 ...
 ```
 
@@ -152,10 +157,10 @@ Starting TypeScript Subscriber Demo...
 ✓ Created subscription on topic: ts_demo
 👂 Subscriber is listening. Press Ctrl+C to stop...
 
-📥 [1] Received: "Hello from TypeScript publisher! Message #1 at 2025-07-16T10:30:00.123Z"
-    Timestamp: 2025-07-16T10:30:00.124Z
-📥 [2] Received: "Hello from TypeScript publisher! Message #2 at 2025-07-16T10:30:01.125Z"
-    Timestamp: 2025-07-16T10:30:01.126Z
+📥 [A/string] [1] Received: "Hello from TypeScript publisher! Message #1 at 2025-07-16T10:30:00.123Z"
+📥 [B/class] Received: "Hello from typed publisher! Message #1"
+📥 [A/string] [2] Received: "Hello from TypeScript publisher! Message #2 at 2025-07-16T10:30:01.125Z"
+📥 [B/class] Received: "Hello from typed publisher! Message #2"
 ...
 ```
 
@@ -176,14 +181,23 @@ demo/typescript/topics/
 
 ## Code Explanation
 
+Both demos show the **two equivalent, fully type-safe ways** to identify a
+message type:
+
+- **String name** (Style A): pass the type string, e.g. `'std_msgs/msg/String'`.
+- **Message class** (Style B): obtain the constructor with `rclnodejs.require(...)`
+  and pass it directly. TypeScript then infers the message type from the
+  constructor, so no explicit annotation is needed.
+
 ### Publisher (`src/publisher.ts`)
 
 The publisher demonstrates:
 
 - **Node Creation**: Creates a ROS2 node using TypeScript
-- **Publisher Setup**: Creates a publisher for `std_msgs/msg/String` messages
+- **Publisher Setup**: Creates publishers for `std_msgs/msg/String` messages
 - **Timer Usage**: Uses `node.createTimer()` for periodic message publishing
-- **Message Creation**: Uses `rclnodejs.createMessageObject()` with proper typing
+- **Message Creation**: Builds messages with `createMessageObject()` (Style A)
+  or by instantiating the message class (Style B)
 - **Graceful Shutdown**: Handles SIGINT for clean shutdown
 
 Key TypeScript features used:
@@ -192,21 +206,29 @@ Key TypeScript features used:
 import * as rclnodejs from 'rclnodejs';
 
 const node = new rclnodejs.Node('ts_publisher_demo');
+
+// Style A — string name
 const publisher = node.createPublisher('std_msgs/msg/String', TOPIC_NAME);
 const message = rclnodejs.createMessageObject('std_msgs/msg/String');
+
+// Style B — message class (type inferred from the constructor)
+const StringMsg = rclnodejs.require('std_msgs/msg/String');
+const typedPublisher = node.createPublisher(StringMsg, TOPIC_NAME);
+const typedMessage = new StringMsg(); // `typedMessage.data` is typed
 ```
 
 ### Subscriber (`src/subscriber.ts`)
 
 The subscriber demonstrates:
 
-- **Subscription Creation**: Creates a typed subscription for string messages
+- **Subscription Creation**: Creates typed subscriptions for string messages
 - **Callback Handling**: Processes incoming messages with proper TypeScript typing
 - **Message Processing**: Displays received messages with timestamps
 
 Key TypeScript features used:
 
 ```typescript
+// Style A — string name, callback type annotated explicitly
 const subscription = node.createSubscription(
   'std_msgs/msg/String',
   TOPIC_NAME,
@@ -214,6 +236,12 @@ const subscription = node.createSubscription(
     console.log(`Received: "${message.data}"`);
   }
 );
+
+// Style B — message class, callback type inferred from the constructor
+const StringMsg = rclnodejs.require('std_msgs/msg/String');
+node.createSubscription(StringMsg, TOPIC_NAME, (message) => {
+  console.log(`Received: "${message.data}"`);
+});
 ```
 
 ## TypeScript Benefits
@@ -252,7 +280,7 @@ This demo showcases several TypeScript advantages:
    **Solution**: Source your ROS 2 setup file:
 
    ```bash
-   source /opt/ros/jazzy/setup.bash
+   source /opt/ros/lyrical/setup.bash
    ```
 
 3. **Build errors:**
@@ -300,12 +328,17 @@ const TOPIC_NAME = 'your_custom_topic';
 
 ### Change Message Type
 
-To use a different message type, update the type string and interface:
+To use a different message type, update the type string or message class:
 
 ```typescript
-// For example, using geometry_msgs/msg/Twist
+// Style A — string name
 const publisher = node.createPublisher('geometry_msgs/msg/Twist', 'cmd_vel');
 const message = rclnodejs.createMessageObject('geometry_msgs/msg/Twist');
+
+// Style B — message class (type inferred from the constructor)
+const Twist = rclnodejs.require('geometry_msgs/msg/Twist');
+const typedPublisher = node.createPublisher(Twist, 'cmd_vel');
+const message2 = new Twist();
 ```
 
 ### Adjust Publishing Rate

--- a/demo/typescript/topics/package.json
+++ b/demo/typescript/topics/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "rclnodejs": "file:../../"
+    "rclnodejs": "file:../../.."
   }
 }

--- a/demo/typescript/topics/src/publisher.ts
+++ b/demo/typescript/topics/src/publisher.ts
@@ -3,6 +3,15 @@
  *
  * This demo shows how to create a ROS2 publisher using TypeScript
  * with rclnodejs. It publishes string messages to the "ts_demo" topic.
+ *
+ * It also demonstrates the two equivalent, fully type-safe ways to
+ * identify a message type:
+ *   - String name:   node.createPublisher('std_msgs/msg/String', ...)
+ *   - Message class: node.createPublisher(StringMsg, ...)
+ *
+ * With the class form (obtained from `rclnodejs.require(...)`), TypeScript
+ * infers the publisher's message type directly from the constructor, so
+ * `new StringMsg()` is typed without any explicit annotation.
  */
 
 import * as rclnodejs from 'rclnodejs';
@@ -25,22 +34,35 @@ async function main(): Promise<void> {
     const node = new rclnodejs.Node('ts_publisher_demo');
     console.log(`✓ Created node: ${node.getFullyQualifiedName()}`);
 
-    // Create a publisher for std_msgs/msg/String messages
+    // Style A — string name. Create a publisher for std_msgs/msg/String
+    // messages, building each message with `createMessageObject`:
     const publisher = node.createPublisher('std_msgs/msg/String', TOPIC_NAME);
     console.log(`✓ Created publisher on topic: ${TOPIC_NAME}`);
+
+    // Style B — message class. Obtain the constructor with
+    // `rclnodejs.require(...)` and pass it directly. The publisher's message
+    // type is inferred from the constructor, and `new StringMsg()` is typed
+    // without any annotation. Both styles are equally type-safe.
+    const StringMsg = rclnodejs.require('std_msgs/msg/String');
+    const typedPublisher = node.createPublisher(StringMsg, TOPIC_NAME);
 
     // Message counter
     let messageCount = 0;
 
     // Create a timer to publish messages at regular intervals
     const timer = node.createTimer(PUBLISH_INTERVAL, () => {
-      // Create a string message
+      // Style A — build the message with createMessageObject:
       const message = rclnodejs.createMessageObject('std_msgs/msg/String');
       message.data = `Hello from TypeScript publisher! Message #${++messageCount} at ${new Date().toISOString()}`;
-
-      // Publish the message
       publisher.publish(message);
-      console.log(`📤 Published: "${message.data}"`);
+      console.log(`📤 [A/string] Published: "${message.data}"`);
+
+      // Style B — build the message by instantiating the class. The
+      // `data` field is typed from the inferred message type.
+      const typedMessage = new StringMsg();
+      typedMessage.data = `Hello from typed publisher! Message #${messageCount}`;
+      typedPublisher.publish(typedMessage);
+      console.log(`📤 [B/class] Published: "${typedMessage.data}"`);
     });
 
     console.log(`✓ Created timer with ${PUBLISH_INTERVAL}ms interval`);

--- a/demo/typescript/topics/src/subscriber.ts
+++ b/demo/typescript/topics/src/subscriber.ts
@@ -3,6 +3,15 @@
  *
  * This demo shows how to create a ROS2 subscriber using TypeScript
  * with rclnodejs. It subscribes to string messages from the "ts_demo" topic.
+ *
+ * It also demonstrates the two equivalent, fully type-safe ways to
+ * identify a message type:
+ *   - String name:   node.createSubscription('std_msgs/msg/String', ...)
+ *   - Message class: node.createSubscription(StringMsg, ...)
+ *
+ * With the class form (obtained from `rclnodejs.require(...)`), TypeScript
+ * infers the callback's message type directly from the constructor, so no
+ * explicit `message` annotation is needed.
  */
 
 import * as rclnodejs from 'rclnodejs';
@@ -27,16 +36,29 @@ async function main(): Promise<void> {
     // Message counter
     let receivedCount = 0;
 
-    // Create a subscription for std_msgs/msg/String messages
+    // Create a subscription for std_msgs/msg/String messages.
+    //
+    // Style A — string name. The callback message type is annotated
+    // explicitly as rclnodejs.std_msgs.msg.String:
     const subscription = node.createSubscription(
       'std_msgs/msg/String',
       TOPIC_NAME,
       (message: rclnodejs.std_msgs.msg.String) => {
         receivedCount++;
-        console.log(`📥 [${receivedCount}] Received: "${message.data}"`);
-        console.log(`    Timestamp: ${new Date().toISOString()}`);
+        console.log(
+          `📥 [A/string] [${receivedCount}] Received: "${message.data}"`
+        );
       }
     );
+
+    // Style B — message class. Obtain the constructor with
+    // `rclnodejs.require(...)` and pass it directly. The `message`
+    // parameter type is inferred as rclnodejs.std_msgs.msg.String, so no
+    // explicit annotation is required. Both styles are equally type-safe.
+    const StringMsg = rclnodejs.require('std_msgs/msg/String');
+    node.createSubscription(StringMsg, TOPIC_NAME, (message) => {
+      console.log(`📥 [B/class] Received: "${message.data}"`);
+    });
 
     console.log(`✓ Created subscription on topic: ${TOPIC_NAME}`);
     console.log('👂 Subscriber is listening. Press Ctrl+C to stop...\n');

--- a/lib/interface_loader.js
+++ b/lib/interface_loader.js
@@ -205,7 +205,17 @@ let interfaceLoader = {
   loadInterface(packageName, type, messageName) {
     if (arguments.length === 1) {
       const type = arguments[0];
-      if (typeof type === 'object') {
+      if (typeof type === 'function') {
+        // Already a loaded interface class/constructor (e.g. the value
+        // returned by a previous loadInterface call or rclnodejs.require).
+        // Every generated interface class exposes a static type() method, so
+        // use it to distinguish a genuine interface from an arbitrary
+        // function. Return it as-is so loadInterface is idempotent; otherwise
+        // fall through to the MESSAGE_NOT_FOUND error below.
+        if (typeof type.type === 'function') {
+          return type;
+        }
+      } else if (typeof type === 'object') {
         return this.loadInterfaceByObject(type);
       } else if (typeof type === 'string') {
         return this.loadInterfaceByString(type);

--- a/rostsd_gen/index.js
+++ b/rostsd_gen/index.js
@@ -164,7 +164,7 @@ function savePkgInfoAsTSD(pkgInfos, fd) {
   fs.writeSync(fd, '  type Message = MessagesMap[MessageTypeClassName];\n');
   fs.writeSync(
     fd,
-    '  type MessageType<T> = T extends MessageTypeClassName ? MessagesMap[T] : object;\n\n'
+    '  type MessageType<T> = T extends MessageTypeClassName ? MessagesMap[T] : T extends new (...args: any[]) => infer R ? R : object;\n\n'
   );
 
   // write message contructor mappings
@@ -193,7 +193,7 @@ function savePkgInfoAsTSD(pkgInfos, fd) {
   fs.writeSync(fd, '  type Service = ServicesMap[ServiceTypeClassName];\n');
   fs.writeSync(
     fd,
-    '  type ServiceType<T> = T extends ServiceTypeClassName ? ServicesMap[T] : object;\n\n'
+    '  type ServiceType<T> = T extends ServiceTypeClassName ? ServicesMap[T] : T extends { Request: any; Response: any } ? T : object;\n\n'
   );
 
   // write actions type mappings
@@ -206,7 +206,7 @@ function savePkgInfoAsTSD(pkgInfos, fd) {
   fs.writeSync(fd, '  type Action = ActionsMap[ActionTypeClassName];\n');
   fs.writeSync(
     fd,
-    '  type ActionType<T> = T extends ActionTypeClassName ? ActionsMap[T] : object;\n\n'
+    '  type ActionType<T> = T extends ActionTypeClassName ? ActionsMap[T] : T extends { Goal: any; Feedback: any; Result: any } ? T : object;\n\n'
   );
 
   fs.writeSync(

--- a/test/test-action-server.js
+++ b/test/test-action-server.js
@@ -167,6 +167,51 @@ describe('rclnodejs action server', function () {
     server.destroy();
   });
 
+  it('Test single goal accept with constructor-form typeClass', async function () {
+    // Regression test: passing the loaded interface constructor (the value
+    // returned by rclnodejs.require) to ActionServer/ActionClient must work
+    // the same as passing the type string. See loadInterface idempotency.
+    let goalUuid = createUuid();
+    let goalOrder = 10;
+
+    function goalCallback(goal) {
+      assert.strictEqual(goal.order, goalOrder);
+      return rclnodejs.GoalResponse.ACCEPT;
+    }
+
+    function handleAcceptedCallback(goalHandle) {
+      goalHandle.execute();
+    }
+
+    let ctorClient = new rclnodejs.ActionClient(
+      node,
+      Fibonacci,
+      'fibonacci_ctor'
+    );
+
+    let server = new rclnodejs.ActionServer(
+      node,
+      Fibonacci,
+      'fibonacci_ctor',
+      executeCallback,
+      goalCallback,
+      handleAcceptedCallback
+    );
+
+    let goal = new Fibonacci.Goal();
+    goal.order = goalOrder;
+
+    await ctorClient.waitForServer(1000);
+    const handle = await ctorClient.sendGoal(goal, null, goalUuid);
+    assert.ok(handle.accepted);
+
+    let result = await handle.getResult();
+    assert.ok(result);
+
+    ctorClient.destroy();
+    server.destroy();
+  });
+
   it('Test single goal reject', async function () {
     let goalUuid = createUuid();
     let goalOrder = 10;

--- a/test/test-message-type.js
+++ b/test/test-message-type.js
@@ -405,3 +405,28 @@ describe('Rclnodejs message type testing', function () {
     });
   });
 });
+
+describe('loadInterface() argument handling', function () {
+  const loader = require('../lib/interface_loader.js');
+
+  it('returns a loaded interface class as-is (idempotent)', function () {
+    const StringMsg = loader.loadInterface('std_msgs/msg/String');
+    assert.strictEqual(typeof StringMsg, 'function');
+    // Passing the constructor back in should return the very same class.
+    assert.strictEqual(loader.loadInterface(StringMsg), StringMsg);
+  });
+
+  it('throws for an arbitrary function that is not a generated interface', function () {
+    const notAnInterface = () => {};
+    assert.throws(
+      () => loader.loadInterface(notAnInterface),
+      (err) => err && err.code === 'MESSAGE_NOT_FOUND'
+    );
+
+    class Foo {}
+    assert.throws(
+      () => loader.loadInterface(Foo),
+      (err) => err && err.code === 'MESSAGE_NOT_FOUND'
+    );
+  });
+});

--- a/test/test-service.js
+++ b/test/test-service.js
@@ -69,6 +69,43 @@ describe('Test service class', function () {
     rclnodejs.spin(clientNode);
   });
 
+  it('Node.createService()/createClient() with constructor-form typeClass', function (done) {
+    // Regression test: passing the loaded interface constructor (the value
+    // returned by rclnodejs.require) to createService/createClient must work
+    // the same as passing the type string.
+    const clientNode = rclnodejs.createNode('ctor_ps_client');
+    const serviceNode = rclnodejs.createNode('ctor_ps_service');
+    const AddTwoInts = rclnodejs.require('example_interfaces/srv/AddTwoInts');
+
+    serviceNode.createService(
+      AddTwoInts,
+      'ctor_ps_channel',
+      (request, response) => {
+        assert.deepStrictEqual(request.a, 1n);
+        assert.deepStrictEqual(request.b, 2n);
+        let result = response.template;
+        result.sum = request.a + request.b;
+        response.send(result);
+      }
+    );
+    const client = clientNode.createClient(AddTwoInts, 'ctor_ps_channel');
+    const request = new AddTwoInts.Request();
+    request.a = 1n;
+    request.b = 2n;
+
+    const timer = clientNode.createTimer(BigInt(100000000), () => {
+      client.sendRequest(request, (response) => {
+        timer.cancel();
+        assert.deepStrictEqual(response.sum, 3n);
+        serviceNode.destroy();
+        clientNode.destroy();
+        done();
+      });
+    });
+    rclnodejs.spin(serviceNode);
+    rclnodejs.spin(clientNode);
+  });
+
   it('Get service options', function () {
     const node = rclnodejs.createNode('test_node');
     const service = node.createService(

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -211,6 +211,24 @@ node.createPublisher(TYPE_CLASS, TOPIC, publisher.options, (event: object) => {
 expectType<void>(publisher.assertLiveliness());
 expectType<string>(publisher.loggerName);
 
+// ---- TypeClass forms ----
+// Case 1: a message/service class constructor (e.g. the value returned by rclnodejs.require)
+const StringClass = rclnodejs.require('std_msgs/msg/String');
+expectAssignable<rclnodejs.TypeClass>(StringClass);
+const publisherFromCtor = node.createPublisher(StringClass, TOPIC);
+expectType<rclnodejs.Publisher<typeof StringClass>>(publisherFromCtor);
+
+// Case 2: a string representing the message class name
+expectAssignable<rclnodejs.TypeClass>(TYPE_CLASS);
+const publisherFromString = node.createPublisher(TYPE_CLASS, TOPIC);
+expectType<rclnodejs.Publisher<'std_msgs/msg/String'>>(publisherFromString);
+
+// Case 3: an object descriptor of the message class
+const typeDescriptor = { package: 'std_msgs', type: 'msg', name: 'String' };
+expectAssignable<rclnodejs.TypeClass>(typeDescriptor);
+const publisherFromDescriptor = node.createPublisher(typeDescriptor, TOPIC);
+expectType<rclnodejs.Publisher<typeof typeDescriptor>>(publisherFromDescriptor);
+
 // ---- LifecyclePublisher ----
 const lifecyclePublisher = lifecycleNode.createLifecyclePublisher(
   TYPE_CLASS,
@@ -342,6 +360,30 @@ expectType<void>(
 );
 expectType<boolean>(client.isDestroyed());
 expectType<string>(client.loggerName);
+
+// ---- Service/Client constructor-form typing ----
+// Passing a service constructor (the value returned by rclnodejs.require) should
+// infer the concrete request/response message types, not fall back to `object`.
+const AddTwoInts = rclnodejs.require('example_interfaces/srv/AddTwoInts');
+const serviceFromCtor = node.createService(
+  AddTwoInts,
+  'add_two_ints_ctor',
+  (request) => {
+    expectType<rclnodejs.example_interfaces.srv.AddTwoInts_Request>(request);
+  }
+);
+expectType<rclnodejs.example_interfaces.srv.AddTwoIntsConstructor>(
+  serviceFromCtor
+);
+
+const clientFromCtor = node.createClient(AddTwoInts, 'add_two_ints_ctor');
+expectType<rclnodejs.Client<typeof AddTwoInts>>(clientFromCtor);
+clientFromCtor.sendRequest(new AddTwoInts.Request(), (response) => {
+  expectType<rclnodejs.example_interfaces.srv.AddTwoInts_Response>(response);
+});
+expectType<Promise<rclnodejs.example_interfaces.srv.AddTwoInts_Response>>(
+  clientFromCtor.sendRequestAsync(new AddTwoInts.Request())
+);
 
 // ---- Timer ----
 const timerCallback: rclnodejs.TimerRequestCallback = (timerInfo) => {
@@ -600,6 +642,25 @@ expectType<void>(
     rclnodejs.Node.getDefaultOptions() as rclnodejs.QoS,
     rclnodejs.ServiceIntrospectionStates.CONTENTS
   )
+);
+
+// ---- Action constructor-form typing ----
+// Passing an action constructor (the value returned by rclnodejs.require) should
+// infer the concrete goal/feedback/result message types, not fall back to `object`.
+const actionClientFromCtor = new rclnodejs.ActionClient(
+  node,
+  Fibonacci,
+  'fibonacci_ctor'
+);
+expectType<rclnodejs.ActionClient<typeof Fibonacci>>(actionClientFromCtor);
+expectType<rclnodejs.example_interfaces.action.Fibonacci_Goal>(
+  {} as rclnodejs.ActionGoal<typeof Fibonacci>
+);
+expectType<rclnodejs.example_interfaces.action.Fibonacci_Feedback>(
+  {} as rclnodejs.ActionFeedback<typeof Fibonacci>
+);
+expectType<rclnodejs.example_interfaces.action.Fibonacci_Result>(
+  {} as rclnodejs.ActionResult<typeof Fibonacci>
 );
 
 // ---- ActionUuid -----

--- a/types/action_client.d.ts
+++ b/types/action_client.d.ts
@@ -1,13 +1,19 @@
 declare module 'rclnodejs' {
   type ActionGoal<T> = T extends ActionTypeClassName
     ? InstanceType<ActionsMap[T]['Goal']>
-    : object;
+    : T extends { Goal: new (...args: any[]) => infer R }
+      ? R
+      : object;
   type ActionFeedback<T> = T extends ActionTypeClassName
     ? InstanceType<ActionsMap[T]['Feedback']>
-    : object;
+    : T extends { Feedback: new (...args: any[]) => infer R }
+      ? R
+      : object;
   type ActionResult<T> = T extends ActionTypeClassName
     ? InstanceType<ActionsMap[T]['Result']>
-    : object;
+    : T extends { Result: new (...args: any[]) => infer R }
+      ? R
+      : object;
 
   /**
    * Goal handle for working with Action Clients.

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -3,10 +3,24 @@ declare module 'rclnodejs' {
    * Identifies type of ROS message such as msg or srv.
    */
   type TypeClass<T = TypeClassName> =
-    | (() => any)
-    | T // a string representing the message class, e.g. 'std_msgs/msg/String',
+    | (new (...args: any[]) => any) // a message class constructor, e.g. the value returned by rclnodejs.require('std_msgs/msg/String')
     | {
-        // object representing a message class, e.g. {package: 'std_msgs', type: 'msg', name: 'String'}
+        // a service class constructor, e.g. the value returned by rclnodejs.require('example_interfaces/srv/AddTwoInts')
+        readonly Request: new (...args: any[]) => any;
+        readonly Response: new (...args: any[]) => any;
+      }
+    | {
+        // an action class constructor, e.g. the value returned by rclnodejs.require('example_interfaces/action/Fibonacci')
+        readonly Goal: new (...args: any[]) => any;
+        readonly Feedback: new (...args: any[]) => any;
+        readonly Result: new (...args: any[]) => any;
+      }
+    | T // a string representing the message/service/action class, e.g. 'std_msgs/msg/String',
+    | {
+        // object representing a message class, e.g. {package: 'std_msgs', type: 'msg', name: 'String'}.
+        // NOTE: this form is supported at runtime but provides no message type inference in
+        // TypeScript (messages resolve to `object`). Prefer the string or constructor form for
+        // full type safety.
         package: string;
         type: string;
         name: string;

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -1,6 +1,17 @@
 declare module 'rclnodejs' {
   /**
-   * Identifies type of ROS message such as msg or srv.
+   * Identifies a ROS message, service or action type.
+   *
+   * A type can be supplied in any of the following forms:
+   * - a constructor returned by {@link require | rclnodejs.require(...)} — for a
+   *   message (e.g. `std_msgs/msg/String`), a service (with `Request`/`Response`)
+   *   or an action (with `Goal`/`Feedback`/`Result`). This form is fully typed:
+   *   the concrete message types are inferred for callbacks, requests, responses,
+   *   goals, feedback and results.
+   * - a string, e.g. `'std_msgs/msg/String'`. Also fully typed.
+   * - an object descriptor, e.g. `{package: 'std_msgs', type: 'msg', name: 'String'}`.
+   *   Supported at runtime but not statically resolvable, so it falls back to
+   *   `object`. Prefer the string or constructor form for full type safety.
    */
   type TypeClass<T = TypeClassName> =
     | (new (...args: any[]) => any) // a message class constructor, e.g. the value returned by rclnodejs.require('std_msgs/msg/String')

--- a/types/service.d.ts
+++ b/types/service.d.ts
@@ -1,11 +1,15 @@
 declare module 'rclnodejs' {
   type ServiceRequestMessage<T> = T extends ServiceTypeClassName
     ? InstanceType<ServicesMap[T]['Request']>
-    : object;
+    : T extends { Request: new (...args: any[]) => infer R }
+      ? R
+      : object;
 
   type ServiceResponseMessage<T> = T extends ServiceTypeClassName
     ? InstanceType<ServicesMap[T]['Response']>
-    : object;
+    : T extends { Response: new (...args: any[]) => infer R }
+      ? R
+      : object;
 
   /**
    * Callback for receiving service requests from a client.


### PR DESCRIPTION
Support the constructor form of `TypeClass` (the value returned by `rclnodejs.require(...)`) with full type inference for messages, services, and actions, bringing it on par with the existing string and object-descriptor forms, and make the runtime loader accept that form so it works end to end.

## Types
- `TypeClass` now recognizes message, service (`{ Request, Response }`), and action (`{ Goal, Feedback, Result }`) constructor shapes (`types/node.d.ts`, `types/service.d.ts`, `types/action_client.d.ts`).
- `ServiceRequestMessage` / `ServiceResponseMessage` and `ActionGoal` / `ActionFeedback` / `ActionResult` infer the concrete payload types from the constructor.
- `ServiceType` / `ActionType` and the `rostsd_gen` generator (`rostsd_gen/index.js`) handle the constructor form.

## Runtime
- `lib/interface_loader.js`: `loadInterface()` accepts an already-loaded interface constructor and returns it as-is (idempotent), validated via the generated class's static `type()` method. Arbitrary functions still fall through to the existing `MESSAGE_NOT_FOUND` error. This fixes the `MESSAGE_NOT_FOUND` failure when a constructor was passed to `ActionServer` / `ActionClient`, which call `loadInterface` unconditionally.

## Tests
- `test/types/index.test-d.ts`: `tsd` coverage for every `TypeClass` form — message, service, and action via constructor, string, and object descriptor.
- `test/test-action-server.js`, `test/test-service.js`: runtime regression tests that pass the constructor form to `ActionServer` / `ActionClient` and `createService` / `createClient` and exercise a full round-trip.
- `test/test-message-type.js`: unit tests for `loadInterface()` idempotency and the arbitrary-function rejection path.

## Demos
- `topics`, `services`, and `actions` TypeScript demos updated to demonstrate both the string-name and message/service/action-class styles, with typed callbacks via `typeof Ctor`.
- All three demos depend on the local rclnodejs (`file:../../..`) and document `npm install --ignore-scripts`; README source examples use the current LTS (Lyrical).

Fix: #1525