### PR TITLE
[Web runtime] Add SSE subscribe + CORS to HttpTransport

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,10 @@ how much glue you want to write.
   the browser SDK types `call` / `publish` / `subscribe` end-to-end
   from your ROS 2 message types; and every capability
   is also a plain HTTP endpoint —
-  `curl -X POST http://<host>/capability/call/<name>` — so shell
-  scripts, Postman, AI-agent tool-use, and even a bare browser
-  `fetch()` (CORS-enabled) just work.
+  `curl -X POST http://<host>/capability/call/<name>`, with `subscribe`
+  streaming as Server-Sent Events (`GET .../capability/subscribe/<name>`) —
+  so shell scripts, Postman, AI-agent tool-use, and even a bare browser
+  `fetch()` / `EventSource` (CORS-enabled) just work.
   _New in `2.0.0-beta.0`._
 
   ```ts

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ how much glue you want to write.
   streaming as Server-Sent Events (`GET .../capability/subscribe/<name>`) —
   so shell scripts, Postman, AI-agent tool-use, and even a bare browser
   `fetch()` / `EventSource` (CORS-enabled) just work.
-  _New in `2.0.0-beta.0`._
 
   ```ts
   import { connect } from 'rclnodejs/web';
@@ -137,7 +136,6 @@ how much glue you want to write.
 - **[`rosocket`](./rosocket/README.md)** — thin WebSocket gateway,
   zero browser dependencies (just built-in `WebSocket` + `JSON`).
   Best for quick prototypes and `roslibjs`-style apps.
-  _New in `2.0.0-beta.0`._
 
   ```bash
   npx rosocket --port 9000 --topic /chatter:std_msgs/msg/String

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ how much glue you want to write.
   from your ROS 2 message types; and every capability
   is also a plain HTTP endpoint —
   `curl -X POST http://<host>/capability/call/<name>` — so shell
-  scripts, Postman, and AI-agent tool-use just work.
+  scripts, Postman, AI-agent tool-use, and even a bare browser
+  `fetch()` (CORS-enabled) just work.
   _New in `2.0.0-beta.0`._
 
   ```ts

--- a/bin/rclnodejs-web.js
+++ b/bin/rclnodejs-web.js
@@ -91,6 +91,12 @@ const argv = process.argv.slice(2);
           port: cfg.http.port,
           host: cfg.http.host || cfg.host,
           basePath: cfg.http.basePath || cfg.path,
+          sse: cfg.http.sse,
+          sseKeepAliveMs:
+            cfg.http.sseKeepAliveMs != null
+              ? cfg.http.sseKeepAliveMs
+              : undefined,
+          cors: cfg.http.cors,
         })
       );
     }
@@ -118,8 +124,11 @@ const argv = process.argv.slice(2);
       if (httpTransport) {
         const httpHost = displayHost(cfg.http.host || cfg.host);
         const httpBase = cfg.http.basePath || cfg.path;
+        const httpKinds = cfg.http.sse
+          ? 'call/publish + subscribe (SSE)'
+          : 'call/publish only';
         process.stdout.write(
-          `                  also http://${httpHost}:${httpTransport.port}${httpBase} (call/publish only)\n`
+          `                  also http://${httpHost}:${httpTransport.port}${httpBase} (${httpKinds})\n`
         );
       }
     }

--- a/bin/rclnodejs-web.js
+++ b/bin/rclnodejs-web.js
@@ -21,6 +21,7 @@ import {
   parseArgv,
   loadConfigFile,
   mergeConfig,
+  validateConfig,
   HELP,
 } from '../lib/runtime/cli-config.js';
 
@@ -51,6 +52,11 @@ const argv = process.argv.slice(2);
   let cfg;
   try {
     cfg = mergeConfig(loadConfigFile(parsed.configPath), parsed.partial);
+    // Re-validate the merged result: loadConfigFile only validates the
+    // JSON file, so values supplied purely via flags (e.g.
+    // `--http-sse-keep-alive foo` → NaN, or a non-numeric `--http-port`)
+    // would otherwise reach the transport unchecked.
+    validateConfig(cfg, 'options');
   } catch (e) {
     fail(e);
   }

--- a/demo/web/javascript/README.md
+++ b/demo/web/javascript/README.md
@@ -84,6 +84,31 @@ stream — no SDK, no WebSocket. It works cross-origin (`:8080` → `:9001`)
 because the demo also enables CORS (`new HttpTransport({ sse: true, cors:
 true })`); in production, pass your site's origin instead of `true`.
 
+The same is true for `call` / `publish` from the browser itself: the
+**native `fetch()` panel** (section 7) hits these endpoints directly —
+the `curl` commands above translate one-to-one to `fetch()` (same method,
+URL, headers and JSON body), again cross-origin thanks to CORS:
+
+```js
+// service call → 200 + JSON reply
+const res = await fetch(
+  'http://localhost:9001/capability/call/add_two_ints',
+  {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ a: '7n', b: '35n' }),
+  },
+);
+console.log((await res.json()).sum); // '42n'
+
+// topic publish → 204 No Content
+await fetch('http://localhost:9001/capability/publish/web_demo_chatter', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ data: 'hi from fetch()' }),
+});
+```
+
 > For browser apps, prefer the WebSocket transport for `subscribe` — one
 > connection multiplexes every topic. SSE targets the curl / AI-agent /
 > server-side persona.

--- a/demo/web/javascript/README.md
+++ b/demo/web/javascript/README.md
@@ -57,19 +57,18 @@ can flip the SDK between the two without restarting.
 
 ## Same capability, no SDK
 
-Every `call` / `publish` is also reachable as plain HTTP — drive the
-runtime from `curl`, Postman, or an AI agent without any JavaScript:
+Every `call` / `publish` is reachable as plain HTTP — drive the runtime
+from `curl`, Postman, or an AI agent, no JavaScript required:
 
 ```bash
 curl -sS -X POST http://localhost:9001/capability/call/add_two_ints \
-  -H 'content-type: application/json' \
-  -d '{"a":"7n","b":"35n"}'
+  -H 'content-type: application/json' -d '{"a":"7n","b":"35n"}'
 # => {"sum":"42n"}
 ```
 
-This demo's `runtime.mjs` also enables SSE (`new HttpTransport({ sse: true })`),
-so `subscribe` is reachable over HTTP as a `text/event-stream` — useful for
-clients that can't hold a WebSocket open:
+The demo also enables SSE (`new HttpTransport({ sse: true })`), so
+`subscribe` works over HTTP as a `text/event-stream` — handy for clients
+that can't hold a WebSocket open:
 
 ```bash
 curl -N http://localhost:9001/capability/subscribe/web_demo_chatter
@@ -78,70 +77,50 @@ curl -N http://localhost:9001/capability/subscribe/web_demo_chatter
 #
 # event: message
 # data: {"data":"hi from curl"}
-# …one `message` event per published sample, until you ^C
 ```
 
-Browser apps should still prefer the WebSocket transport for `subscribe`
-(one connection multiplexes every topic). SSE subscribe targets the
-curl / AI-agent / server-side persona.
+The page's **native `EventSource` panel** (section 6) reads this same
+stream — no SDK, no WebSocket. It works cross-origin (`:8080` → `:9001`)
+because the demo also enables CORS (`new HttpTransport({ sse: true, cors:
+true })`); in production, pass your site's origin instead of `true`.
 
-The page also has a **native `EventSource` panel** (section 6) that
-subscribes to `/web_demo_chatter` over the same SSE endpoint — no SDK, no
-WebSocket, just the browser primitive over plain HTTP. Because the page
-(`:8080`) and the HTTP transport (`:9001`) are different origins, the
-demo's `runtime.mjs` enables CORS (`new HttpTransport({ sse: true, cors:
-true })`) so the cross-origin `EventSource` is allowed. In production,
-pass your site's origin instead of `true`.
+> For browser apps, prefer the WebSocket transport for `subscribe` — one
+> connection multiplexes every topic. SSE targets the curl / AI-agent /
+> server-side persona.
 
-### Pair it with the stock publisher example
+### Pair it with your own publisher
 
-The EventSource panel's topic box defaults to `/web_demo_chatter` (the
-shared demo topic), but the runtime also exposes `/topic` so you can
-feed the demo from your own node. In a third shell, run the standard
-publisher example:
+The runtime also exposes `/topic`, so you can feed the demo from any ROS 2
+node instead of the in-page publisher. Run the stock publisher example in
+a third shell, then point the EventSource panel (or `curl`) at `/topic`:
 
 ```bash
 source /opt/ros/<distro>/setup.bash
 node ../../../example/topics/publisher/publisher-example.mjs
-# Publishing message: Hello ROS 0
-# Publishing message: Hello ROS 1
-# …
-```
+# Publishing message: Hello ROS 0, 1, 2, …
 
-Then set the panel's topic box to `/topic` and click **open
-EventSource** — you'll see that node's `Hello ROS N` messages stream in.
-The same works over `curl`:
-
-```bash
 curl -N http://localhost:9001/capability/subscribe/topic
 # event: message
 # data: {"data":"Hello ROS 0"}
 ```
 
-This makes [`publisher-example.mjs`](../../../example/topics/publisher/publisher-example.mjs)
-and the web demo a ready-made publisher/subscriber pair for trying the
-web runtime against your own publishers.
-
 ## Without the bundled `runtime.mjs`
 
-`runtime.mjs` bundles the rclnodejs/web runtime and the demo's sample
-ROS 2 nodes (the `/add_two_ints` service) into one process so the demo
-runs out of the box. In a real project you already have those ROS 2
-nodes running elsewhere, so you only need the runtime. **Replace shell
-1's `node runtime.mjs` with the CLI** — shell 2 (`node static.mjs`) and
-the browser code are unchanged:
+`runtime.mjs` bundles the runtime and the demo's sample nodes into one
+process so it runs out of the box. In a real project those nodes already
+run elsewhere, so you only need the runtime — replace shell 1 with the
+CLI (shell 2 and the browser code are unchanged):
 
 ```bash
-# shell 1 (instead of `node runtime.mjs`); the `-p rclnodejs` tells npx
-# the `rclnodejs-web` binary lives inside the `rclnodejs` package:
+# the `-p rclnodejs` tells npx the binary lives in the rclnodejs package:
 npx -p rclnodejs rclnodejs-web web.json
 
-# the publisher / service the demo expects:
+# plus the service the demo expects (and any std_msgs/String publisher
+# on /web_demo_chatter):
 ros2 run demo_nodes_cpp add_two_ints_server
-# (and a publisher of std_msgs/String on /web_demo_chatter from any source)
 ```
 
-> Note: this demo enables the SSE subscribe endpoint programmatically in
-> `runtime.mjs` via `new HttpTransport({ sse: true, cors: true })`. The
-> `rclnodejs-web` CLI can do the same with `--http-sse` and `--http-cors`
-> (or `"http": { "sse": true, "cors": "*" }` in `web.json`).
+> The bundled `runtime.mjs` enables SSE + CORS via
+> `new HttpTransport({ sse: true, cors: true })`. The CLI does the same
+> with `--http-sse` / `--http-cors` (or `"http": { "sse": true, "cors":
+> "*" }` in `web.json`).

--- a/demo/web/javascript/README.md
+++ b/demo/web/javascript/README.md
@@ -20,8 +20,9 @@ node runtime.mjs
 #               also http://localhost:9001/capability/subscribe/<name>  (SSE)
 ```
 
