### PR TITLE
Add Humble to the Windows build-and-test matrix

### DIFF
--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -16,11 +16,16 @@ jobs:
       matrix:
         node-version: [24.X]
         ros_distribution:
+          - humble
           - jazzy
           - kilted
           - lyrical
           - rolling
         include:
+          # Humble Hawksbill (May 2022 - May 2027)
+          - ros_distribution: humble
+            ros_zip_url: "https://github.com/ros2/ros2/releases/download/release-humble-20260220/ros2-humble-20260220-windows-release-amd64.zip"
+            run_tests: false
           - ros_distribution: jazzy
             ros_zip_url: "https://github.com/ros2/ros2/releases/download/release-jazzy-20260128/ros2-jazzy-20260128-windows-release-amd64.zip"
             run_tests: false


### PR DESCRIPTION
`windows-build-and-test.yml` only tested jazzy/kilted/lyrical/rolling, despite `docs/BUILDING.md` documenting Humble as a supported ROS 2 distribution on Windows — zero CI coverage existed for that combination.

- Add `humble` to the matrix, build-only (`run_tests: false`), matching the existing jazzy/kilted pattern — only `lyrical` runs the full test suite on Windows.

Fix: #1583 
