### PR TITLE
Modernize tsconfig.json for Node.js module resolution

### DIFF
--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -414,12 +414,15 @@ expectType<void>(timer.clearOnResetCallback());
 expectType<rclnodejs.TimerInfo>(timer.callTimerWithInfo());
 
 // ---- Rate ----
-const rate = await node.createRate(1);
-expectType<rclnodejs.Rate>(rate);
-expectType<number>(rate.frequency);
-expectType<boolean>(rate.isCanceled());
-expectType<Promise<void>>(rate.sleep());
-expectType<void>(rate.cancel());
+expectType<Promise<rclnodejs.Rate>>(node.createRate(1));
+void (async () => {
+  const rate = await node.createRate(1);
+  expectType<rclnodejs.Rate>(rate);
+  expectType<number>(rate.frequency);
+  expectType<boolean>(rate.isCanceled());
+  expectType<Promise<void>>(rate.sleep());
+  expectType<void>(rate.cancel());
+})();
 
 // ---- Duration ----
 const duration1 = new rclnodejs.Duration();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,16 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "target": "es2020",
-    /* Strict Type-Checking Options */
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "es2022",
     "strict": true,
-    /* Additional Checks */
     /* next line commented out because we need unused vars for type tests */
     // "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "lib": ["es2020"]
+    "lib": ["es2022"],
+    "types": ["node"]
   },
   "include": [
         "types/**/*"


### PR DESCRIPTION
- Switch `module` and `moduleResolution` to `nodenext` to align with modern Node.js library publishing and ES module resolution semantics.
- Bump `target` and `lib` to `es2022`. The project's existing `engines` floor (`node >= 20.20.2`) guarantees full ES2022 runtime support, so targeting es2022 is safe and lets type-checking reflect modern language features instead of nodenext's floating `target: esnext`.
- Add `"types": ["node"]` so raw `tsc --noEmit` resolves Node globals (Buffer, setTimeout, child_process, events, AbortSignal) without relying on tsd's implicit @types/node injection.
- Refactor a top-level `await` in test/types/index.test-d.ts into an async IIFE, since nodenext classifies the file as CommonJS where top-level await is illegal.
- Remove stale boilerplate section-label comments (`Strict Type-Checking Options`, `Additional Checks`) carried over from the original generated tsconfig template.

Fix: #1527