-`runtime.mjs` exposes a tiny `/add_two_ints` service + 1 Hz
-`/web_demo_tick` publisher so every panel has live data.
+`runtime.mjs` exposes a tiny `/add_two_ints` service and the shared
+`/web_demo_chatter` talker/listener topic (publish from one panel,
+receive in the others).
 
 **Shell 2 — static-file server (hosts `index.html` + maps `/sdk/*` to
 the in-repo [`web/`](../../../web/) folder so the page can `import`
@@ -46,7 +47,7 @@ Open <http://localhost:8080/> in any modern browser. Runtime in shell
   const reply = await ros.call('/add_two_ints', { a: '2n', b: '40n' });
   console.log(reply.sum); // '42n'
 
-  await ros.subscribe('/web_demo_tick', (msg) => render(msg.data));
+  await ros.subscribe('/web_demo_chatter', (msg) => render(msg.data));
   await ros.publish('/web_demo_chatter', { data: 'hi' });
 </script>
 ```
@@ -71,12 +72,12 @@ so `subscribe` is reachable over HTTP as a `text/event-stream` — useful for
 clients that can't hold a WebSocket open:
 
 ```bash
-curl -N http://localhost:9001/capability/subscribe/web_demo_tick
+curl -N http://localhost:9001/capability/subscribe/web_demo_chatter
 # event: ready
-# data: {"capability":"/web_demo_tick","subId":"sse"}
+# data: {"capability":"/web_demo_chatter","subId":"sse"}
 #
 # event: message
-# data: {"data":"tick 0 @ 2026-06-12T…"}
+# data: {"data":"hi from curl"}
 # …one `message` event per published sample, until you ^C
 ```
 
@@ -85,7 +86,7 @@ Browser apps should still prefer the WebSocket transport for `subscribe`
 curl / AI-agent / server-side persona.
 
 The page also has a **native `EventSource` panel** (section 6) that
-subscribes to `/web_demo_tick` over the same SSE endpoint — no SDK, no
+subscribes to `/web_demo_chatter` over the same SSE endpoint — no SDK, no
 WebSocket, just the browser primitive over plain HTTP. Because the page
 (`:8080`) and the HTTP transport (`:9001`) are different origins, the
 demo's `runtime.mjs` enables CORS (`new HttpTransport({ sse: true, cors:
@@ -94,10 +95,10 @@ pass your site's origin instead of `true`.
 
 ### Pair it with the stock publisher example
 
-The EventSource panel's topic box defaults to `/web_demo_tick`, but the
-runtime also exposes `/topic` so you can feed the demo from your own
-node instead of the built-in tick loop. In a third shell, run the
-standard publisher example:
+The EventSource panel's topic box defaults to `/web_demo_chatter` (the
+shared demo topic), but the runtime also exposes `/topic` so you can
+feed the demo from your own node. In a third shell, run the standard
+publisher example:
 
 ```bash
 source /opt/ros/<distro>/setup.bash
@@ -124,12 +125,11 @@ web runtime against your own publishers.
 ## Without the bundled `runtime.mjs`
 
 `runtime.mjs` bundles the rclnodejs/web runtime and the demo's sample
-ROS 2 nodes (the `/add_two_ints` service + the `/web_demo_tick`
-publisher) into one process so the demo runs out of the box. In a
-real project you already have those ROS 2 nodes running elsewhere,
-so you only need the runtime. **Replace shell 1's `node runtime.mjs`
-with the CLI** — shell 2 (`node static.mjs`) and the browser code are
-unchanged:
+ROS 2 nodes (the `/add_two_ints` service) into one process so the demo
+runs out of the box. In a real project you already have those ROS 2
+nodes running elsewhere, so you only need the runtime. **Replace shell
+1's `node runtime.mjs` with the CLI** — shell 2 (`node static.mjs`) and
+the browser code are unchanged:
 
 ```bash
 # shell 1 (instead of `node runtime.mjs`); the `-p rclnodejs` tells npx
@@ -138,7 +138,7 @@ npx -p rclnodejs rclnodejs-web web.json
 
 # the publisher / service the demo expects:
 ros2 run demo_nodes_cpp add_two_ints_server
-# (and a publisher of std_msgs/String on /web_demo_tick from any source)
+# (and a publisher of std_msgs/String on /web_demo_chatter from any source)
 ```
 
 > Note: this demo enables the SSE subscribe endpoint programmatically in

--- a/demo/web/javascript/README.md
+++ b/demo/web/javascript/README.md
@@ -17,6 +17,7 @@ source /opt/ros/<distro>/setup.bash
 node runtime.mjs
 # rclnodejs/web : ws://localhost:9000/capability
 #               also http://localhost:9001/capability  (call/publish, curl-able)
+#               also http://localhost:9001/capability/subscribe/<name>  (SSE)
 ```
 
 `runtime.mjs` exposes a tiny `/add_two_ints` service + 1 Hz
@@ -65,7 +66,60 @@ curl -sS -X POST http://localhost:9001/capability/call/add_two_ints \
 # => {"sum":"42n"}
 ```
 
-Subscribe stays on WebSocket.
+This demo's `runtime.mjs` also enables SSE (`new HttpTransport({ sse: true })`),
+so `subscribe` is reachable over HTTP as a `text/event-stream` — useful for
+clients that can't hold a WebSocket open:
+
+```bash
+curl -N http://localhost:9001/capability/subscribe/web_demo_tick
+# event: ready
+# data: {"capability":"/web_demo_tick","subId":"sse"}
+#
+# event: message
+# data: {"data":"tick 0 @ 2026-06-12T…"}
+# …one `message` event per published sample, until you ^C
+```
+
+Browser apps should still prefer the WebSocket transport for `subscribe`
+(one connection multiplexes every topic). SSE subscribe targets the
+curl / AI-agent / server-side persona.
+
+The page also has a **native `EventSource` panel** (section 6) that
+subscribes to `/web_demo_tick` over the same SSE endpoint — no SDK, no
+WebSocket, just the browser primitive over plain HTTP. Because the page
+(`:8080`) and the HTTP transport (`:9001`) are different origins, the
+demo's `runtime.mjs` enables CORS (`new HttpTransport({ sse: true, cors:
+true })`) so the cross-origin `EventSource` is allowed. In production,
+pass your site's origin instead of `true`.
+
+### Pair it with the stock publisher example
+
+The EventSource panel's topic box defaults to `/web_demo_tick`, but the
+runtime also exposes `/topic` so you can feed the demo from your own
+node instead of the built-in tick loop. In a third shell, run the
+standard publisher example:
+
+```bash
+source /opt/ros/<distro>/setup.bash
+node ../../../example/topics/publisher/publisher-example.mjs
+# Publishing message: Hello ROS 0
+# Publishing message: Hello ROS 1
+# …
+```
+
+Then set the panel's topic box to `/topic` and click **open
+EventSource** — you'll see that node's `Hello ROS N` messages stream in.
+The same works over `curl`:
+
+```bash
+curl -N http://localhost:9001/capability/subscribe/topic
+# event: message
+# data: {"data":"Hello ROS 0"}
+```
+
+This makes [`publisher-example.mjs`](../../../example/topics/publisher/publisher-example.mjs)
+and the web demo a ready-made publisher/subscriber pair for trying the
+web runtime against your own publishers.
 
 ## Without the bundled `runtime.mjs`
 
@@ -86,3 +140,8 @@ npx -p rclnodejs rclnodejs-web web.json
 ros2 run demo_nodes_cpp add_two_ints_server
 # (and a publisher of std_msgs/String on /web_demo_tick from any source)
 ```
+
+> Note: this demo enables the SSE subscribe endpoint programmatically in
+> `runtime.mjs` via `new HttpTransport({ sse: true, cors: true })`. The
+> `rclnodejs-web` CLI can do the same with `--http-sse` and `--http-cors`
+> (or `"http": { "sse": true, "cors": "*" }` in `web.json`).

--- a/demo/web/javascript/index.html
+++ b/demo/web/javascript/index.html
@@ -364,6 +364,58 @@ es.addEventListener(<span class="str">'message'</span>, (e) =&gt; {
 es.close();</pre>
     </div>
 
+    <h2>
+      7. Native <code>fetch()</code> — call &amp; publish over HTTP
+      <span class="badge">no SDK</span>
+    </h2>
+    <p style="font-size: 0.9em; color: #555">
+      The <code>curl</code> commands in section 5 translate one-to-one to the
+      browser's <code>fetch()</code> API — same method, URL, headers and JSON
+      body. Because the runtime sends CORS headers
+      (<code>new HttpTransport({ cors: true })</code>), these cross-origin
+      requests succeed straight from the page (served on <code>:8080</code>,
+      runtime on <code>:9001</code>). <code>call</code> returns
+      <code>200</code> + a JSON reply; <code>publish</code> returns
+      <code>204 No Content</code>. The publish lands on the same
+      <code>/web_demo_chatter</code> topic as panels 2 and 3, so it also shows
+      up in their logs.
+    </p>
+    <div class="panel">
+      <div class="controls">
+        <div class="row">
+          <button id="fetchCallBtn">fetch call <code>/add_two_ints</code></button>
+          <button id="fetchPubBtn">
+            fetch publish <code>/web_demo_chatter</code>
+          </button>
+        </div>
+        <div class="log" id="fetchLog"></div>
+      </div>
+      <pre
+        class="code"
+      ><span class="com">// No import — fetch() is built into every browser.</span>
+<span class="com">// Service call → 200 + JSON reply:</span>
+<span class="kw">const</span> res = <span class="kw">await</span> fetch(
+  <span class="str">'http://localhost:9001/capability/call/add_two_ints'</span>,
+  {
+    method: <span class="str">'POST'</span>,
+    headers: { <span class="str">'content-type'</span>: <span class="str">'application/json'</span> },
+    body: JSON.stringify({ a: <span class="str">'7n'</span>, b: <span class="str">'35n'</span> }),
+  },
+);
+<span class="kw">const</span> reply = <span class="kw">await</span> res.json();
+console.log(reply.sum); <span class="com">// '42n'</span>
+
+<span class="com">// Topic publish → 204 No Content (no body):</span>
+<span class="kw">await</span> fetch(
+  <span class="str">'http://localhost:9001/capability/publish/web_demo_chatter'</span>,
+  {
+    method: <span class="str">'POST'</span>,
+    headers: { <span class="str">'content-type'</span>: <span class="str">'application/json'</span> },
+    body: JSON.stringify({ data: <span class="str">'hello from fetch()'</span> }),
+  },
+);</pre>
+    </div>
+
     <script type="module">
       import { connect } from '/sdk/index.js';
 
@@ -568,6 +620,47 @@ es.close();</pre>
         sseCloseBtn.onclick = () => {
           closeEs();
           log('sseLog', 'closed', 'ok');
+        };
+
+        // Native fetch() — call/publish straight to the HTTP transport,
+        // no SDK and no WebSocket. CORS on the runtime lets these
+        // cross-origin requests (page on :8080 → runtime on :9001)
+        // succeed. Independent of the WS/HTTP transport toggle above.
+        document.getElementById('fetchCallBtn').onclick = async () => {
+          try {
+            const res = await fetch(
+              `${ENDPOINTS.http}/capability/call/add_two_ints`,
+              {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ a: '7n', b: '35n' }),
+              }
+            );
+            const reply = await res.json();
+            log('fetchLog', `7 + 35 = ${reply.sum} (HTTP ${res.status})`, 'ok');
+          } catch (e) {
+            log('fetchLog', `call error: ${e.message}`, 'err');
+          }
+        };
+        document.getElementById('fetchPubBtn').onclick = async () => {
+          try {
+            const res = await fetch(
+              `${ENDPOINTS.http}/capability/publish/web_demo_chatter`,
+              {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ data: 'hello from fetch()' }),
+              }
+            );
+            // publish replies 204 No Content on success.
+            log(
+              'fetchLog',
+              `published 'hello from fetch()' (HTTP ${res.status})`,
+              res.ok ? 'ok' : 'err'
+            );
+          } catch (e) {
+            log('fetchLog', `publish error: ${e.message}`, 'err');
+          }
         };
 
         for (const radio of document.querySelectorAll(

--- a/demo/web/javascript/index.html
+++ b/demo/web/javascript/index.html
@@ -193,7 +193,7 @@
 console.log(reply.sum); <span class="com">// '42n'</span></pre>
     </div>
 
-    <h2>2. Topic subscription — <code>/web_demo_tick</code></h2>
+    <h2>2. Topic subscription — <code>/web_demo_chatter</code></h2>
     <div class="panel">
       <div class="controls">
         <div class="row">
@@ -208,8 +208,9 @@ console.log(reply.sum); <span class="com">// '42n'</span></pre>
 
 <span class="kw">const</span> ros = <span class="kw">await</span> connect(<span class="str">'ws://localhost:9000/capability'</span>);
 
-<span class="com">// The server publishes /web_demo_tick once a second.</span>
-<span class="kw">const</span> sub = <span class="kw">await</span> ros.<span class="kw">subscribe</span>(<span class="str">'/web_demo_tick'</span>, (msg) =&gt; {
+<span class="com">// /web_demo_chatter is the shared demo topic — anything panel 3</span>
+<span class="com">// (or curl) publishes to it lands here, since it's the same topic.</span>
+<span class="kw">const</span> sub = <span class="kw">await</span> ros.<span class="kw">subscribe</span>(<span class="str">'/web_demo_chatter'</span>, (msg) =&gt; {
   console.log(<span class="str">'recv:'</span>, msg.data);
 });
 
@@ -295,12 +296,12 @@ curl -sS -X POST http://localhost:9001/capability/publish/web_demo_chatter \
 
 <span class="com"># subscribe over SSE — streams text/event-stream until you ^C</span>
 <span class="com"># (-N disables curl's buffering so events print as they arrive)</span>
-curl -N http://localhost:9001/capability/subscribe/web_demo_tick
+curl -N http://localhost:9001/capability/subscribe/web_demo_chatter
 <span class="com"># event: ready</span>
-<span class="com"># data: {"capability":"/web_demo_tick","subId":"sse"}</span>
+<span class="com"># data: {"capability":"/web_demo_chatter","subId":"sse"}</span>
 <span class="com">#</span>
 <span class="com"># event: message</span>
-<span class="com"># data: {"data":"tick 0 @ 2026-06-12T…"}</span>
+<span class="com"># data: {"data":"hi from curl"}</span>
 <span class="com"># …one `message` event per published sample…</span>
 
 <span class="com"># allow-list rejection — returns 404 + structured error body</span>
@@ -322,14 +323,11 @@ curl -sS -X POST http://localhost:9001/capability/call/dangerous \
       section 2 is still the better fit.
     </p>
     <p style="font-size: 0.9em; color: #555">
-      The topic box defaults to <code>/web_demo_tick</code> (the demo's
-      built-in tick loop). It is also wired to <code>/topic</code> so you can
-      feed the demo from the stock publisher example instead — run
-      <code
-        >node ../../../example/topics/publisher/publisher-example.mjs</code
-      >
-      in another shell, set the box to <code>/topic</code>, and watch your own
-      node's messages stream in.
+      The topic box defaults to <code>/web_demo_chatter</code> — the same
+      topic panels 2 and 3 use, so a publish from panel 3 streams in here at
+      the same time it reaches the WebSocket subscriber. Point the box at
+      <code>/topic</code> instead to subscribe to an external ROS 2 publisher
+      (see the README's <em>publisher example</em> pairing).
     </p>
     <div class="panel">
       <div class="controls">
@@ -337,7 +335,7 @@ curl -sS -X POST http://localhost:9001/capability/call/dangerous \
           <input
             id="sseTopic"
             type="text"
-            value="/web_demo_tick"
+            value="/web_demo_chatter"
             spellcheck="false"
             aria-label="topic to subscribe to"
           />
@@ -349,9 +347,9 @@ curl -sS -X POST http://localhost:9001/capability/call/dangerous \
       <pre
         class="code"
       ><span class="com">// No import — EventSource is built into every browser.</span>
-<span class="com">// Swap the topic for '/topic' to pair with publisher-example.mjs.</span>
+<span class="com">// '/web_demo_chatter' is the shared demo topic; use '/topic' to pair with publisher-example.mjs.</span>
 <span class="kw">const</span> es = <span class="kw">new</span> EventSource(
-  <span class="str">'http://localhost:9001/capability/subscribe/web_demo_tick'</span>,
+  <span class="str">'http://localhost:9001/capability/subscribe/web_demo_chatter'</span>,
 );
 
 es.addEventListener(<span class="str">'ready'</span>, (e) =&gt;
@@ -472,7 +470,7 @@ es.close();</pre>
         subBtn.onclick = async () => {
           if (!ros) return;
           try {
-            tickSub = await ros.subscribe('/web_demo_tick', (msg) =>
+            tickSub = await ros.subscribe('/web_demo_chatter', (msg) =>
               log('tickLog', msg.data)
             );
             subBtn.disabled = true;
@@ -537,7 +535,7 @@ es.close();</pre>
         sseBtn.onclick = () => {
           closeEs();
           // Accept '/topic' or 'topic'; the URL path carries the bare name.
-          const name = (sseTopic.value || '/web_demo_tick')
+          const name = (sseTopic.value || '/web_demo_chatter')
             .trim()
             .replace(/^\//, '');
           const url = `${ENDPOINTS.http}/capability/subscribe/${encodeURIComponent(

--- a/demo/web/javascript/index.html
+++ b/demo/web/javascript/index.html
@@ -200,7 +200,7 @@ console.log(reply.sum); <span class="com">// '42n'</span></pre>
           <button id="subBtn">subscribe</button>
           <button id="unsubBtn" disabled>unsubscribe</button>
         </div>
-        <div class="log" id="tickLog"></div>
+        <div class="log" id="subLog"></div>
       </div>
       <pre
         class="code"
@@ -405,14 +405,14 @@ es.close();</pre>
       };
 
       let ros;
-      let tickSub;
+      let chatterSub;
 
       async function teardown() {
-        if (tickSub) {
+        if (chatterSub) {
           try {
-            await tickSub.close();
+            await chatterSub.close();
           } catch (_) {}
-          tickSub = null;
+          chatterSub = null;
           document.getElementById('subBtn').disabled = false;
           document.getElementById('unsubBtn').disabled = true;
         }
@@ -470,23 +470,23 @@ es.close();</pre>
         subBtn.onclick = async () => {
           if (!ros) return;
           try {
-            tickSub = await ros.subscribe('/web_demo_chatter', (msg) =>
-              log('tickLog', msg.data)
+            chatterSub = await ros.subscribe('/web_demo_chatter', (msg) =>
+              log('subLog', msg.data)
             );
             subBtn.disabled = true;
             unsubBtn.disabled = false;
-            log('tickLog', `subscribed (subId=${tickSub.subId})`, 'ok');
+            log('subLog', `subscribed (subId=${chatterSub.subId})`, 'ok');
           } catch (e) {
-            log('tickLog', `error: ${e.message} (${e.code})`, 'err');
+            log('subLog', `error: ${e.message} (${e.code})`, 'err');
           }
         };
         unsubBtn.onclick = async () => {
-          if (!tickSub) return;
-          await tickSub.close();
-          tickSub = null;
+          if (!chatterSub) return;
+          await chatterSub.close();
+          chatterSub = null;
           unsubBtn.disabled = true;
           subBtn.disabled = false;
-          log('tickLog', 'unsubscribed', 'ok');
+          log('subLog', 'unsubscribed', 'ok');
         };
 
         document.getElementById('pubBtn').onclick = async () => {

--- a/demo/web/javascript/index.html
+++ b/demo/web/javascript/index.html
@@ -273,8 +273,12 @@ console.log(reply.sum); <span class="com">// '42n'</span></pre>
       The HTTP transport is what makes <code>rclnodejs/web</code>
       <em>actually</em> web-native: every <code>call</code> and
       <code>publish</code> in your allow-list is reachable from any HTTP client
-      — curl, Postman, an AI agent… no JavaScript required. Subscribe stays on
-      WebSocket.
+      — curl, Postman, an AI agent… no JavaScript required. With
+      <code>sse: true</code> on the runtime (set in this demo's
+      <code>runtime.mjs</code>), <code>subscribe</code> is also reachable as a
+      Server-Sent Events stream — handy for clients that can't hold a
+      WebSocket open. Browser apps still prefer the WebSocket transport, which
+      multiplexes many topics on one connection.
     </p>
     <pre
       class="code"
@@ -289,10 +293,78 @@ curl -sS -X POST http://localhost:9001/capability/publish/web_demo_chatter \
   -H <span class="str">'content-type: application/json'</span> \
   -d <span class="str">'{"data":"hi from curl"}'</span>
 
+<span class="com"># subscribe over SSE — streams text/event-stream until you ^C</span>
+<span class="com"># (-N disables curl's buffering so events print as they arrive)</span>
+curl -N http://localhost:9001/capability/subscribe/web_demo_tick
+<span class="com"># event: ready</span>
+<span class="com"># data: {"capability":"/web_demo_tick","subId":"sse"}</span>
+<span class="com">#</span>
+<span class="com"># event: message</span>
+<span class="com"># data: {"data":"tick 0 @ 2026-06-12T…"}</span>
+<span class="com"># …one `message` event per published sample…</span>
+
 <span class="com"># allow-list rejection — returns 404 + structured error body</span>
 curl -sS -X POST http://localhost:9001/capability/call/dangerous \
   -H <span class="str">'content-type: application/json'</span> -d <span class="str">'{}'</span>
 <span class="com"># =&gt; {"ok":false,"error":"capability not exposed: call /dangerous","code":"not_exposed"}</span></pre>
+
+    <h2>
+      6. Native <code>EventSource</code> — SSE subscribe over HTTP
+      <span class="badge">no SDK</span>
+    </h2>
+    <p style="font-size: 0.9em; color: #555">
+      The same SSE stream the <code>curl</code> example above reads is a
+      first-class browser API: <code>EventSource</code>. No SDK, no WebSocket —
+      just a plain HTTP GET the browser keeps open and auto-reconnects. This
+      works cross-origin because the runtime sends CORS headers
+      (<code>new HttpTransport({ sse: true, cors: true })</code>). For
+      multiplexing many topics on one connection, the WebSocket transport in
+      section 2 is still the better fit.
+    </p>
+    <p style="font-size: 0.9em; color: #555">
+      The topic box defaults to <code>/web_demo_tick</code> (the demo's
+      built-in tick loop). It is also wired to <code>/topic</code> so you can
+      feed the demo from the stock publisher example instead — run
+      <code
+        >node ../../../example/topics/publisher/publisher-example.mjs</code
+      >
+      in another shell, set the box to <code>/topic</code>, and watch your own
+      node's messages stream in.
+    </p>
+    <div class="panel">
+      <div class="controls">
+        <div class="row">
+          <input
+            id="sseTopic"
+            type="text"
+            value="/web_demo_tick"
+            spellcheck="false"
+            aria-label="topic to subscribe to"
+          />
+          <button id="sseBtn">open EventSource</button>
+          <button id="sseCloseBtn" disabled>close</button>
+        </div>
+        <div class="log" id="sseLog"></div>
+      </div>
+      <pre
+        class="code"
+      ><span class="com">// No import — EventSource is built into every browser.</span>
+<span class="com">// Swap the topic for '/topic' to pair with publisher-example.mjs.</span>
+<span class="kw">const</span> es = <span class="kw">new</span> EventSource(
+  <span class="str">'http://localhost:9001/capability/subscribe/web_demo_tick'</span>,
+);
+
+es.addEventListener(<span class="str">'ready'</span>, (e) =&gt;
+  console.log(<span class="str">'subscribed:'</span>, JSON.parse(e.data)),
+);
+es.addEventListener(<span class="str">'message'</span>, (e) =&gt; {
+  <span class="kw">const</span> msg = JSON.parse(e.data);
+  console.log(<span class="str">'recv:'</span>, msg.data);
+});
+
+<span class="com">// later — stop receiving:</span>
+es.close();</pre>
+    </div>
 
     <script type="module">
       import { connect } from '/sdk/index.js';
@@ -442,6 +514,62 @@ curl -sS -X POST http://localhost:9001/capability/call/dangerous \
           } catch (e) {
             log('badLog', `rejected: ${e.message} (${e.code})`, 'ok');
           }
+        };
+
+        // Native EventSource — independent of the WS/HTTP transport
+        // toggle above. It always talks to the HTTP transport's SSE
+        // endpoint directly, which is exactly the point: no SDK, no
+        // WebSocket, just a browser primitive over plain HTTP (CORS is
+        // enabled on the runtime so this works cross-origin).
+        const sseBtn = document.getElementById('sseBtn');
+        const sseCloseBtn = document.getElementById('sseCloseBtn');
+        const sseTopic = document.getElementById('sseTopic');
+        let es;
+        const closeEs = () => {
+          if (es) {
+            es.close();
+            es = null;
+          }
+          sseBtn.disabled = false;
+          sseCloseBtn.disabled = true;
+          sseTopic.disabled = false;
+        };
+        sseBtn.onclick = () => {
+          closeEs();
+          // Accept '/topic' or 'topic'; the URL path carries the bare name.
+          const name = (sseTopic.value || '/web_demo_tick')
+            .trim()
+            .replace(/^\//, '');
+          const url = `${ENDPOINTS.http}/capability/subscribe/${encodeURIComponent(
+            name
+          )}`;
+          es = new EventSource(url);
+          sseBtn.disabled = true;
+          sseCloseBtn.disabled = false;
+          sseTopic.disabled = true;
+          log('sseLog', `EventSource → ${url}`, 'ok');
+          es.addEventListener('ready', (e) => {
+            const info = JSON.parse(e.data);
+            log('sseLog', `ready (subId=${info.subId})`, 'ok');
+          });
+          es.addEventListener('message', (e) => {
+            log('sseLog', JSON.parse(e.data).data);
+          });
+          es.addEventListener('error', (e) => {
+            // SSE `error` events carry no payload for transport drops;
+            // our runtime only sends a data-bearing `error` event for a
+            // terminal failure (e.g. capability removed).
+            if (e.data) {
+              const err = JSON.parse(e.data);
+              log('sseLog', `error: ${err.error} (${err.code})`, 'err');
+            } else if (es && es.readyState === EventSource.CONNECTING) {
+              log('sseLog', 'connection lost — auto-reconnecting…', 'err');
+            }
+          });
+        };
+        sseCloseBtn.onclick = () => {
+          closeEs();
+          log('sseLog', 'closed', 'ok');
         };
 
         for (const radio of document.querySelectorAll(

--- a/demo/web/javascript/runtime.mjs
+++ b/demo/web/javascript/runtime.mjs
@@ -101,6 +101,14 @@ const runtime = createRuntime({
     new HttpTransport({
       port: HTTP_PORT,
       host: '::',
+      // Opt-in Server-Sent Events for `subscribe` over plain HTTP:
+      //   GET /capability/subscribe/<name>   (text/event-stream)
+      // Intended for clients that can't hold a WebSocket open (curl,
+      // AI agents, serverless / edge functions). Browser apps should
+      // still prefer the WebSocket transport, which multiplexes many
+      // topics on one connection. Off by default in HttpTransport.
+      sse: true,
+      cors: true,
     }),
   ],
 });
@@ -110,6 +118,11 @@ runtime.expose({
   subscribe: {
     '/web_demo_tick': 'std_msgs/msg/String',
     '/web_demo_chatter': 'std_msgs/msg/String',
+    // Pairs with the stock publisher example so developers can feed the
+    // demo from their own node instead of the built-in tick loop:
+    //   node ../../../example/topics/publisher/publisher-example.mjs
+    // then subscribe to `/topic` from the browser / curl / EventSource.
+    '/topic': 'std_msgs/msg/String',
   },
 });
 await runtime.start();
@@ -126,6 +139,9 @@ console.log(
 );
 console.log(
   `  HTTP      : http://${displayHost('::')}:${HTTP_PORT}/capability  (call / publish, curl-able)`
+);
+console.log(
+  `  HTTP SSE  : http://${displayHost('::')}:${HTTP_PORT}/capability/subscribe/<name>  (subscribe via text/event-stream)`
 );
 console.log();
 console.log(`Exposed capabilities (${total}):`);

--- a/demo/web/javascript/runtime.mjs
+++ b/demo/web/javascript/runtime.mjs
@@ -38,7 +38,7 @@ function displayHost(host) {
 // Render the registry as a small human-readable table:
 //   call       /add_two_ints       example_interfaces/srv/AddTwoInts
 //   publish    /web_demo_chatter   std_msgs/msg/String
-//   subscribe  /web_demo_tick      std_msgs/msg/String
+//   subscribe  /web_demo_chatter   std_msgs/msg/String
 function formatCapabilities(caps) {
   const rows = [];
   for (const verb of ['call', 'publish', 'subscribe']) {
@@ -68,17 +68,6 @@ node.createService(
     response.send(reply);
   }
 );
-
-// A real ROS 2 publisher producing a tick once a second so the
-// browser's subscribe() has something to receive without the user
-// having to publish first.
-const tickPub = node.createPublisher('std_msgs/msg/String', '/web_demo_tick');
-let counter = 0;
-setInterval(() => {
-  tickPub.publish({
-    data: `tick ${counter++} @ ${new Date().toISOString()}`,
-  });
-}, 1000);
 
 rclnodejs.spin(node);
 
@@ -116,10 +105,12 @@ runtime.expose({
   call: { '/add_two_ints': 'example_interfaces/srv/AddTwoInts' },
   publish: { '/web_demo_chatter': 'std_msgs/msg/String' },
   subscribe: {
-    '/web_demo_tick': 'std_msgs/msg/String',
+    // Shared talker/listener topic: panels 2 (WebSocket), 3 (round-trip),
+    // and 6 (SSE) all use it — so a browser publish is visible across
+    // every subscriber at once.
     '/web_demo_chatter': 'std_msgs/msg/String',
     // Pairs with the stock publisher example so developers can feed the
-    // demo from their own node instead of the built-in tick loop:
+    // demo from their own node:
     //   node ../../../example/topics/publisher/publisher-example.mjs
     // then subscribe to `/topic` from the browser / curl / EventSource.
     '/topic': 'std_msgs/msg/String',

--- a/demo/web/javascript/web.json
+++ b/demo/web/javascript/web.json
@@ -15,8 +15,8 @@
       "/web_demo_chatter": "std_msgs/msg/String"
     },
     "subscribe": {
-      "/web_demo_tick": "std_msgs/msg/String",
-      "/web_demo_chatter": "std_msgs/msg/String"
+      "/web_demo_chatter": "std_msgs/msg/String",
+      "/topic": "std_msgs/msg/String"
     }
   }
 }

--- a/demo/web/javascript/web.json
+++ b/demo/web/javascript/web.json
@@ -4,8 +4,10 @@
   "path": "/capability",
   "node": "rclnodejs_web_demo",
   "http": {
-    "$comment": "HTTP transport for `call` and `publish`. curl-able, AI-agent friendly. Subscribe still uses WebSocket.",
-    "port": 9001
+    "$comment": "HTTP transport for `call` and `publish` (curl-able, AI-agent friendly). `sse` also exposes `subscribe` over Server-Sent Events; `cors: \"*\"` allows any origin so a cross-origin browser EventSource can connect. Matches the bundled runtime.mjs.",
+    "port": 9001,
+    "sse": true,
+    "cors": "*"
   },
   "expose": {
     "call": {

--- a/demo/web/typescript/README.md
+++ b/demo/web/typescript/README.md
@@ -29,6 +29,12 @@ npm run server
 `server.ts` runs the runtime *and* a tiny `/add_two_ints` service +
 1 Hz `/web_demo_tick` publisher so every panel has live data.
 
+> The HTTP transport here serves `call` / `publish` only; `subscribe`
+> uses WebSocket. HTTP `subscribe` over Server-Sent Events is an opt-in
+> (`new HttpTransport({ sse: true })`, or `--http-sse` on the CLI) — see
+> the [JavaScript demo](../javascript/README.md) for a working SSE +
+> `EventSource` example.
+
 **Shell 2 — Vite dev server:**
 
 ```bash

--- a/demo/web/typescript/README.md
+++ b/demo/web/typescript/README.md
@@ -26,8 +26,8 @@ npm run server
 #               also http://localhost:9001/capability
 ```
 
-`server.ts` runs the runtime *and* a tiny `/add_two_ints` service +
-1 Hz `/web_demo_tick` publisher so every panel has live data.
+`server.ts` runs the runtime *plus* a tiny `/add_two_ints` service and a
+1 Hz `/web_demo_tick` publisher, so every panel has live data.
 
 > The HTTP transport here serves `call` / `publish` only; `subscribe`
 > uses WebSocket. HTTP `subscribe` over Server-Sent Events is an opt-in
@@ -44,26 +44,20 @@ npm run dev
 
 ## Without the bundled `server.ts`
 
-`npm run server` is a convenience for this demo — it bundles the
-runtime **and** a tiny `/add_two_ints` service + `/web_demo_tick`
-publisher into one process so the demo works out of the box.
-
-In a real project you already have those ROS 2 nodes running
-elsewhere, so you only need the runtime. **Replace shell 1's
-`npm run server` with the CLI** — shell 2 (`npm run dev`) and
-`src/main.ts` are unchanged:
+`npm run server` bundles the runtime and the demo's sample nodes into one
+process so it runs out of the box. In a real project those nodes already
+run elsewhere, so you only need the runtime — replace shell 1 with the
+CLI (shell 2 and `src/main.ts` are unchanged):
 
 ```bash
-# shell 1 (instead of `npm run server`)
 npx rclnodejs-web web.json
 
-# the publisher / service the demo expects:
+# plus the nodes the demo expects:
 ros2 run demo_nodes_cpp add_two_ints_server
-# (and a publisher of std_msgs/String on /web_demo_tick from any source)
+# (and any std_msgs/String publisher on /web_demo_tick)
 ```
 
-The browser doesn't know or care which option is running — it only
-sees `ws://localhost:9000/capability` either way.
+The browser only sees `ws://localhost:9000/capability` either way.
 
 ## Other npm scripts
 

--- a/lib/runtime/cli-config.js
+++ b/lib/runtime/cli-config.js
@@ -26,8 +26,17 @@ const DEFAULTS = Object.freeze({
   // Optional HTTP transport for `call`/`publish`. Disabled by default;
   // set `port` (or pass `--http-port` on the CLI) to turn it on.
   // `host` defaults to the same dual-stack address as the WS listener.
-  // `basePath` defaults to `/capability`.
-  http: { port: null, host: null, basePath: null },
+  // `basePath` defaults to `/capability`. `sse` opts `subscribe` into a
+  // Server-Sent Events stream; `cors` controls cross-origin access
+  // (`false` = none, `true` = any origin, string/array = allow-list).
+  http: {
+    port: null,
+    host: null,
+    basePath: null,
+    sse: false,
+    sseKeepAliveMs: null,
+    cors: false,
+  },
   expose: { call: {}, publish: {}, subscribe: {} },
 });
 
@@ -81,6 +90,22 @@ function parseArgv(argv) {
       partial.http.host = eat(a);
     } else if (a === '--http-base-path') {
       partial.http.basePath = eat(a);
+    } else if (a === '--http-sse') {
+      partial.http.sse = true;
+      i++;
+    } else if (a === '--http-sse-keep-alive') {
+      partial.http.sseKeepAliveMs = Number(eat(a));
+    } else if (a === '--http-cors') {
+      // Repeatable. `*` (or `true`) means any origin; otherwise each
+      // value is added to an allow-list. Once any origin is `*`, the
+      // policy stays "any".
+      const v = eat(a);
+      if (v === '*' || v === 'true') {
+        partial.http.cors = true;
+      } else if (partial.http.cors !== true) {
+        if (!Array.isArray(partial.http.cors)) partial.http.cors = [];
+        partial.http.cors.push(v);
+      }
     } else if (a === '--call' || a === '--publish' || a === '--subscribe') {
       const kind = a.slice(2);
       const pair = eat(a);
@@ -181,6 +206,28 @@ function validateConfig(cfg, origin = 'config') {
     ) {
       throw new CliError(`${origin}: "http.basePath" must be a string`);
     }
+    if (cfg.http.sse !== undefined && typeof cfg.http.sse !== 'boolean') {
+      throw new CliError(`${origin}: "http.sse" must be a boolean`);
+    }
+    if (
+      cfg.http.sseKeepAliveMs !== undefined &&
+      cfg.http.sseKeepAliveMs !== null &&
+      !Number.isFinite(cfg.http.sseKeepAliveMs)
+    ) {
+      throw new CliError(`${origin}: "http.sseKeepAliveMs" must be a number`);
+    }
+    if (cfg.http.cors !== undefined && cfg.http.cors !== null) {
+      const c = cfg.http.cors;
+      const ok =
+        typeof c === 'boolean' ||
+        typeof c === 'string' ||
+        (Array.isArray(c) && c.every((v) => typeof v === 'string'));
+      if (!ok) {
+        throw new CliError(
+          `${origin}: "http.cors" must be a boolean, string, or string[]`
+        );
+      }
+    }
   }
   if (cfg.expose !== undefined) {
     if (
@@ -241,7 +288,14 @@ function mergeConfig(...sources) {
       if (src[k] !== undefined) out[k] = src[k];
     }
     if (src.http) {
-      for (const k of ['port', 'host', 'basePath']) {
+      for (const k of [
+        'port',
+        'host',
+        'basePath',
+        'sse',
+        'sseKeepAliveMs',
+        'cors',
+      ]) {
         if (src.http[k] !== undefined && src.http[k] !== null) {
           out.http[k] = src.http[k];
         }
@@ -279,10 +333,14 @@ WebSocket transport (always on):
       --host <addr>           WS bind host             (default ::, dual-stack)
       --path <url>            WS URL path              (default /capability)
 
-HTTP transport (opt-in; for call/publish only):
+HTTP transport (opt-in; for call/publish, and subscribe via SSE):
       --http-port <n>         HTTP listen port         (disabled if omitted)
       --http-host <addr>      HTTP bind host           (default same as --host)
       --http-base-path <p>    HTTP base path           (default /capability)
+      --http-sse              enable GET subscribe over Server-Sent Events
+      --http-sse-keep-alive <ms>  SSE heartbeat interval   (default 15000, 0 off)
+      --http-cors <origin>    allow cross-origin requests; '*' = any origin,
+                              or repeat the flag to build an allow-list
 
 Capabilities:
       --call <name>=<type>    expose a service capability   (repeatable)
@@ -304,13 +362,17 @@ Examples:
   rclnodejs-web --port 9000 --http-port 9001 \\
     --call /add_two_ints=example_interfaces/srv/AddTwoInts
 
+  # Add SSE subscribe + CORS so a browser EventSource can connect:
+  rclnodejs-web --port 9000 --http-port 9001 --http-sse --http-cors '*' \\
+    --subscribe /scan=sensor_msgs/msg/LaserScan
+
   # Or all from a JSON config:
   rclnodejs-web web.json
 
 Config-file shape (every field optional):
   {
     "port": 9000, "host": "::", "path": "/capability",
-    "http": { "port": 9001 },
+    "http": { "port": 9001, "sse": true, "cors": "*" },
     "expose": {
       "call":      { "/add_two_ints": "example_interfaces/srv/AddTwoInts" },
       "publish":   { "/cmd_vel":      "geometry_msgs/msg/Twist" },

--- a/lib/runtime/index.d.ts
+++ b/lib/runtime/index.d.ts
@@ -108,6 +108,9 @@ export interface HttpTransportOptions {
   port?: number;
   host?: string;
   basePath?: string;
+  sse?: boolean;
+  sseKeepAliveMs?: number;
+  cors?: boolean | string | string[];
   verifyRequest?: (req: import('http').IncomingMessage) => boolean;
 }
 

--- a/lib/runtime/transports/http.js
+++ b/lib/runtime/transports/http.js
@@ -606,6 +606,12 @@ class HttpTransport extends TransportAdapter {
    * `cors` is disabled. For an allow-list, the request `Origin` is echoed
    * only when it matches (and `Vary: Origin` is set so caches don't mix
    * responses across origins).
+   *
+   * `Access-Control-Allow-Headers` reflects the browser's
+   * `Access-Control-Request-Headers` when present, so authenticated or
+   * custom-header requests (`Authorization`, `X-*`, …) pass preflight
+   * rather than being limited to `content-type`. The reflected value is
+   * added to `Vary` to keep caches correct.
    */
   _applyCors(req, res) {
     if (!this.cors) return;
@@ -620,7 +626,15 @@ class HttpTransport extends TransportAdapter {
       }
     }
     res.setHeader('access-control-allow-methods', 'GET, POST, OPTIONS');
-    res.setHeader('access-control-allow-headers', 'content-type');
+    // Echo whatever headers the browser says it will send; fall back to
+    // `content-type` for non-preflight requests that carry no such hint.
+    const requested = req.headers['access-control-request-headers'];
+    if (requested) {
+      res.appendHeader('vary', 'Access-Control-Request-Headers');
+      res.setHeader('access-control-allow-headers', requested);
+    } else {
+      res.setHeader('access-control-allow-headers', 'content-type');
+    }
     res.setHeader('access-control-max-age', '86400');
   }
 }

--- a/lib/runtime/transports/http.js
+++ b/lib/runtime/transports/http.js
@@ -466,8 +466,28 @@ class HttpTransport extends TransportAdapter {
     // errors alike. setHeader persists through later writeHead() calls.
     this._applyCors(req, res);
 
+    let pathname;
+    try {
+      pathname = new URL(req.url || '/', 'http://localhost').pathname;
+    } catch {
+      return _writeJson(res, 400, {
+        ok: false,
+        error: 'invalid request URL',
+        code: 'invalid_url',
+      });
+    }
+
+    if (!pathname.startsWith(this.basePath + '/')) {
+      return _writeJson(res, 404, {
+        ok: false,
+        error: `not a capability route: ${pathname}`,
+        code: 'not_found',
+      });
+    }
+
     // Preflight: browsers send OPTIONS before a cross-origin POST with a
-    // JSON content-type. Answer it directly (no auth, no body).
+    // JSON content-type. Answer it directly (no auth, no body) — but only
+    // for capability routes, so unrelated paths still 404 above.
     if (req.method === 'OPTIONS' && this.cors) {
       res.writeHead(204).end();
       return;
@@ -492,25 +512,6 @@ class HttpTransport extends TransportAdapter {
           code: 'unauthorized',
         });
       }
-    }
-
-    let pathname;
-    try {
-      pathname = new URL(req.url || '/', 'http://localhost').pathname;
-    } catch {
-      return _writeJson(res, 400, {
-        ok: false,
-        error: 'invalid request URL',
-        code: 'invalid_url',
-      });
-    }
-
-    if (!pathname.startsWith(this.basePath + '/')) {
-      return _writeJson(res, 404, {
-        ok: false,
-        error: `not a capability route: ${pathname}`,
-        code: 'not_found',
-      });
     }
 
     const tail = pathname.slice(this.basePath.length + 1); // strip basePath + '/'
@@ -716,18 +717,23 @@ function _normaliseBasePath(value) {
 
 /**
  * Normalise the `cors` option into either `false`, `true` (any origin),
- * or a `Set<string>` of allowed origins.
+ * or a `Set<string>` of allowed origins. A `"*"` value (or an array that
+ * contains `"*"`) means "any origin" and is treated as `true`, matching
+ * the CLI's `--http-cors *` shorthand.
  */
 function _normaliseCors(value) {
   if (value === undefined || value === null || value === false) return false;
   if (value === true) return true;
-  if (typeof value === 'string') return new Set([value]);
+  if (typeof value === 'string') {
+    return value === '*' ? true : new Set([value]);
+  }
   if (Array.isArray(value)) {
     if (!value.every((v) => typeof v === 'string')) {
       throw new TypeError(
         'HttpTransport: cors array must contain only origin strings'
       );
     }
+    if (value.includes('*')) return true;
     return new Set(value);
   }
   throw new TypeError(

--- a/lib/runtime/transports/http.js
+++ b/lib/runtime/transports/http.js
@@ -174,6 +174,184 @@ class HttpRequestConnection extends Connection {
 }
 
 /**
+ * A long-lived {@link Connection} that streams a single subscription over
+ * Server-Sent Events (`text/event-stream`).
+ *
+ * Unlike {@link HttpRequestConnection} (one request → one reply), this
+ * connection stays open: it drives the dispatcher with exactly one
+ * `subscribe` frame and then relays every `{event:'message'}` delivery to
+ * the client as an SSE `message` event until the client disconnects.
+ *
+ * The dispatcher is unchanged — it sees the same `subscribe` frame and the
+ * same `{event:'message', subId, payload}` deliveries it would send over
+ * WebSocket. This class only reframes them as SSE lines.
+ *
+ * HTTP status semantics are preserved for the *establishment* of the
+ * stream: the `200 text/event-stream` headers are not written until the
+ * dispatcher acknowledges the subscribe (`{ok:true}`). If the subscribe is
+ * rejected (e.g. `not_exposed`), the headers have not been sent yet, so the
+ * failure surfaces as a normal JSON error response with the mapped status
+ * code — exactly like `call`/`publish`.
+ */
+class HttpSseConnection extends Connection {
+  /**
+   * @param {import('http').IncomingMessage} req
+   * @param {import('http').ServerResponse} res
+   * @param {string} capability  ROS name to subscribe to.
+   * @param {object} [options]
+   * @param {number} [options.keepAliveMs=15000]  Heartbeat comment interval.
+   */
+  constructor(req, res, capability, options = {}) {
+    super();
+    this.req = req;
+    this.res = res;
+    this._capability = capability;
+    this._keepAliveMs =
+      options.keepAliveMs != null ? options.keepAliveMs : 15000;
+    this._streaming = false;
+    this._closed = false;
+    this._keepAlive = null;
+    // Fixed subId: an SSE connection carries exactly one subscription.
+    this._subId = 'sse';
+
+    const onClose = () => this._emitCloseOnce();
+    req.on('close', onClose);
+    res.on('close', onClose);
+    res.on('error', (e) => {
+      debug('sse response error: %s', e.message);
+      this._emitCloseOnce();
+    });
+  }
+
+  /**
+   * Kick off dispatch: emit a single `subscribe` frame. The dispatcher
+   * replies synchronously with `{ok:true}` (→ start the stream) or an
+   * error (→ JSON failure response).
+   */
+  begin() {
+    this.emit('message', {
+      id: this._subId,
+      kind: 'subscribe',
+      capability: this._capability,
+    });
+  }
+
+  send(frame) {
+    if (this._closed) return;
+
+    // Subscription delivery — the steady-state case.
+    if (frame.event === 'message') {
+      this._ensureStream();
+      this._writeEvent('message', frame.payload);
+      return;
+    }
+
+    // Subscribe acknowledgement: switch the response into an event stream.
+    if (frame.ok === true) {
+      this._ensureStream();
+      this._writeEvent('ready', {
+        capability: this._capability,
+        subId: this._subId,
+      });
+      return;
+    }
+
+    // Failure path.
+    const code = frame.code || 'internal_error';
+    if (!this._streaming) {
+      // Headers not sent yet — surface as a normal HTTP error.
+      const status = _STATUS_BY_CODE[code] || 500;
+      this._writeError(status, code, frame.error || 'subscribe failed');
+    } else {
+      // Already streaming — emit a terminal SSE error event, then close.
+      this._writeEvent('error', { error: frame.error, code });
+    }
+    this._emitCloseOnce();
+  }
+
+  /** Close the stream; the dispatcher's `cleanup` follows via `'close'`. */
+  // eslint-disable-next-line no-unused-vars
+  close(code, reason) {
+    this._emitCloseOnce();
+  }
+
+  _ensureStream() {
+    if (this._streaming) return;
+    this._streaming = true;
+    this.res.writeHead(200, {
+      'content-type': 'text/event-stream; charset=utf-8',
+      'cache-control': 'no-cache, no-transform',
+      connection: 'keep-alive',
+      // Disable proxy buffering (nginx) so events flush immediately.
+      'x-accel-buffering': 'no',
+    });
+    if (typeof this.res.flushHeaders === 'function') {
+      this.res.flushHeaders();
+    }
+    if (this._keepAliveMs > 0) {
+      this._keepAlive = setInterval(() => {
+        if (this._closed) return;
+        try {
+          this.res.write(': keep-alive\n\n');
+        } catch (e) {
+          debug('sse keep-alive write failed: %s', e.message);
+          this._emitCloseOnce();
+        }
+      }, this._keepAliveMs);
+      // Don't let the heartbeat keep the event loop alive on its own.
+      if (typeof this._keepAlive.unref === 'function') {
+        this._keepAlive.unref();
+      }
+    }
+  }
+
+  _writeEvent(event, data) {
+    if (this._closed) return;
+    const json = JSON.stringify(data ?? null);
+    // Each newline in the payload must become its own `data:` line.
+    let chunk = `event: ${event}\n`;
+    for (const line of json.split('\n')) {
+      chunk += `data: ${line}\n`;
+    }
+    chunk += '\n';
+    try {
+      this.res.write(chunk);
+    } catch (e) {
+      debug('sse write failed: %s', e.message);
+      this._emitCloseOnce();
+    }
+  }
+
+  _writeError(status, code, message) {
+    const body = JSON.stringify({ ok: false, error: message, code });
+    try {
+      this.res.writeHead(status, {
+        'content-type': 'application/json; charset=utf-8',
+        'content-length': Buffer.byteLength(body),
+      });
+      this.res.end(body);
+    } catch (e) {
+      debug('sse writeError failed: %s', e.message);
+    }
+  }
+
+  _emitCloseOnce() {
+    if (this._closed) return;
+    this._closed = true;
+    if (this._keepAlive) {
+      clearInterval(this._keepAlive);
+      this._keepAlive = null;
+    }
+    try {
+      this.res.end();
+    } catch {
+      /* response may already be finished */
+    }
+    this.emit('close');
+  }
+}
+
+/**
  * HTTP adapter for the Web Runtime.
  *
  * Exposes `call` and `publish` capabilities over plain HTTP:
@@ -181,18 +359,24 @@ class HttpRequestConnection extends Connection {
  *     POST /capability/call/<name>
  *     POST /capability/publish/<name>
  *
- * Subscriptions stay on the WebSocket transport (one HTTP connection
- * per inbound message would burn the browser's per-origin budget).
- * Anything that isn't `POST /capability/call/<name>` or
- * `POST /capability/publish/<name>` returns a 404 / 405 — the adapter
- * does not serve unrelated routes.
+ * When `sse: true`, it additionally exposes `subscribe` as a Server-Sent
+ * Events stream:
+ *
+ *     GET /capability/subscribe/<name>     (text/event-stream)
+ *
+ * SSE subscribe is opt-in and intended for clients that cannot hold a
+ * WebSocket open (curl, AI agents, serverless/edge functions). Browser
+ * apps should keep using the WebSocket transport for `subscribe`, which
+ * multiplexes many topics on one connection. Anything that isn't a
+ * recognised route returns a 404 / 405 — the adapter does not serve
+ * unrelated paths.
  *
  * @example
  *   const runtime = createRuntime({
  *     node,
  *     transports: [
  *       new WebSocketTransport({ port: 9000 }),
- *       new HttpTransport({ port: 9001 }),
+ *       new HttpTransport({ port: 9001, sse: true }),
  *     ],
  *   });
  */
@@ -202,6 +386,20 @@ class HttpTransport extends TransportAdapter {
    * @param {number} [options.port=9001]
    * @param {string} [options.host='::']
    * @param {string} [options.basePath='/capability']
+   * @param {boolean} [options.sse=false]
+   *   Enable `GET /capability/subscribe/<name>` Server-Sent Events
+   *   streaming. Off by default; `subscribe` returns `unsupported_kind`
+   *   unless this is set.
+   * @param {number} [options.sseKeepAliveMs=15000]
+   *   Heartbeat comment interval for SSE streams, in milliseconds. Set to
+   *   `0` to disable heartbeats.
+   * @param {boolean|string|string[]} [options.cors=false]
+   *   Cross-Origin Resource Sharing policy. `false` (default) sends no
+   *   CORS headers. `true` allows any origin (`Access-Control-Allow-Origin:
+   *   *`). A string or array of strings allows only those origins (the
+   *   request's `Origin` is echoed back when it matches). Required for a
+   *   browser on a different origin to `fetch()` / `EventSource()` this
+   *   transport.
    * @param {(req: import('http').IncomingMessage) => boolean} [options.verifyRequest]
    *   Optional auth hook called with the raw request. Return `false` to
    *   reject the request with 401. Mirrors `WebSocketTransport.verifyClient`.
@@ -211,6 +409,10 @@ class HttpTransport extends TransportAdapter {
     this.port = options.port != null ? options.port : 9001;
     this.host = options.host != null ? options.host : '::';
     this.basePath = _normaliseBasePath(options.basePath);
+    this.sse = options.sse === true;
+    this.sseKeepAliveMs =
+      options.sseKeepAliveMs != null ? options.sseKeepAliveMs : 15000;
+    this.cors = _normaliseCors(options.cors);
     this.verifyRequest = options.verifyRequest;
     this._server = null;
     this._onConnection = null;
@@ -259,6 +461,18 @@ class HttpTransport extends TransportAdapter {
   // ---------- internals ----------
 
   _route(req, res) {
+    // Apply CORS headers (if configured) before anything else, so they
+    // appear on every response — JSON replies, 204s, SSE streams, and
+    // errors alike. setHeader persists through later writeHead() calls.
+    this._applyCors(req, res);
+
+    // Preflight: browsers send OPTIONS before a cross-origin POST with a
+    // JSON content-type. Answer it directly (no auth, no body).
+    if (req.method === 'OPTIONS' && this.cors) {
+      res.writeHead(204).end();
+      return;
+    }
+
     if (this.verifyRequest) {
       let allowed;
       try {
@@ -322,10 +536,40 @@ class HttpTransport extends TransportAdapter {
       });
     }
 
+    if (kind === 'subscribe') {
+      if (!this.sse) {
+        return _writeJson(res, 404, {
+          ok: false,
+          error:
+            'subscribe over HTTP is disabled (enable `sse` or use WebSocket)',
+          code: 'unsupported_kind',
+        });
+      }
+      if (req.method !== 'GET') {
+        res.setHeader('allow', 'GET');
+        return _writeJson(res, 405, {
+          ok: false,
+          error: `method not allowed: ${req.method} (use GET for SSE subscribe)`,
+          code: 'method_not_allowed',
+        });
+      }
+      const conn = new HttpSseConnection(req, res, name, {
+        keepAliveMs: this.sseKeepAliveMs,
+      });
+      try {
+        this._onConnection(conn);
+        conn.begin();
+      } catch (e) {
+        debug('onConnection threw: %s', e.stack || e.message);
+        conn.close();
+      }
+      return;
+    }
+
     if (kind !== 'call' && kind !== 'publish') {
       return _writeJson(res, 404, {
         ok: false,
-        error: `unsupported kind over HTTP: ${kind} (use WebSocket for subscribe/action)`,
+        error: `unsupported kind over HTTP: ${kind} (use WebSocket for action)`,
         code: 'unsupported_kind',
       });
     }
@@ -354,6 +598,29 @@ class HttpTransport extends TransportAdapter {
         conn.close();
       }
     });
+  }
+
+  /**
+   * Set CORS response headers per the configured policy. No-op when
+   * `cors` is disabled. For an allow-list, the request `Origin` is echoed
+   * only when it matches (and `Vary: Origin` is set so caches don't mix
+   * responses across origins).
+   */
+  _applyCors(req, res) {
+    if (!this.cors) return;
+    const allow = this.cors; // true → any; otherwise a Set of origins
+    if (allow === true) {
+      res.setHeader('access-control-allow-origin', '*');
+    } else {
+      const origin = req.headers.origin;
+      res.setHeader('vary', 'Origin');
+      if (origin && allow.has(origin)) {
+        res.setHeader('access-control-allow-origin', origin);
+      }
+    }
+    res.setHeader('access-control-allow-methods', 'GET, POST, OPTIONS');
+    res.setHeader('access-control-allow-headers', 'content-type');
+    res.setHeader('access-control-max-age', '86400');
   }
 }
 
@@ -445,6 +712,27 @@ function _normaliseBasePath(value) {
     throw new TypeError('HttpTransport: basePath must not be empty');
   }
   return p;
+}
+
+/**
+ * Normalise the `cors` option into either `false`, `true` (any origin),
+ * or a `Set<string>` of allowed origins.
+ */
+function _normaliseCors(value) {
+  if (value === undefined || value === null || value === false) return false;
+  if (value === true) return true;
+  if (typeof value === 'string') return new Set([value]);
+  if (Array.isArray(value)) {
+    if (!value.every((v) => typeof v === 'string')) {
+      throw new TypeError(
+        'HttpTransport: cors array must contain only origin strings'
+      );
+    }
+    return new Set(value);
+  }
+  throw new TypeError(
+    `HttpTransport: cors must be a boolean, string, or string[], got ${typeof value}`
+  );
 }
 
 export { HttpTransport };

--- a/scripts/npmjs-readme.md
+++ b/scripts/npmjs-readme.md
@@ -100,7 +100,7 @@ Then `import * as rclnodejs from 'rclnodejs'` works the same as the JavaScript e
 
 `rclnodejs` ships **two** ways to reach ROS 2 from the browser — pick one based on how much glue you want to write.
 
-- **`rclnodejs/web`** — typed, allow-listed, `curl`-able browser SDK. A `web.json` file is your public API; the browser SDK types `call` / `publish` / `subscribe` end-to-end from your ROS 2 message types; every capability is also a plain HTTP endpoint (`curl -X POST http://<host>/capability/call/<name>`), so shell scripts, Postman, and AI-agent tool-use just work. _New in `2.0.0-beta.0`._
+- **`rclnodejs/web`** — typed, allow-listed, `curl`-able browser SDK. A `web.json` file is your public API; the browser SDK types `call` / `publish` / `subscribe` end-to-end from your ROS 2 message types; every capability is also a plain HTTP endpoint (`curl -X POST http://<host>/capability/call/<name>`), with `subscribe` streaming as Server-Sent Events (`GET http://<host>/capability/subscribe/<name>`), so shell scripts, Postman, AI-agent tool-use, and a bare browser `fetch()` / `EventSource` (CORS-enabled) just work.
 
   ```ts
   import { connect } from 'rclnodejs/web';

--- a/test/test-web-cli.js
+++ b/test/test-web-cli.js
@@ -358,6 +358,20 @@ describe('rclnodejs-web CLI', function () {
       assert.strictEqual(merged.http.cors, '*');
       assert.strictEqual(merged.http.sseKeepAliveMs, 5000);
     });
+
+    it('validateConfig rejects a flag-only NaN keep-alive (bin flow)', function () {
+      // Mirrors bin/rclnodejs-web.js: parse → merge → validate. A
+      // non-numeric `--http-sse-keep-alive` becomes NaN in the parsed
+      // partial; the post-merge validateConfig is what rejects it, since
+      // loadConfigFile only validates JSON config files.
+      const { partial } = parseArgv(['--http-sse-keep-alive', 'foo']);
+      assert.ok(Number.isNaN(partial.http.sseKeepAliveMs));
+      const merged = mergeConfig({}, partial);
+      assert.throws(
+        () => validateConfig(merged, 'options'),
+        (e) => e instanceof CliError && /http\.sseKeepAliveMs/.test(e.message)
+      );
+    });
   });
 
   describe('end-to-end CLI launch', function () {

--- a/test/test-web-cli.js
+++ b/test/test-web-cli.js
@@ -141,6 +141,46 @@ describe('rclnodejs-web CLI', function () {
       assert.strictEqual(partial.http.host, '127.0.0.1');
       assert.strictEqual(partial.http.basePath, '/cap');
     });
+
+    it('parses --http-sse / --http-sse-keep-alive', function () {
+      const { partial } = parseArgv([
+        '--http-sse',
+        '--http-sse-keep-alive',
+        '30000',
+      ]);
+      assert.strictEqual(partial.http.sse, true);
+      assert.strictEqual(partial.http.sseKeepAliveMs, 30000);
+    });
+
+    it('parses --http-cors * as "any origin"', function () {
+      const { partial } = parseArgv(['--http-cors', '*']);
+      assert.strictEqual(partial.http.cors, true);
+    });
+
+    it('accumulates repeated --http-cors into an allow-list', function () {
+      const { partial } = parseArgv([
+        '--http-cors',
+        'https://a.example',
+        '--http-cors',
+        'https://b.example',
+      ]);
+      assert.deepStrictEqual(partial.http.cors, [
+        'https://a.example',
+        'https://b.example',
+      ]);
+    });
+
+    it('--http-cors * wins over specific origins regardless of order', function () {
+      const { partial } = parseArgv([
+        '--http-cors',
+        'https://a.example',
+        '--http-cors',
+        '*',
+        '--http-cors',
+        'https://b.example',
+      ]);
+      assert.strictEqual(partial.http.cors, true);
+    });
   });
 
   describe('config file loading + validation', function () {
@@ -209,6 +249,42 @@ describe('rclnodejs-web CLI', function () {
       );
     });
 
+    it('accepts http.sse / http.sseKeepAliveMs / http.cors', function () {
+      assert.doesNotThrow(() =>
+        validateConfig({
+          http: { port: 9001, sse: true, sseKeepAliveMs: 0, cors: '*' },
+        })
+      );
+      assert.doesNotThrow(() =>
+        validateConfig({ http: { cors: ['https://a.example'] } })
+      );
+    });
+
+    it('rejects non-boolean http.sse', function () {
+      assert.throws(
+        () => validateConfig({ http: { sse: 'yes' } }),
+        (e) => e instanceof CliError && /http\.sse/.test(e.message)
+      );
+    });
+
+    it('rejects non-number http.sseKeepAliveMs', function () {
+      assert.throws(
+        () => validateConfig({ http: { sseKeepAliveMs: 'soon' } }),
+        (e) => e instanceof CliError && /http\.sseKeepAliveMs/.test(e.message)
+      );
+    });
+
+    it('rejects http.cors of the wrong shape', function () {
+      assert.throws(
+        () => validateConfig({ http: { cors: 42 } }),
+        (e) => e instanceof CliError && /http\.cors/.test(e.message)
+      );
+      assert.throws(
+        () => validateConfig({ http: { cors: [1, 2] } }),
+        (e) => e instanceof CliError && /http\.cors/.test(e.message)
+      );
+    });
+
     it('rejects http with non-number port', function () {
       assert.throws(
         () => validateConfig({ http: { port: 'nine' } }),
@@ -266,6 +342,21 @@ describe('rclnodejs-web CLI', function () {
     it('http: omitting it leaves the transport disabled (port=null)', function () {
       const merged = mergeConfig({}, {});
       assert.strictEqual(merged.http.port, null);
+    });
+
+    it('http: sse/cors default off, and merge from either source', function () {
+      const base = mergeConfig({}, {});
+      assert.strictEqual(base.http.sse, false);
+      assert.strictEqual(base.http.cors, false);
+      assert.strictEqual(base.http.sseKeepAliveMs, null);
+
+      const merged = mergeConfig(
+        { http: { port: 9001, sse: true, cors: '*' } },
+        { http: { sseKeepAliveMs: 5000 } }
+      );
+      assert.strictEqual(merged.http.sse, true);
+      assert.strictEqual(merged.http.cors, '*');
+      assert.strictEqual(merged.http.sseKeepAliveMs, 5000);
     });
   });
 

--- a/test/test-web-http.js
+++ b/test/test-web-http.js
@@ -433,6 +433,284 @@ describe('rclnodejs/web — HTTP transport (call + publish)', function () {
   });
 });
 
+// ===================================================================
+// SSE subscribe + CORS — opt-in HTTP behaviour (sse: true, cors: …).
+// ===================================================================
+describe('rclnodejs/web — HTTP transport (SSE subscribe + CORS)', function () {
+  this.timeout(60 * 1000);
+
+  let node;
+  let runtime;
+  let base; // "http://127.0.0.1:<port>"
+  let serviceImpl;
+
+  before(async function () {
+    await rclnodejs.init();
+    node = rclnodejs.createNode('http_sse_test_node');
+    rclnodejs.spin(node);
+
+    serviceImpl = node.createService(
+      'example_interfaces/srv/AddTwoInts',
+      '/sse_add',
+      (request, response) => {
+        const reply = response.template;
+        reply.sum = request.a + request.b;
+        response.send(reply);
+      }
+    );
+
+    runtime = createRuntime({
+      node,
+      transport: new HttpTransport({
+        port: 0,
+        host: '127.0.0.1',
+        sse: true,
+        cors: true,
+      }),
+    });
+    runtime.expose({
+      call: { '/sse_add': 'example_interfaces/srv/AddTwoInts' },
+      publish: { '/sse_chatter': 'std_msgs/msg/String' },
+      subscribe: { '/sse_chatter': 'std_msgs/msg/String' },
+    });
+    await runtime.start();
+    base = `http://127.0.0.1:${runtime.transports[0].port}`;
+  });
+
+  after(async function () {
+    if (runtime) await runtime.stop();
+    if (node && serviceImpl) {
+      try {
+        node.destroyService(serviceImpl);
+      } catch (_) {}
+    }
+    rclnodejs.shutdown();
+  });
+
+  describe('SSE subscribe', function () {
+    it('GET subscribe streams a ready event then message events', async function () {
+      const ac = new AbortController();
+      const res = await fetch(base + '/capability/subscribe/sse_chatter', {
+        headers: { accept: 'text/event-stream' },
+        signal: ac.signal,
+      });
+      assert.strictEqual(res.status, 200);
+      assert.match(res.headers.get('content-type') || '', /text\/event-stream/);
+      const sse = sseReader(res);
+      try {
+        // The runtime emits `ready` once the dispatcher acknowledges the
+        // subscribe (headers are deferred until then).
+        const ready = await sse.next((e) => e.event === 'ready');
+        assert.strictEqual(JSON.parse(ready.data).capability, '/sse_chatter');
+
+        // Publish over HTTP until a delivery streams back. (Subscriptions
+        // only see samples published after they're established, so we
+        // retry on an interval to avoid a startup race.)
+        const pump = setInterval(() => {
+          fetch(base + '/capability/publish/sse_chatter', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ data: 'sse-hello' }),
+          }).catch(() => {});
+        }, 100);
+        try {
+          const msg = await sse.next((e) => e.event === 'message');
+          assert.strictEqual(JSON.parse(msg.data).data, 'sse-hello');
+        } finally {
+          clearInterval(pump);
+        }
+      } finally {
+        await sse.cancel();
+        ac.abort();
+      }
+    });
+
+    it('rejects a non-GET subscribe with 405 + allow: GET', async function () {
+      const res = await fetch(base + '/capability/subscribe/sse_chatter', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      });
+      assert.strictEqual(res.status, 405);
+      assert.strictEqual(res.headers.get('allow'), 'GET');
+      const body = await res.json();
+      assert.strictEqual(body.code, 'method_not_allowed');
+    });
+
+    it('rejects an unexposed SSE subscribe as a JSON error (not a stream)', async function () {
+      // The 200 text/event-stream headers are deferred until the
+      // dispatcher acks, so a rejected subscribe surfaces as a normal
+      // JSON error with the mapped status — never a half-open stream.
+      const res = await fetch(base + '/capability/subscribe/nope', {
+        headers: { accept: 'text/event-stream' },
+      });
+      assert.strictEqual(res.status, 404);
+      assert.match(res.headers.get('content-type') || '', /application\/json/);
+      const body = await res.json();
+      assert.strictEqual(body.code, 'not_exposed');
+    });
+  });
+
+  describe('CORS', function () {
+    it('answers OPTIONS preflight on capability routes with 204 + headers', async function () {
+      const res = await fetch(base + '/capability/call/sse_add', {
+        method: 'OPTIONS',
+        headers: {
+          origin: 'http://localhost:8080',
+          'access-control-request-method': 'POST',
+          'access-control-request-headers': 'content-type, authorization',
+        },
+      });
+      assert.strictEqual(res.status, 204);
+      assert.strictEqual(res.headers.get('access-control-allow-origin'), '*');
+      assert.match(
+        res.headers.get('access-control-allow-methods') || '',
+        /POST/
+      );
+      // Reflects the browser's requested headers so Authorization / custom
+      // headers pass preflight rather than being limited to content-type.
+      assert.strictEqual(
+        res.headers.get('access-control-allow-headers'),
+        'content-type, authorization'
+      );
+    });
+
+    it('falls back to content-type when no request-headers hint is sent', async function () {
+      const res = await fetch(base + '/capability/call/sse_add', {
+        method: 'OPTIONS',
+        headers: {
+          origin: 'http://localhost:8080',
+          'access-control-request-method': 'POST',
+        },
+      });
+      assert.strictEqual(res.status, 204);
+      assert.strictEqual(
+        res.headers.get('access-control-allow-headers'),
+        'content-type'
+      );
+    });
+
+    it('adds CORS headers to actual (non-preflight) responses', async function () {
+      const res = await fetch(base + '/capability/call/sse_add', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          origin: 'http://localhost:8080',
+        },
+        body: JSON.stringify({ a: '1n', b: '2n' }),
+      });
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.headers.get('access-control-allow-origin'), '*');
+      assert.strictEqual((await res.json()).sum, '3n');
+    });
+
+    it('does not answer OPTIONS preflight for non-capability paths', async function () {
+      const res = await fetch(base + '/not-a-capability', {
+        method: 'OPTIONS',
+        headers: { origin: 'http://localhost:8080' },
+      });
+      assert.strictEqual(res.status, 404);
+    });
+  });
+
+  describe('CORS allow-list', function () {
+    let listRuntime;
+    let listBase;
+
+    before(async function () {
+      listRuntime = createRuntime({
+        node,
+        transport: new HttpTransport({
+          port: 0,
+          host: '127.0.0.1',
+          cors: ['http://allowed.example'],
+        }),
+      });
+      listRuntime.expose({
+        call: { '/sse_add': 'example_interfaces/srv/AddTwoInts' },
+      });
+      await listRuntime.start();
+      listBase = `http://127.0.0.1:${listRuntime.transports[0].port}`;
+    });
+
+    after(async function () {
+      if (listRuntime) await listRuntime.stop();
+    });
+
+    it('echoes an allowed origin and sets Vary: Origin', async function () {
+      const res = await fetch(listBase + '/capability/call/sse_add', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          origin: 'http://allowed.example',
+        },
+        body: JSON.stringify({ a: '2n', b: '3n' }),
+      });
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(
+        res.headers.get('access-control-allow-origin'),
+        'http://allowed.example'
+      );
+      assert.match(res.headers.get('vary') || '', /Origin/i);
+    });
+
+    it('omits allow-origin for an origin not on the list', async function () {
+      const res = await fetch(listBase + '/capability/call/sse_add', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          origin: 'http://evil.example',
+        },
+        body: JSON.stringify({ a: '2n', b: '3n' }),
+      });
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.headers.get('access-control-allow-origin'), null);
+    });
+  });
+});
+
+// Minimal Server-Sent Events reader over a fetch() response body. Parses
+// `event:`/`data:` lines into `{event, data}` records and exposes a
+// `next(predicate)` that resolves with the first matching record. Keep-
+// alive comment lines (`:`-prefixed) are ignored.
+function sseReader(res) {
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  const state = { buffer: '', event: 'message', data: '' };
+
+  async function next(predicate, timeoutMs = 8000) {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      let nl;
+      while ((nl = state.buffer.indexOf('\n')) >= 0) {
+        const line = state.buffer.slice(0, nl).replace(/\r$/, '');
+        state.buffer = state.buffer.slice(nl + 1);
+        if (line === '') {
+          const ev = { event: state.event, data: state.data };
+          state.event = 'message';
+          state.data = '';
+          if (ev.data !== '' && predicate(ev)) return ev;
+          continue;
+        }
+        if (line.startsWith(':')) continue; // keep-alive comment
+        const ci = line.indexOf(':');
+        const field = ci === -1 ? line : line.slice(0, ci);
+        const val = ci === -1 ? '' : line.slice(ci + 1).replace(/^ /, '');
+        if (field === 'event') state.event = val;
+        else if (field === 'data') state.data += val;
+      }
+      if (Date.now() > deadline) {
+        throw new Error('sseReader: timed out waiting for event');
+      }
+      const { value, done } = await reader.read();
+      if (done) throw new Error('sseReader: stream ended early');
+      state.buffer += decoder.decode(value, { stream: true });
+    }
+  }
+
+  return { next, cancel: () => reader.cancel().catch(() => {}) };
+}
+
 function waitFor(predicate, timeoutMs) {
   const started = Date.now();
   return new Promise((resolve, reject) => {

--- a/web/README.md
+++ b/web/README.md
@@ -130,7 +130,8 @@ window.addEventListener('beforeunload', () => ros.close());
 
 When `--http-port` is on, every `call` / `publish` is reachable from
 any HTTP client — curl, Postman, AI-agent tool-use, no SDK required.
-Subscribe stays on WebSocket.
+With `--http-sse` (or `"http": { "sse": true }`), `subscribe` is also
+reachable over HTTP as a Server-Sent Events stream.
 
 ```bash
 # Service call
@@ -143,6 +144,29 @@ curl -sS -X POST http://localhost:9001/capability/call/add_two_ints \
 curl -sS -X POST http://localhost:9001/capability/publish/chatter \
   -H 'content-type: application/json' \
   -d '{"data":"hi from curl"}'
+
+# Subscribe over Server-Sent Events (needs --http-sse). Streams until
+# you disconnect; -N keeps curl from buffering the event stream.
+curl -N http://localhost:9001/capability/subscribe/chatter
+# event: ready
+# data: {"capability":"/chatter","subId":"sse"}
+#
+# event: message
+# data: {"data":"hello"}
+```
+
+From a browser, the same SSE endpoint works with the built-in
+`EventSource` (cross-origin when `--http-cors` is set):
+
+```js
+const es = new EventSource(
+  'http://localhost:9001/capability/subscribe/chatter'
+);
+es.addEventListener('message', (e) => {
+  const msg = JSON.parse(e.data);
+  console.log(msg.data);
+});
+es.addEventListener('error', () => es.close());
 ```
 
 ## 4. `rclnodejs/web` vs. `rosbridge` + `roslibjs`


### PR DESCRIPTION
Adds Server-Sent Events (SSE) subscription support and CORS to the HTTP transport, so browsers and other HTTP clients can `subscribe` to ROS topics over plain HTTP (no WebSocket required) and call the runtime cross-origin.

## Core (`lib/runtime/`)

- **`transports/http.js`** (+334 / −26) — the bulk of the change:
  - New `HttpSseConnection`: a long-lived `Connection` that streams one subscription as `text/event-stream`. The `200` SSE headers are deferred until the dispatcher acks (`{ok:true}`), so a rejected subscribe still returns a normal JSON error instead of a half-open stream; on success it emits a `ready` event (`{capability, subId:"sse"}`) followed by `message` events, and starts an unref'd keep-alive `setInterval`. Includes `_writeEvent`, `_writeError`, and a once-only close path.
  - `subscribe` is served only when `sse: true`, via `GET /capability/subscribe/<name>` (non-GET → `405` with `allow: GET`; unexposed / `sse` off → JSON `404`); `call` and `publish` continue to work as before.
  - CORS via `_applyCors` / `_normaliseCors`: `cors` accepts `true`/`'*'` (any origin), a single origin string, or an allow-list array. Allow-list mode echoes a matching `Origin` and sets `Vary: Origin`. `Access-Control-Allow-Headers` reflects the browser's `Access-Control-Request-Headers` on preflight (falling back to `content-type`), so `Authorization` and custom headers pass. `OPTIONS` preflight returns `204` for capability routes when CORS is on. CORS headers are applied first, so they appear on JSON replies, 204s, and SSE streams alike.
  - `sseKeepAliveMs` configurable (default `15000`, `0` disables).
- **`cli-config.js`** (+67 / −5) — new flags `--http-sse`, `--http-sse-keep-alive <ms>`, and repeatable `--http-cors <origin>`; maps to `http.sse` / `http.sseKeepAliveMs` / `http.cors`. DEFAULTS, validation, merge, HELP, and examples all updated.
- **`index.d.ts`** (+3) — `HttpTransportOptions` gains `sse?: boolean; sseKeepAliveMs?: number; cors?: boolean | string | string[];`.

## CLI (`bin/rclnodejs-web.js`)

- (+16 / −1) Passes `sse` / `sseKeepAliveMs` / `cors` through to `HttpTransport`, and re-runs `validateConfig` on the merged result so flag-only values (e.g. `--http-sse-keep-alive foo` → NaN) are rejected before reaching the transport; banner distinguishes "call/publish + subscribe (SSE)" vs "call/publish only".

## Demos (`demo/web/javascript`, `demo/web/typescript`)

- `runtime.mjs` (+20 / −13) — `HttpTransport` runs with `sse: true, cors: true`; exposes `/add_two_ints`, publishes/subscribes `/web_demo_chatter`, and subscribes `/topic` (drops the standalone `/web_demo_tick` publisher so all panels share one topic); banner gains an "HTTP SSE" line.
- `web.json` (+6 / −4) — `http` block now sets `port: 9001, sse: true, cors: "*"`; subscribe exposes `/web_demo_chatter` + `/topic`.
- `index.html` (+237 / −18) — new native `EventSource` (SSE) panel and `fetch()` panel with `ready`/`message`/`error` handlers and open/close controls, plus curl examples.
- `javascript/README.md` (+82 / −19), `typescript/README.md` (+15 / −15) — document the SSE/CORS flow; the TS demo notes its HTTP transport stays call/publish-only and points to the JS demo for SSE.

## Docs

- `web/README.md` (+25 / −1) — §3 curl recipes gain an SSE `curl -N` example and a browser `EventSource` snippet.
- `README.md` (+4 / −4), `scripts/npmjs-readme.md` (+1 / −1) — `rclnodejs/web` bullet notes `subscribe` over SSE and a CORS-enabled browser `fetch()` / `EventSource`.

## Tests

- `test/test-web-http.js` (+278) — SSE + CORS HTTP integration suite: deferred-header behaviour, `ready`/`message` events, keep-alive, 404/405 routing, preflight, origin echo / allow-list.
- `test/test-web-cli.js` (+105) — new cases for `--http-sse`, `--http-sse-keep-alive` (including bin-flow NaN rejection), and `--http-cors` (single, accumulation, precedence) plus config validation.

Fix: #1510