### PR TITLE
[docs] Demonstrate web-native SSE subscribe in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ how much glue you want to write.
   ); // reply.sum is typed as `${number}n`
   ```
 
+  No SDK needed for subscribe — any browser streams a live ROS 2 topic via built-in `EventSource`:
+
+  ```js
+  const es = new EventSource('http://host:9000/capability/subscribe/chatter');
+  es.onmessage = (e) => console.log(JSON.parse(e.data)); // live ROS 2 messages
+  ```
+
 - **[`rosocket`](./rosocket/README.md)** — thin WebSocket gateway,
   zero browser dependencies (just built-in `WebSocket` + `JSON`).
   Best for quick prototypes and `roslibjs`-style apps.

--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ how much glue you want to write.
   ); // reply.sum is typed as `${number}n`
   ```
 
-  No SDK needed for subscribe — any browser streams a live ROS 2 topic via built-in `EventSource`:
+  No SDK needed for subscribe — with the HTTP/SSE transport enabled (`--http-sse`, plus `--http-cors` for cross-origin), any browser streams a live ROS 2 topic via built-in `EventSource`:
 
   ```js
-  const es = new EventSource('http://host:9000/capability/subscribe/chatter');
+  const es = new EventSource('http://host:9001/capability/subscribe/chatter');
   es.onmessage = (e) => console.log(JSON.parse(e.data)); // live ROS 2 messages
   ```
 

--- a/scripts/npmjs-readme.md
+++ b/scripts/npmjs-readme.md
@@ -110,10 +110,10 @@ Then `import * as rclnodejs from 'rclnodejs'` works the same as the JavaScript e
   ); // reply.sum is typed as `${number}n`
   ```
 
-  No SDK needed for subscribe — any browser streams a live ROS 2 topic via built-in `EventSource`:
+  No SDK needed for subscribe — with the HTTP/SSE transport enabled (`--http-sse`, plus `--http-cors` for cross-origin), any browser streams a live ROS 2 topic via built-in `EventSource`:
 
   ```js
-  const es = new EventSource('http://host:9000/capability/subscribe/chatter');
+  const es = new EventSource('http://host:9001/capability/subscribe/chatter');
   es.onmessage = (e) => console.log(JSON.parse(e.data)); // live ROS 2 messages
   ```
 

--- a/scripts/npmjs-readme.md
+++ b/scripts/npmjs-readme.md
@@ -110,6 +110,13 @@ Then `import * as rclnodejs from 'rclnodejs'` works the same as the JavaScript e
   ); // reply.sum is typed as `${number}n`
   ```
 
+  No SDK needed for subscribe — any browser streams a live ROS 2 topic via built-in `EventSource`:
+
+  ```js
+  const es = new EventSource('http://host:9000/capability/subscribe/chatter');
+  es.onmessage = (e) => console.log(JSON.parse(e.data)); // live ROS 2 messages
+  ```
+
   See the [Web SDK guide](https://github.com/RobotWebTools/rclnodejs/tree/develop/web).
 
 - **`rosocket`** — thin WebSocket gateway, zero browser dependencies (just built-in `WebSocket` + `JSON`). Best for quick prototypes and `roslibjs`-style apps.


### PR DESCRIPTION
This PR updates the project READMEs to highlight a “web-native” way to subscribe to ROS 2 topics using Server-Sent Events (SSE) via the browser’s built-in `EventSource`, without requiring a browser SDK.

**Changes:**
- Add an `EventSource` snippet demonstrating SSE-based topic subscription in the root `README.md`.
- Mirror the same SSE subscription snippet in `scripts/npmjs-readme.md` (used for npm packaging/readme generation).

Fix: #1510