### PR TITLE
[Windows] Fix native build failure on the VS 2026 toolset

### DIFF
--- a/third_party/ref-napi/src/ref_napi_bindings.cpp
+++ b/third_party/ref-napi/src/ref_napi_bindings.cpp
@@ -100,15 +100,22 @@ class PointerBuffer : public ObjectWrap<PointerBuffer> {
 };
 
 Object PointerBuffer::Init(Napi::Env env, Object exports) {
-  Function func =
-      DefineClass(env, "PointerBuffer",
-                  {InstanceMethod("isNull", &PointerBuffer::IsNull),
-                   InstanceMethod("get", &PointerBuffer::Get),
-                   InstanceMethod("address", &PointerBuffer::Address),
-                   InstanceMethod("toString", &PointerBuffer::ToString),
-                   InstanceMethod("copy", &PointerBuffer::Copy),
-                   InstanceMethod("slice", &PointerBuffer::Slice),
-                   InstanceAccessor<&PointerBuffer::Length>("length")});
+  Function func = DefineClass(
+      env, "PointerBuffer",
+      {InstanceMethod("isNull", &PointerBuffer::IsNull),
+       InstanceMethod("get", &PointerBuffer::Get),
+       InstanceMethod("address", &PointerBuffer::Address),
+       InstanceMethod("toString", &PointerBuffer::ToString),
+       InstanceMethod("copy", &PointerBuffer::Copy),
+       InstanceMethod("slice", &PointerBuffer::Slice),
+       // Use the runtime InstanceAccessor(name, getter, setter)
+       // overload rather than the templated
+       // InstanceAccessor<&Fn>() form: the latter's constexpr
+       // member-pointer template argument triggers an MSVC
+       // Internal Compiler Error (C1001) on the VS 2026 (v18)
+       // toolset used by the windows-2025 CI runner. This form
+       // is equivalent and compiles cleanly on every platform.
+       InstanceAccessor("length", &PointerBuffer::Length, nullptr)});
 
   exports.Set("PointerBuffer", func);
   InstanceData* data = InstanceData::Get(env);


### PR DESCRIPTION
The `windows-2025` GitHub Actions runner provisions Visual Studio 2026 (v18) alongside VS 2022, and `gha-setup-vsdevenv` selects the newest install via `vswhere -latest`. The v18 `constexpr` evaluator crashes with an Internal Compiler Error (C1001) while instantiating node-addon-api's templated `InstanceAccessor<&Fn>()` helper (`napi-inl.h`), which takes the getter as a `constexpr` member-pointer template argument.

Replace the templated accessor with the equivalent runtime overload in `ref-napi`'s `PointerBuffer::Init`:

- `InstanceAccessor<&PointerBuffer::Length>("length")`
+ `InstanceAccessor("length", &PointerBuffer::Length, nullptr)`

The runtime overload passes the getter as a plain function pointer and the setter as `nullptr`, preserving the read-only `length` accessor exactly while avoiding the `constexpr` template path that trips the ICE. This compiles cleanly on every platform/toolset and is a no-op at runtime.

Fix: #1538