### PR TITLE
[Doc] Switch npmjs README examples to ESM

### DIFF
--- a/scripts/npmjs-readme.md
+++ b/scripts/npmjs-readme.md
@@ -5,13 +5,13 @@
 Supported ROS 2 distributions include Humble, Jazzy, Kilted, Lyrical, and Rolling.
 
 ```javascript
-const rclnodejs = require('rclnodejs');
-rclnodejs.init().then(() => {
-  const node = new rclnodejs.Node('publisher_example_node');
-  const publisher = node.createPublisher('std_msgs/msg/String', 'topic');
-  publisher.publish(`Hello ROS 2 from rclnodejs`);
-  node.spin();
-});
+import rclnodejs from 'rclnodejs';
+
+await rclnodejs.init();
+const node = new rclnodejs.Node('publisher_example_node');
+const publisher = node.createPublisher('std_msgs/msg/String', 'topic');
+publisher.publish(`Hello ROS 2 from rclnodejs`);
+node.spin();
 ```
 
 This example assumes your ROS 2 environment is already sourced.
@@ -87,9 +87,9 @@ TypeScript declaration files are included in the package. In most projects, conf
 ```jsonc
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "target": "es2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "es2022",
   },
 }
 ```


### PR DESCRIPTION
Align the npm-published README (scripts/npmjs-readme.md) with the package's ESM-first API.

- Quick-start snippet: replace the CommonJS `require()` + `init().then()` form with native ESM `import rclnodejs from 'rclnodejs'` and top-level `await rclnodejs.init()`.
- TypeScript guidance: update the sample tsconfig from `commonjs` / `node` / `es2020` to `NodeNext` / `NodeNext` / `es2022` to match ESM module resolution.

Fix: #1541