### PR TITLE
[Action] Add ActionEndpointInfo and action graph count APIs

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ import ActionUuid from './lib/action/uuid.js';
 import ClientGoalHandle from './lib/action/client_goal_handle.js';
 import { CancelResponse, GoalResponse } from './lib/action/response.js';
 import ServerGoalHandle from './lib/action/server_goal_handle.js';
+import ActionEndpointInfo from './lib/action/endpoint_info.js';
 import { toJSONSafe, toJSONString } from './lib/message_serialization.js';
 import {
   getActionClientNamesAndTypesByNode,
@@ -294,6 +295,9 @@ let rcl = {
 
   /** {@link ActionUuid} class */
   ActionUuid: ActionUuid,
+
+  /** {@link ActionEndpointInfo} class */
+  ActionEndpointInfo: ActionEndpointInfo,
 
   /** {@link ClientGoalHandle} class */
   ClientGoalHandle: ClientGoalHandle,

--- a/lib/action/endpoint_info.js
+++ b/lib/action/endpoint_info.js
@@ -1,0 +1,48 @@
+// Copyright (c) 2026, The Robot Web Tools Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Aggregated endpoint information for one action client or server.
+ */
+class ActionEndpointInfo {
+  /**
+   * @param {object} info - Raw endpoint information from the native layer.
+   * @hideconstructor
+   */
+  constructor(info) {
+    this.goalServiceInfo = info.goal_service_info;
+    this.cancelServiceInfo = info.cancel_service_info;
+    this.resultServiceInfo = info.result_service_info;
+    this.feedbackTopicInfo = info.feedback_topic_info;
+    this.statusTopicInfo = info.status_topic_info;
+  }
+
+  get nodeName() {
+    return this.goalServiceInfo.node_name;
+  }
+
+  get nodeNamespace() {
+    return this.goalServiceInfo.node_namespace;
+  }
+
+  get actionType() {
+    return this.goalServiceInfo.service_type.replace(/_SendGoal$/, '');
+  }
+
+  get endpointType() {
+    return this.goalServiceInfo.endpoint_type;
+  }
+}
+
+export default ActionEndpointInfo;

--- a/lib/action/endpoint_info.js
+++ b/lib/action/endpoint_info.js
@@ -21,27 +21,74 @@ class ActionEndpointInfo {
    * @hideconstructor
    */
   constructor(info) {
-    this.goalServiceInfo = info.goal_service_info;
-    this.cancelServiceInfo = info.cancel_service_info;
-    this.resultServiceInfo = info.result_service_info;
-    this.feedbackTopicInfo = info.feedback_topic_info;
-    this.statusTopicInfo = info.status_topic_info;
+    this._goalServiceInfo = info.goal_service_info;
+    this._cancelServiceInfo = info.cancel_service_info;
+    this._resultServiceInfo = info.result_service_info;
+    this._feedbackTopicInfo = info.feedback_topic_info;
+    this._statusTopicInfo = info.status_topic_info;
   }
 
+  /**
+   * @type {object}
+   */
+  get goalServiceInfo() {
+    return this._goalServiceInfo;
+  }
+
+  /**
+   * @type {object}
+   */
+  get cancelServiceInfo() {
+    return this._cancelServiceInfo;
+  }
+
+  /**
+   * @type {object}
+   */
+  get resultServiceInfo() {
+    return this._resultServiceInfo;
+  }
+
+  /**
+   * @type {object}
+   */
+  get feedbackTopicInfo() {
+    return this._feedbackTopicInfo;
+  }
+
+  /**
+   * @type {object}
+   */
+  get statusTopicInfo() {
+    return this._statusTopicInfo;
+  }
+
+  /**
+   * @type {string}
+   */
   get nodeName() {
-    return this.goalServiceInfo.node_name;
+    return this._goalServiceInfo.node_name;
   }
 
+  /**
+   * @type {string}
+   */
   get nodeNamespace() {
-    return this.goalServiceInfo.node_namespace;
+    return this._goalServiceInfo.node_namespace;
   }
 
+  /**
+   * @type {string}
+   */
   get actionType() {
-    return this.goalServiceInfo.service_type.replace(/_SendGoal$/, '');
+    return this._goalServiceInfo.service_type.replace(/_SendGoal$/, '');
   }
 
+  /**
+   * @type {number}
+   */
   get endpointType() {
-    return this.goalServiceInfo.endpoint_type;
+    return this._goalServiceInfo.endpoint_type;
   }
 }
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -1515,7 +1515,7 @@ class Node extends rclnodejs.ShadowNode {
   /**
    * Return the number of action clients on an action.
    * @param {string} actionName - The action name to query.
-   * @returns {number|null} The number of discovered action clients, or null when unsupported.
+   * @returns {number|null} The number of action clients, or null when the ROS distro is older than Lyrical.
    */
   countActionClients(actionName) {
     if (typeof rclnodejs.countActionClients !== 'function') {
@@ -1533,7 +1533,7 @@ class Node extends rclnodejs.ShadowNode {
   /**
    * Return the number of action servers on an action.
    * @param {string} actionName - The action name to query.
-   * @returns {number|null} The number of discovered action servers, or null when unsupported.
+   * @returns {number|null} The number of action servers, or null when the ROS distro is older than Lyrical.
    */
   countActionServers(actionName) {
     if (typeof rclnodejs.countActionServers !== 'function') {
@@ -1551,7 +1551,7 @@ class Node extends rclnodejs.ShadowNode {
   /**
    * Return endpoint information for action clients on an action.
    * @param {string} actionName - The action name to query.
-   * @returns {Array<ActionEndpointInfo>|null} The discovered action clients, or null when unsupported.
+   * @returns {Array<ActionEndpointInfo>|null} The action clients, or null when the ROS distro is older than Rolling.
    */
   getActionClientsInfoByAction(actionName) {
     if (typeof rclnodejs.getActionClientsInfoByAction !== 'function') {
@@ -1571,7 +1571,7 @@ class Node extends rclnodejs.ShadowNode {
   /**
    * Return endpoint information for action servers on an action.
    * @param {string} actionName - The action name to query.
-   * @returns {Array<ActionEndpointInfo>|null} The discovered action servers, or null when unsupported.
+   * @returns {Array<ActionEndpointInfo>|null} The action servers, or null when the ROS distro is older than Rolling.
    */
   getActionServersInfoByAction(actionName) {
     if (typeof rclnodejs.getActionServersInfoByAction !== 'function') {
@@ -2599,13 +2599,13 @@ class Node extends rclnodejs.ShadowNode {
 
   // Unlike topic/service queries, the queried action name is not remapped.
   _getValidatedActionName(actionName) {
-    const fqActionName = rclnodejs.expandTopicName(
+    const fullyQualifiedActionName = rclnodejs.expandTopicName(
       actionName,
       this.name(),
       this.namespace()
     );
-    validateFullTopicName(fqActionName);
-    return fqActionName;
+    validateFullTopicName(fullyQualifiedActionName);
+    return fullyQualifiedActionName;
   }
 
   _getValidatedTopic(topicName, noDemangle) {

--- a/lib/node.js
+++ b/lib/node.js
@@ -44,6 +44,7 @@ import Service from './service.js';
 import Subscription from './subscription.js';
 import ObservableSubscription from './observable_subscription.js';
 import MessageInfo from './message_info.js';
+import ActionEndpointInfo from './action/endpoint_info.js';
 import { declareQosParameters, _resolveQoS } from './qos_overriding_options.js';
 import TimeSource from './time_source.js';
 import Timer from './timer.js';
@@ -1512,6 +1513,82 @@ class Node extends rclnodejs.ShadowNode {
   }
 
   /**
+   * Return the number of action clients on an action.
+   * @param {string} actionName - The action name to query.
+   * @returns {number|null} The number of discovered action clients, or null when unsupported.
+   */
+  countActionClients(actionName) {
+    if (typeof rclnodejs.countActionClients !== 'function') {
+      console.warn(
+        'countActionClients is not supported by this version of ROS 2'
+      );
+      return null;
+    }
+    return rclnodejs.countActionClients(
+      this.handle,
+      this._getValidatedActionName(actionName)
+    );
+  }
+
+  /**
+   * Return the number of action servers on an action.
+   * @param {string} actionName - The action name to query.
+   * @returns {number|null} The number of discovered action servers, or null when unsupported.
+   */
+  countActionServers(actionName) {
+    if (typeof rclnodejs.countActionServers !== 'function') {
+      console.warn(
+        'countActionServers is not supported by this version of ROS 2'
+      );
+      return null;
+    }
+    return rclnodejs.countActionServers(
+      this.handle,
+      this._getValidatedActionName(actionName)
+    );
+  }
+
+  /**
+   * Return endpoint information for action clients on an action.
+   * @param {string} actionName - The action name to query.
+   * @returns {Array<ActionEndpointInfo>|null} The discovered action clients, or null when unsupported.
+   */
+  getActionClientsInfoByAction(actionName) {
+    if (typeof rclnodejs.getActionClientsInfoByAction !== 'function') {
+      console.warn(
+        'getActionClientsInfoByAction is not supported by this version of ROS 2'
+      );
+      return null;
+    }
+    return rclnodejs
+      .getActionClientsInfoByAction(
+        this.handle,
+        this._getValidatedActionName(actionName)
+      )
+      .map((info) => new ActionEndpointInfo(info));
+  }
+
+  /**
+   * Return endpoint information for action servers on an action.
+   * @param {string} actionName - The action name to query.
+   * @returns {Array<ActionEndpointInfo>|null} The discovered action servers, or null when unsupported.
+   */
+  getActionServersInfoByAction(actionName) {
+    if (typeof rclnodejs.getActionServersInfoByAction !== 'function') {
+      console.warn(
+        'getActionServersInfoByAction is not supported by this version of ROS 2'
+      );
+      return null;
+    }
+    return rclnodejs
+      .getActionServersInfoByAction(
+        this.handle,
+        this._getValidatedActionName(actionName)
+      )
+      .map((info) => new ActionEndpointInfo(info));
+  }
+
+  /**
    * Return a list of publishers on a given topic.
    *
    * The returned parameter is a list of TopicEndpointInfo objects, where each will contain
@@ -2518,6 +2595,17 @@ class Node extends rclnodejs.ShadowNode {
   _addActionServer(actionServer) {
     this._actionServers.push(actionServer);
     this.syncHandles();
+  }
+
+  // Unlike topic/service queries, the queried action name is not remapped.
+  _getValidatedActionName(actionName) {
+    const fqActionName = rclnodejs.expandTopicName(
+      actionName,
+      this.name(),
+      this.namespace()
+    );
+    validateFullTopicName(fqActionName);
+    return fqActionName;
   }
 
   _getValidatedTopic(topicName, noDemangle) {

--- a/src/rcl_graph_bindings.cpp
+++ b/src/rcl_graph_bindings.cpp
@@ -17,6 +17,7 @@
 #include <rcl/error_handling.h>
 #include <rcl/graph.h>
 #include <rcl/rcl.h>
+#include <rcl_action/graph.h>
 
 #include <string>
 
@@ -39,6 +40,12 @@ typedef rcl_ret_t (*rcl_get_info_by_service_func_t)(
     const char* service_name, bool no_mangle,
     rcl_service_endpoint_info_array_t* info_array);
 #endif  // ROS_VERSION >= 2605
+
+#if ROS_VERSION >= 5000
+typedef rcl_ret_t (*rcl_action_get_info_by_action_func_t)(
+    const rcl_node_t* node, rcutils_allocator_t* allocator,
+    const char* action_name, rcl_action_endpoint_info_array_t* info_array);
+#endif  // ROS_VERSION >= 5000
 
 Napi::Value GetPublisherNamesAndTypesByNode(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
@@ -207,6 +214,34 @@ Napi::Value GetServiceNamesAndTypes(const Napi::CallbackInfo& info) {
   return result_list;
 }
 
+#if ROS_VERSION >= 2605
+Napi::Value CountActionClients(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  std::string action_name = info[1].As<Napi::String>().Utf8Value();
+  size_t count = 0;
+
+  THROW_ERROR_IF_NOT_EQUAL(
+      RCL_RET_OK, rcl_action_count_clients(node, action_name.c_str(), &count),
+      "Failed to count action clients");
+  return Napi::Number::New(env, count);
+}
+
+Napi::Value CountActionServers(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  std::string action_name = info[1].As<Napi::String>().Utf8Value();
+  size_t count = 0;
+
+  THROW_ERROR_IF_NOT_EQUAL(
+      RCL_RET_OK, rcl_action_count_servers(node, action_name.c_str(), &count),
+      "Failed to count action servers");
+  return Napi::Number::New(env, count);
+}
+#endif  // ROS_VERSION >= 2605
+
 Napi::Value GetInfoByTopic(Napi::Env env, rcl_node_t* node,
                            const char* topic_name, bool no_mangle,
                            const char* type,
@@ -324,6 +359,60 @@ Napi::Value GetServersInfoByService(const Napi::CallbackInfo& info) {
 }
 #endif  // ROS_VERSION >= 2605
 
+#if ROS_VERSION >= 5000
+Napi::Value GetInfoByAction(
+    Napi::Env env, rcl_node_t* node, const char* action_name, const char* type,
+    rcl_action_get_info_by_action_func_t rcl_action_get_info_by_action) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcl_action_endpoint_info_array_t info_array =
+      rcl_action_get_zero_initialized_endpoint_info_array();
+
+  RCPPUTILS_SCOPE_EXIT({
+    rcl_ret_t fini_ret =
+        rcl_action_endpoint_info_array_fini(&info_array, &allocator);
+    if (RCL_RET_OK != fini_ret) {
+      Napi::Error::New(env, rcl_get_error_string().str)
+          .ThrowAsJavaScriptException();
+      rcl_reset_error();
+    }
+  });
+
+  rcl_ret_t ret =
+      rcl_action_get_info_by_action(node, &allocator, action_name, &info_array);
+  if (RCL_RET_OK != ret) {
+    if (RCL_RET_UNSUPPORTED == ret) {
+      Napi::Error::New(
+          env, std::string("Failed to get information by action for ") + type +
+                   ": function not supported by RMW_IMPLEMENTATION")
+          .ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+    Napi::Error::New(
+        env, std::string("Failed to get information by action for ") + type)
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  return ConvertToJSActionEndpointInfoList(env, &info_array);
+}
+
+Napi::Value GetActionClientsInfoByAction(const Napi::CallbackInfo& info) {
+  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  std::string action_name = info[1].As<Napi::String>().Utf8Value();
+  return GetInfoByAction(info.Env(), node, action_name.c_str(), "clients",
+                         rcl_action_get_clients_info_by_action);
+}
+
+Napi::Value GetActionServersInfoByAction(const Napi::CallbackInfo& info) {
+  RclHandle* node_handle = RclHandle::Unwrap(info[0].As<Napi::Object>());
+  rcl_node_t* node = reinterpret_cast<rcl_node_t*>(node_handle->ptr());
+  std::string action_name = info[1].As<Napi::String>().Utf8Value();
+  return GetInfoByAction(info.Env(), node, action_name.c_str(), "servers",
+                         rcl_action_get_servers_info_by_action);
+}
+#endif  // ROS_VERSION >= 5000
+
 Napi::Object InitGraphBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("getPublisherNamesAndTypesByNode",
               Napi::Function::New(env, GetPublisherNamesAndTypesByNode));
@@ -342,11 +431,21 @@ Napi::Object InitGraphBindings(Napi::Env env, Napi::Object exports) {
   exports.Set("getSubscriptionsInfoByTopic",
               Napi::Function::New(env, GetSubscriptionsInfoByTopic));
 #if ROS_VERSION >= 2605
+  exports.Set("countActionClients",
+              Napi::Function::New(env, CountActionClients));
+  exports.Set("countActionServers",
+              Napi::Function::New(env, CountActionServers));
   exports.Set("getClientsInfoByService",
               Napi::Function::New(env, GetClientsInfoByService));
   exports.Set("getServersInfoByService",
               Napi::Function::New(env, GetServersInfoByService));
 #endif  // ROS_VERSION >= 2605
+#if ROS_VERSION >= 5000
+  exports.Set("getActionClientsInfoByAction",
+              Napi::Function::New(env, GetActionClientsInfoByAction));
+  exports.Set("getActionServersInfoByAction",
+              Napi::Function::New(env, GetActionServersInfoByAction));
+#endif  // ROS_VERSION >= 5000
   return exports;
 }
 

--- a/src/rcl_utilities.cpp
+++ b/src/rcl_utilities.cpp
@@ -106,11 +106,17 @@ Napi::Value ConvertToJSTopicEndpoint(
 
   Napi::Object endpoint = Napi::Object::New(env);
   endpoint.Set("node_name",
-               Napi::String::New(env, topic_endpoint_info->node_name));
+               Napi::String::New(env, topic_endpoint_info->node_name
+                                          ? topic_endpoint_info->node_name
+                                          : ""));
   endpoint.Set("node_namespace",
-               Napi::String::New(env, topic_endpoint_info->node_namespace));
+               Napi::String::New(env, topic_endpoint_info->node_namespace
+                                          ? topic_endpoint_info->node_namespace
+                                          : ""));
   endpoint.Set("topic_type",
-               Napi::String::New(env, topic_endpoint_info->topic_type));
+               Napi::String::New(env, topic_endpoint_info->topic_type
+                                          ? topic_endpoint_info->topic_type
+                                          : ""));
 #if ROS_VERSION > 2205  // 2205 == Humble
   endpoint.Set("topic_type_hash",
                ConvertToHashObject(env, &topic_endpoint_info->topic_type_hash));
@@ -129,11 +135,18 @@ Napi::Value ConvertToJSServiceEndpointInfo(
     Napi::Env env, const rmw_service_endpoint_info_t* service_endpoint_info) {
   Napi::Object endpoint = Napi::Object::New(env);
   endpoint.Set("node_name",
-               Napi::String::New(env, service_endpoint_info->node_name));
-  endpoint.Set("node_namespace",
-               Napi::String::New(env, service_endpoint_info->node_namespace));
+               Napi::String::New(env, service_endpoint_info->node_name
+                                          ? service_endpoint_info->node_name
+                                          : ""));
+  endpoint.Set(
+      "node_namespace",
+      Napi::String::New(env, service_endpoint_info->node_namespace
+                                 ? service_endpoint_info->node_namespace
+                                 : ""));
   endpoint.Set("service_type",
-               Napi::String::New(env, service_endpoint_info->service_type));
+               Napi::String::New(env, service_endpoint_info->service_type
+                                          ? service_endpoint_info->service_type
+                                          : ""));
   endpoint.Set(
       "service_type_hash",
       ConvertToHashObject(env, &service_endpoint_info->service_type_hash));
@@ -320,6 +333,34 @@ Napi::Array ConvertToJSServiceEndpointInfoList(
   return list;
 }
 #endif  // ROS_VERSION >= 2605
+
+#if ROS_VERSION >= 5000
+Napi::Array ConvertToJSActionEndpointInfoList(
+    Napi::Env env, const rcl_action_endpoint_info_array_t* info_array) {
+  Napi::Array list = Napi::Array::New(env, info_array->size);
+  for (size_t i = 0; i < info_array->size; ++i) {
+    const rcl_action_endpoint_info_t* action_info = &info_array->info_array[i];
+    Napi::Object endpoint = Napi::Object::New(env);
+    endpoint.Set(
+        "goal_service_info",
+        ConvertToJSServiceEndpointInfo(env, &action_info->goal_service_info));
+    endpoint.Set(
+        "cancel_service_info",
+        ConvertToJSServiceEndpointInfo(env, &action_info->cancel_service_info));
+    endpoint.Set(
+        "result_service_info",
+        ConvertToJSServiceEndpointInfo(env, &action_info->result_service_info));
+    endpoint.Set(
+        "feedback_topic_info",
+        ConvertToJSTopicEndpoint(env, &action_info->feedback_topic_info));
+    endpoint.Set(
+        "status_topic_info",
+        ConvertToJSTopicEndpoint(env, &action_info->status_topic_info));
+    list.Set(i, endpoint);
+  }
+  return list;
+}
+#endif  // ROS_VERSION >= 5000
 
 char** AbstractArgsFromNapiArray(const Napi::Array& jsArgv) {
   size_t argc = jsArgv.Length();

--- a/src/rcl_utilities.h
+++ b/src/rcl_utilities.h
@@ -18,6 +18,9 @@
 #include <napi.h>
 #include <rcl/graph.h>
 #include <rmw/rmw.h>
+#if ROS_VERSION >= 5000
+#include <rcl_action/graph.h>
+#endif
 
 #include <memory>
 #include <string>
@@ -55,6 +58,11 @@ Napi::Array ConvertToJSTopicEndpointInfoList(
 Napi::Array ConvertToJSServiceEndpointInfoList(
     Napi::Env env, const rmw_service_endpoint_info_array_t* info_array);
 #endif  // ROS_VERSION >= 2605
+
+#if ROS_VERSION >= 5000
+Napi::Array ConvertToJSActionEndpointInfoList(
+    Napi::Env env, const rcl_action_endpoint_info_array_t* info_array);
+#endif  // ROS_VERSION >= 5000
 
 Napi::Value ConvertToQoS(Napi::Env env, const rmw_qos_profile_t* qos_profile);
 

--- a/test/test-action-graph.js
+++ b/test/test-action-graph.js
@@ -67,6 +67,7 @@ describe('rclnodejs action graph', function () {
   async function waitForCount(countFn, expected) {
     const timeout = 5000;
     const start = Date.now();
+    // The count call is synchronous, but DDS discovery is not, so poll until it converges
     let actual = countFn();
     while (actual !== expected && Date.now() - start < timeout) {
       await assertUtils.createDelay(100);
@@ -75,11 +76,31 @@ describe('rclnodejs action graph', function () {
     return actual;
   }
 
+  // An entry appears as soon as its goal service is discovered, so wait for the
+  // remaining sub-entities too rather than just the expected number of entries
+  function isEndpointInfoComplete(result, count) {
+    return (
+      result.length === count &&
+      result.every((info) =>
+        [
+          info.goalServiceInfo,
+          info.cancelServiceInfo,
+          info.resultServiceInfo,
+          info.feedbackTopicInfo,
+          info.statusTopicInfo,
+        ].every((subEntity) => subEntity.node_name !== '')
+      )
+    );
+  }
+
   async function waitForEndpointInfo(infoFn, count) {
     const timeout = 5000;
     const start = Date.now();
     let result = infoFn();
-    while (result.length !== count && Date.now() - start < timeout) {
+    while (
+      !isEndpointInfoComplete(result, count) &&
+      Date.now() - start < timeout
+    ) {
       await assertUtils.createDelay(100);
       result = infoFn();
     }

--- a/test/test-action-graph.js
+++ b/test/test-action-graph.js
@@ -254,6 +254,13 @@ describe('rclnodejs action graph', function () {
   });
 
   it('Test countActionClients and countActionServers', async function () {
+    if (
+      rclnodejs.DistroUtils.getDistroId() <
+      rclnodejs.DistroUtils.DistroId.LYRICAL
+    ) {
+      this.skip();
+    }
+
     assert.strictEqual(
       await waitForCount(
         () => node1.countActionClients(`${NODE2_NS}/${ACTION1_NAME}`),
@@ -273,6 +280,13 @@ describe('rclnodejs action graph', function () {
   });
 
   it('Test getActionClientsInfoByAction', async function () {
+    if (
+      rclnodejs.DistroUtils.getDistroId() <
+      rclnodejs.DistroUtils.DistroId.ROLLING
+    ) {
+      this.skip();
+    }
+
     const infos = await waitForEndpointInfo(
       () => node1.getActionClientsInfoByAction(`${NODE2_NS}/${ACTION1_NAME}`),
       1
@@ -306,6 +320,13 @@ describe('rclnodejs action graph', function () {
   });
 
   it('Test getActionServersInfoByAction', async function () {
+    if (
+      rclnodejs.DistroUtils.getDistroId() <
+      rclnodejs.DistroUtils.DistroId.ROLLING
+    ) {
+      this.skip();
+    }
+
     const infos = await waitForEndpointInfo(
       () => node1.getActionServersInfoByAction(`${NODE2_NS}/${ACTION1_NAME}`),
       1

--- a/test/test-action-graph.js
+++ b/test/test-action-graph.js
@@ -64,6 +64,28 @@ describe('rclnodejs action graph', function () {
     return [];
   }
 
+  async function waitForCount(countFn, expected) {
+    const timeout = 5000;
+    const start = Date.now();
+    let actual = countFn();
+    while (actual !== expected && Date.now() - start < timeout) {
+      await assertUtils.createDelay(100);
+      actual = countFn();
+    }
+    return actual;
+  }
+
+  async function waitForEndpointInfo(infoFn, count) {
+    const timeout = 5000;
+    const start = Date.now();
+    let result = infoFn();
+    while (result.length !== count && Date.now() - start < timeout) {
+      await assertUtils.createDelay(100);
+      result = infoFn();
+    }
+    return result;
+  }
+
   before(function () {
     return rclnodejs.init();
   });
@@ -228,6 +250,79 @@ describe('rclnodejs action graph', function () {
     assert.notStrictEqual(
       result.findIndex((r) => r.name === `${NODE3_NS}/${ACTION2_NAME}`),
       -1
+    );
+  });
+
+  it('Test countActionClients and countActionServers', async function () {
+    assert.strictEqual(
+      await waitForCount(
+        () => node1.countActionClients(`${NODE2_NS}/${ACTION1_NAME}`),
+        1
+      ),
+      1
+    );
+    assert.strictEqual(
+      await waitForCount(
+        () => node1.countActionServers(`${NODE2_NS}/${ACTION1_NAME}`),
+        1
+      ),
+      1
+    );
+    assert.strictEqual(node1.countActionClients('/missing_action'), 0);
+    assert.strictEqual(node1.countActionServers('/missing_action'), 0);
+  });
+
+  it('Test getActionClientsInfoByAction', async function () {
+    const infos = await waitForEndpointInfo(
+      () => node1.getActionClientsInfoByAction(`${NODE2_NS}/${ACTION1_NAME}`),
+      1
+    );
+    assert.strictEqual(infos.length, 1);
+    const info = infos[0];
+    assert.ok(info instanceof rclnodejs.ActionEndpointInfo);
+    assert.strictEqual(info.nodeName, NODE2_NAME);
+    assert.strictEqual(info.nodeNamespace, NODE2_NS);
+    assert.strictEqual(info.actionType, fibonacci);
+    assert.strictEqual(
+      info.goalServiceInfo.service_type,
+      `${fibonacci}_SendGoal`
+    );
+    assert.strictEqual(
+      info.cancelServiceInfo.service_type,
+      'action_msgs/srv/CancelGoal'
+    );
+    assert.strictEqual(
+      info.resultServiceInfo.service_type,
+      `${fibonacci}_GetResult`
+    );
+    assert.strictEqual(
+      info.feedbackTopicInfo.topic_type,
+      `${fibonacci}_FeedbackMessage`
+    );
+    assert.strictEqual(
+      info.statusTopicInfo.topic_type,
+      'action_msgs/msg/GoalStatusArray'
+    );
+  });
+
+  it('Test getActionServersInfoByAction', async function () {
+    const infos = await waitForEndpointInfo(
+      () => node1.getActionServersInfoByAction(`${NODE2_NS}/${ACTION1_NAME}`),
+      1
+    );
+    assert.strictEqual(infos.length, 1);
+    const info = infos[0];
+    assert.ok(info instanceof rclnodejs.ActionEndpointInfo);
+    assert.strictEqual(info.nodeName, NODE2_NAME);
+    assert.strictEqual(info.nodeNamespace, NODE2_NS);
+    assert.strictEqual(info.actionType, fibonacci);
+    assert.strictEqual(
+      info.goalServiceInfo.service_type,
+      `${fibonacci}_SendGoal`
+    );
+    assert.strictEqual(
+      info.feedbackTopicInfo.topic_type,
+      `${fibonacci}_FeedbackMessage`
     );
   });
 });

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -107,6 +107,14 @@ expectType<number>(node.countPublishers(TOPIC));
 expectType<number>(node.countSubscribers(TOPIC));
 expectType<number>(node.countClients(SERVICE_NAME));
 expectType<number>(node.countServices(SERVICE_NAME));
+expectType<number | null>(node.countActionClients('action'));
+expectType<number | null>(node.countActionServers('action'));
+expectType<rclnodejs.ActionEndpointInfo[] | null>(
+  node.getActionClientsInfoByAction('action')
+);
+expectType<rclnodejs.ActionEndpointInfo[] | null>(
+  node.getActionServersInfoByAction('action')
+);
 expectType<rclnodejs.Options<string | rclnodejs.QoS>>(
   rclnodejs.Node.getDefaultOptions()
 );

--- a/types/action_endpoint_info.d.ts
+++ b/types/action_endpoint_info.d.ts
@@ -1,0 +1,34 @@
+declare module 'rclnodejs' {
+  interface TopicEndpointInfo {
+    node_name: string;
+    node_namespace: string;
+    topic_type: string;
+    topic_type_hash: object;
+    endpoint_type: number;
+    endpoint_gid: number[];
+    qos_profile: object;
+  }
+
+  interface ServiceEndpointInfo {
+    node_name: string;
+    node_namespace: string;
+    service_type: string;
+    service_type_hash: object;
+    endpoint_type: number;
+    endpoint_count: number;
+    endpoint_gids: number[][];
+    qos_profiles: object[];
+  }
+
+  class ActionEndpointInfo {
+    readonly goalServiceInfo: ServiceEndpointInfo;
+    readonly cancelServiceInfo: ServiceEndpointInfo;
+    readonly resultServiceInfo: ServiceEndpointInfo;
+    readonly feedbackTopicInfo: TopicEndpointInfo;
+    readonly statusTopicInfo: TopicEndpointInfo;
+    readonly nodeName: string;
+    readonly nodeNamespace: string;
+    readonly actionType: string;
+    readonly endpointType: number;
+  }
+}

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -1,4 +1,5 @@
 /// <reference path="./action_client.d.ts" />
+/// <reference path="./action_endpoint_info.d.ts" />
 /// <reference path="./action_server.d.ts" />
 /// <reference path="./action_uuid.d.ts" />
 /// <reference path="./client.d.ts" />

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -931,18 +931,50 @@ declare module 'rclnodejs' {
      */
     getServiceNamesAndTypes(): Array<NamesAndTypesQueryResult>;
 
-    /** Return the number of action clients on an action. */
+    /**
+     * Return the number of action clients on an action.
+     *
+     * @param actionName - The action on which to count the action clients.
+     * @returns The number of action clients, or `null` when the ROS distro is
+     *          older than Lyrical and does not provide action graph counts.
+     */
     countActionClients(actionName: string): number | null;
 
-    /** Return the number of action servers on an action. */
+    /**
+     * Return the number of action servers on an action.
+     *
+     * @param actionName - The action on which to count the action servers.
+     * @returns The number of action servers, or `null` when the ROS distro is
+     *          older than Lyrical and does not provide action graph counts.
+     */
     countActionServers(actionName: string): number | null;
 
-    /** Return endpoint information for action clients on an action. */
+    /**
+     * Return endpoint information for each action client on an action.
+     *
+     * Each entry aggregates the endpoint information of all the underlying
+     * entities of one action client, i.e. the clients of the goal, cancel and
+     * result services and the subscriptions on the feedback and status topics.
+     *
+     * @param actionName - The action on which to find the action clients.
+     * @returns An array of ActionEndpointInfo, or `null` when the ROS distro is
+     *          older than Rolling and does not provide action endpoint information.
+     */
     getActionClientsInfoByAction(
       actionName: string
     ): ActionEndpointInfo[] | null;
 
-    /** Return endpoint information for action servers on an action. */
+    /**
+     * Return endpoint information for each action server on an action.
+     *
+     * Each entry aggregates the endpoint information of all the underlying
+     * entities of one action server, i.e. the servers of the goal, cancel and
+     * result services and the publishers on the feedback and status topics.
+     *
+     * @param actionName - The action on which to find the action servers.
+     * @returns An array of ActionEndpointInfo, or `null` when the ROS distro is
+     *          older than Rolling and does not provide action endpoint information.
+     */
     getActionServersInfoByAction(
       actionName: string
     ): ActionEndpointInfo[] | null;

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -931,6 +931,22 @@ declare module 'rclnodejs' {
      */
     getServiceNamesAndTypes(): Array<NamesAndTypesQueryResult>;
 
+    /** Return the number of action clients on an action. */
+    countActionClients(actionName: string): number | null;
+
+    /** Return the number of action servers on an action. */
+    countActionServers(actionName: string): number | null;
+
+    /** Return endpoint information for action clients on an action. */
+    getActionClientsInfoByAction(
+      actionName: string
+    ): ActionEndpointInfo[] | null;
+
+    /** Return endpoint information for action servers on an action. */
+    getActionServersInfoByAction(
+      actionName: string
+    ): ActionEndpointInfo[] | null;
+
     /**
      * Return a list of publishers on a given topic.
      *


### PR DESCRIPTION
Adds new ROS 2 action-graph query capabilities to rclnodejs, exposing action client/server counts and per-endpoint metadata through the Node API and corresponding TypeScript types.

**Changes:**
- Add `Node.countActionClients/countActionServers` and endpoint-info query APIs for actions.
- Introduce `ActionEndpointInfo` (JS + TS) to represent aggregated action endpoint metadata.
- Extend native graph bindings/utilities and add tests/type-tests for the new APIs.

Fix: #1570