### PR TITLE
Pump mocha to 12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "husky": "^9.1.7",
     "jsdoc": "^4.0.4",
     "lint-staged": "^17.0.0",
-    "mocha": "^11.0.2",
+    "mocha": "^12.0.0",
     "prebuildify": "^6.0.1",
     "rimraf": "^6.0.1",
     "sinon": "^22.0.0",

--- a/scripts/run_test.cjs
+++ b/scripts/run_test.cjs
@@ -16,13 +16,18 @@
 
 const fs = require('fs');
 const utils = require('../lib/utils.js');
-const Mocha = require('mocha');
 const os = require('os');
 const path = require('path');
 
+// mocha@12 is ESM-only; require()'s interop with it isn't stable across
+// Node versions, so import() it instead, started early since this CJS
+// file can't use top-level await.
+const mochaImport = import('mocha');
+
 utils
   .remove(path.join(path.dirname(__dirname), 'generated'))
-  .then(() => {
+  .then(async () => {
+    const { default: Mocha } = await mochaImport;
     let mocha = new Mocha();
     const testDir = path.join(__dirname, '../test/');
     // eslint-disable-next-line


### PR DESCRIPTION
Updates the project’s test runner dev dependency to address Issue #1580 (“Pump mocha”), keeping the repository’s test tooling current with the intended Mocha 12.x line.

**Changes:**
- Bumped `mocha` devDependency from `^11.0.2` to `^12.0.0`.

Fix: #1580 