### PR TITLE
[Web runtime] Add action capability dispatch to the Web Runtime

### DIFF
--- a/lib/runtime/capability_registry.js
+++ b/lib/runtime/capability_registry.js
@@ -15,8 +15,8 @@
  * touched.
  *
  * Each capability is a tuple `(kind, name, type)` where:
- *   - `kind` is one of `'call' | 'publish' | 'subscribe'`
- *   - `name` is the ROS 2 service or topic name (e.g. `'/cmd_vel'`)
+ *   - `kind` is one of `'call' | 'publish' | 'subscribe' | 'action'`
+ *   - `name` is the ROS 2 service, topic, or action name (e.g. `'/cmd_vel'`)
  *   - `type` is the ROS 2 interface name (e.g. `'std_msgs/msg/String'`)
  */
 class CapabilityRegistry {
@@ -28,6 +28,7 @@ class CapabilityRegistry {
     this._call = new Map(); //      ROS service name -> srv type
     this._publish = new Map(); //   ROS topic name   -> msg type
     this._subscribe = new Map(); // ROS topic name   -> msg type
+    this._action = new Map(); //    ROS action name  -> action type
   }
 
   /**
@@ -57,6 +58,7 @@ class CapabilityRegistry {
    *   call?:      Object<string, string | {type:string}>,
    *   publish?:   Object<string, string | {type:string}>,
    *   subscribe?: Object<string, string | {type:string}>,
+   *   action?:    Object<string, string | {type:string}>,
    * }} spec
    * @returns {CapabilityRegistry} this (chainable)
    */
@@ -70,12 +72,15 @@ class CapabilityRegistry {
     for (const [name, value] of Object.entries(spec.subscribe || {})) {
       this._subscribe.set(name, _typeOf(value, 'subscribe', name));
     }
+    for (const [name, value] of Object.entries(spec.action || {})) {
+      this._action.set(name, _typeOf(value, 'action', name));
+    }
     return this;
   }
 
   /**
    * Resolve a capability lookup.
-   * @param {'call'|'publish'|'subscribe'} kind
+   * @param {'call'|'publish'|'subscribe'|'action'} kind
    * @param {string} name
    * @returns {{kind:string, name:string, type:string}|null}
    */
@@ -98,6 +103,7 @@ class CapabilityRegistry {
       call: Object.fromEntries(this._call),
       publish: Object.fromEntries(this._publish),
       subscribe: Object.fromEntries(this._subscribe),
+      action: Object.fromEntries(this._action),
     };
   }
 
@@ -105,6 +111,7 @@ class CapabilityRegistry {
     if (kind === 'call') return this._call;
     if (kind === 'publish') return this._publish;
     if (kind === 'subscribe') return this._subscribe;
+    if (kind === 'action') return this._action;
     return null;
   }
 }

--- a/lib/runtime/dispatcher.js
+++ b/lib/runtime/dispatcher.js
@@ -8,6 +8,8 @@
 
 import createDebug from 'debug';
 import { toJSONSafe, reviveBigInts } from '../message_serialization.js';
+import ActionClient from '../action/client.js';
+import ActionInterfaces from '../action/interfaces.js';
 
 const debug = createDebug('rclnodejs:runtime');
 
@@ -41,12 +43,17 @@ class Dispatcher {
    */
   handle(conn) {
     const state = {
-      publishers: new Map(), //    capability name -> Publisher
-      subscriptions: new Map(), // subId           -> { name, Subscription }
-      clients: new Map(), //       capability name -> Client
+      publishers: new Map(), //     capability name -> Publisher
+      subscriptions: new Map(), //  subId           -> { name, Subscription }
+      clients: new Map(), //        capability name -> Client
+      actionClients: new Map(), //  capability name -> ActionClient
+      pendingGoals: new Map(), //   goal id         -> capability name
+      goals: new Map(), //          goal id         -> { name, goalHandle }
+      closed: false,
     };
 
     const cleanup = () => {
+      state.closed = true;
       for (const { subscription } of state.subscriptions.values()) {
         try {
           this.node.destroySubscription(subscription);
@@ -71,6 +78,23 @@ class Dispatcher {
         }
       }
       state.clients.clear();
+      // Deliberately not cancelling in-flight goals here: cancelGoal() is
+      // itself async, and destroying the ActionClient synchronously right
+      // after firing it (without awaiting the response) races the pending
+      // rcl reply — same "client will not receive response" native crash
+      // documented on HttpRequestConnection above. A goal already in flight
+      // when the connection drops just runs to completion server-side;
+      // conn.send() on a closed connection is already a documented no-op.
+      // Deferred one tick: even a goal whose result already arrived can
+      // still have rmw-internal bookkeeping for that exchange settling
+      // asynchronously under the hood: destroying the ActionClient in the
+      // very same tick reproduced this crash. Deferring by one event-loop
+      // turn is enough for that to quiesce.
+      setImmediate(() => {
+        for (const name of state.actionClients.keys()) {
+          _releaseActionClientIfIdle(state, name);
+        }
+      });
     };
 
     conn.on('close', cleanup);
@@ -104,13 +128,7 @@ class Dispatcher {
         case 'unsubscribe':
           return this._handleUnsubscribe(conn, id, frame.subId, state);
         case 'action':
-          conn.send({
-            id,
-            ok: false,
-            error: 'action capabilities are not yet supported',
-            code: 'not_implemented',
-          });
-          return;
+          return this._handleAction(conn, id, capability, frame, state);
         default:
           conn.send({
             id,
@@ -237,6 +255,189 @@ class Dispatcher {
       error: `capability not exposed: ${kind} ${name}`,
       code: 'not_exposed',
     });
+  }
+
+  _handleAction(conn, id, name, frame, state) {
+    const op = frame.op;
+    if (op === 'send_goal') {
+      return this._handleActionSendGoal(conn, id, name, frame.payload, state);
+    }
+    if (op === 'cancel') {
+      return this._handleActionCancel(conn, id, frame.goalId, state);
+    }
+    conn.send({
+      id,
+      ok: false,
+      error: `unknown action op: ${op}`,
+      code: 'unknown_kind',
+    });
+  }
+
+  _handleActionSendGoal(conn, id, name, payload, state) {
+    const { actionClients, pendingGoals, goals } = state;
+    const cap = this.registry.resolve('action', name);
+    if (!cap) return this._notExposed(conn, id, 'action', name);
+    if (id === undefined || id === null) {
+      conn.send({
+        ok: false,
+        error: 'action send_goal requires an id',
+        code: 'missing_id',
+      });
+      return;
+    }
+    if (pendingGoals.has(id) || goals.has(id)) {
+      conn.send({
+        id,
+        ok: false,
+        error: `id already in use: ${id}`,
+        code: 'duplicate_id',
+      });
+      return;
+    }
+    let actionClient = actionClients.get(name);
+    if (!actionClient) {
+      actionClient = new ActionClient(this.node, cap.type, name);
+      actionClients.set(name, actionClient);
+    }
+    const goal = reviveBigInts(payload);
+    const feedbackCallback = (feedback) => {
+      conn.send({
+        event: 'feedback',
+        goalId: id,
+        payload: toJSONSafe(feedback),
+      });
+    };
+    let goalHandle;
+    pendingGoals.set(id, name);
+    let sendGoal;
+    try {
+      sendGoal = actionClient.sendGoal(goal, feedbackCallback);
+    } catch (e) {
+      pendingGoals.delete(id);
+      _releaseActionClientIfIdle(state, name);
+      conn.send({
+        id,
+        ok: false,
+        error: `send_goal failed: ${e.message}`,
+        code: 'action_failed',
+      });
+      return;
+    }
+    sendGoal.then(
+      (handle) => {
+        pendingGoals.delete(id);
+        goalHandle = handle;
+        if (!goalHandle.isAccepted()) {
+          conn.send({
+            id,
+            ok: false,
+            error: 'goal rejected',
+            code: 'goal_rejected',
+          });
+          _releaseActionClientIfIdle(state, name);
+          return;
+        }
+        goals.set(id, { name, goalHandle });
+        conn.send({ id, ok: true, payload: { accepted: true } });
+        goalHandle.getResult().then(
+          (result) => {
+            goals.delete(id);
+            conn.send({
+              event: 'result',
+              goalId: id,
+              payload: toJSONSafe(result),
+              status: _goalStatusName(goalHandle.status),
+            });
+            _releaseActionClientIfIdle(state, name);
+          },
+          (e) => {
+            goals.delete(id);
+            conn.send({
+              event: 'result',
+              goalId: id,
+              ok: false,
+              error: `get result failed: ${e.message}`,
+              code: 'action_failed',
+            });
+            _releaseActionClientIfIdle(state, name);
+          }
+        );
+      },
+      (e) => {
+        pendingGoals.delete(id);
+        conn.send({
+          id,
+          ok: false,
+          error: `send_goal failed: ${e.message}`,
+          code: 'action_failed',
+        });
+        _releaseActionClientIfIdle(state, name);
+      }
+    );
+  }
+
+  _handleActionCancel(conn, id, goalId, { goals }) {
+    if (goalId === undefined || goalId === null) {
+      conn.send({
+        id,
+        ok: false,
+        error: 'action cancel requires goalId',
+        code: 'missing_goal_id',
+      });
+      return;
+    }
+    const entry = goals.get(goalId);
+    if (!entry) {
+      conn.send({
+        id,
+        ok: false,
+        error: `unknown goal: ${goalId}`,
+        code: 'unknown_goal_id',
+      });
+      return;
+    }
+    entry.goalHandle.cancelGoal().then(
+      () => conn.send({ id, ok: true }),
+      (e) =>
+        conn.send({
+          id,
+          ok: false,
+          error: `cancel failed: ${e.message}`,
+          code: 'action_failed',
+        })
+    );
+  }
+}
+
+function _releaseActionClientIfIdle(state, name) {
+  if (!state.closed) return;
+  if ([...state.pendingGoals.values()].includes(name)) return;
+  for (const goal of state.goals.values()) {
+    if (goal.name === name) return;
+  }
+  const actionClient = state.actionClients.get(name);
+  if (!actionClient) return;
+  state.actionClients.delete(name);
+  setImmediate(() => {
+    try {
+      actionClient.destroy();
+    } catch {
+      /* destroy is best-effort during connection teardown */
+    }
+  });
+}
+
+/** Map a numeric `GoalStatus` constant to the wire's lowercase status name. */
+function _goalStatusName(status) {
+  switch (status) {
+    case ActionInterfaces.GoalStatus.STATUS_SUCCEEDED:
+      return 'succeeded';
+    case ActionInterfaces.GoalStatus.STATUS_CANCELED:
+      return 'canceled';
+    case ActionInterfaces.GoalStatus.STATUS_ABORTED:
+      return 'aborted';
+    default:
+      return 'unknown';
   }
 }
 

--- a/lib/runtime/index.d.ts
+++ b/lib/runtime/index.d.ts
@@ -15,7 +15,7 @@
 
 import type { Node } from 'rclnodejs';
 
-export type CapabilityKind = 'call' | 'publish' | 'subscribe';
+export type CapabilityKind = 'call' | 'publish' | 'subscribe' | 'action';
 
 /** A single capability entry as resolved from the registry. */
 export interface Capability {
@@ -34,6 +34,7 @@ export interface ExposeSpec {
   call?: CapabilityMap;
   publish?: CapabilityMap;
   subscribe?: CapabilityMap;
+  action?: CapabilityMap;
 }
 
 /** Snapshot returned by `CapabilityRegistry.list()`. */
@@ -41,6 +42,7 @@ export interface RegistrySnapshot {
   call: Record<string, string>;
   publish: Record<string, string>;
   subscribe: Record<string, string>;
+  action: Record<string, string>;
 }
 
 /**
@@ -66,6 +68,8 @@ export interface CapabilityFrame {
   capability?: string;
   payload?: unknown;
   subId?: string | number;
+  op?: 'send_goal' | 'cancel';
+  goalId?: string | number;
   ok?: boolean;
   event?: string;
   error?: string;

--- a/lib/runtime/transports/http.js
+++ b/lib/runtime/transports/http.js
@@ -30,6 +30,10 @@ const _STATUS_BY_CODE = Object.freeze({
   call_failed: 500,
   publish_failed: 500,
   schema_violation: 400,
+  goal_rejected: 409,
+  action_failed: 500,
+  unknown_goal_id: 400,
+  missing_goal_id: 400,
 });
 
 const _MAX_BODY_BYTES = 1 * 1024 * 1024; // 1 MiB cap on request bodies
@@ -352,12 +356,182 @@ class HttpSseConnection extends Connection {
 }
 
 /**
+ * A long-lived {@link Connection} that streams a single action goal over
+ * Server-Sent Events (`text/event-stream`).
+ *
+ * One request → one goal. Drives the dispatcher with a single `action`
+ * `send_goal` frame, then relays `feedback` events and the terminal
+ * `result` event as SSE lines. Unlike {@link HttpSseConnection}, the
+ * stream always closes itself after the result — there is no ongoing
+ * subscription to keep open.
+ *
+ * No cancellation support: HTTP has no client→server back-channel once
+ * the request body is sent, so there is nowhere to carry a `cancel` frame.
+ * A goal that is sent runs to completion (or failure) server-side even if
+ * the client disconnects early. Use the WebSocket transport for
+ * cancelable actions.
+ */
+class HttpActionConnection extends Connection {
+  /**
+   * @param {import('http').IncomingMessage} req
+   * @param {import('http').ServerResponse} res
+   * @param {string} capability  ROS action name to send the goal to.
+   * @param {*} payload  The goal, parsed from the request body.
+   */
+  constructor(req, res, capability, payload) {
+    super();
+    this.req = req;
+    this.res = res;
+    this._capability = capability;
+    this._payload = payload;
+    this._streaming = false;
+    this._closed = false;
+    // Fixed goal id: one HTTP request carries exactly one goal.
+    this._goalId = 'http-action';
+
+    // Only `res` close signals a genuine client disconnect here. Unlike
+    // HttpSseConnection's GET requests (no body), this is a POST whose body
+    // was already fully read by `_readJsonBody` before this connection is
+    // even constructed — `req`'s own 'close' fires once that read completes,
+    // which is *not* a disconnect. Wiring it (as tried during development)
+    // ends the response prematurely, mid-goal, racing the still-in-flight
+    // rcl reply — the same hazard documented on HttpRequestConnection above.
+    const onClose = () => this._emitCloseOnce();
+    res.on('close', onClose);
+    res.on('error', (e) => {
+      debug('action sse response error: %s', e.message);
+      this._emitCloseOnce();
+    });
+  }
+
+  /** Kick off dispatch: emit a single `action` `send_goal` frame. */
+  begin() {
+    this.emit('message', {
+      id: this._goalId,
+      kind: 'action',
+      op: 'send_goal',
+      capability: this._capability,
+      payload: this._payload,
+    });
+  }
+
+  send(frame) {
+    if (this._closed) return;
+
+    // Feedback delivery — zero or more, only while streaming.
+    if (frame.event === 'feedback') {
+      this._ensureStream();
+      this._writeEvent('feedback', frame.payload);
+      return;
+    }
+
+    // Terminal result — exactly one, then the stream closes.
+    if (frame.event === 'result') {
+      this._ensureStream();
+      if (frame.ok === false) {
+        this._writeEvent('error', { error: frame.error, code: frame.code });
+      } else {
+        this._writeEvent('result', frame.payload, { status: frame.status });
+      }
+      return this._emitCloseOnce();
+    }
+
+    // Goal accepted: switch the response into an event stream.
+    if (frame.ok === true) {
+      this._ensureStream();
+      this._writeEvent('accepted', { capability: this._capability });
+      return;
+    }
+
+    // Goal rejected, or send_goal itself failed — headers not sent yet,
+    // surface as a normal HTTP error rather than an SSE stream.
+    const code = frame.code || 'internal_error';
+    const status = _STATUS_BY_CODE[code] || 500;
+    this._writeError(status, code, frame.error || 'send_goal failed');
+    this._emitCloseOnce();
+  }
+
+  /** Force-close the response. The dispatcher's `cleanup` will follow. */
+  // eslint-disable-next-line no-unused-vars
+  close(code, reason) {
+    this._emitCloseOnce();
+  }
+
+  _ensureStream() {
+    if (this._streaming) return;
+    this._streaming = true;
+    this.res.writeHead(200, {
+      'content-type': 'text/event-stream; charset=utf-8',
+      'cache-control': 'no-cache, no-transform',
+      connection: 'keep-alive',
+      'x-accel-buffering': 'no',
+    });
+    if (typeof this.res.flushHeaders === 'function') {
+      this.res.flushHeaders();
+    }
+  }
+
+  _writeEvent(event, data, extra) {
+    if (this._closed) return;
+    const json = JSON.stringify(
+      extra ? { ...extra, payload: data } : (data ?? null)
+    );
+    let chunk = `event: ${event}\n`;
+    for (const line of json.split('\n')) {
+      chunk += `data: ${line}\n`;
+    }
+    chunk += '\n';
+    try {
+      this.res.write(chunk);
+    } catch (e) {
+      debug('action sse write failed: %s', e.message);
+      this._emitCloseOnce();
+    }
+  }
+
+  _writeError(status, code, message) {
+    const body = JSON.stringify({ ok: false, error: message, code });
+    try {
+      this.res.writeHead(status, {
+        'content-type': 'application/json; charset=utf-8',
+        'content-length': Buffer.byteLength(body),
+      });
+      this.res.end(body);
+    } catch (e) {
+      debug('action sse writeError failed: %s', e.message);
+    }
+  }
+
+  _emitCloseOnce() {
+    if (this._closed) return;
+    this._closed = true;
+    try {
+      this.res.end();
+    } catch {
+      /* response may already be finished */
+    }
+    this.emit('close');
+  }
+}
+
+/**
  * HTTP adapter for the Web Runtime.
  *
  * Exposes `call` and `publish` capabilities over plain HTTP:
  *
  *     POST /capability/call/<name>
  *     POST /capability/publish/<name>
+ *
+ * Also exposes `action` capabilities as a one-shot streaming request:
+ *
+ *     POST /capability/action/<name>     (text/event-stream response)
+ *
+ * The goal is sent as the JSON body; the response streams `accepted`,
+ * zero or more `feedback` events, then exactly one terminal `result`
+ * event before closing. There is no way to cancel an in-flight goal over
+ * HTTP (no back-channel once the request is sent) — use the WebSocket
+ * transport if cancellation is required. A client that disconnects
+ * early does not cancel the goal server-side; it runs to completion.
  *
  * When `sse: true`, it additionally exposes `subscribe` as a Server-Sent
  * Events stream:
@@ -567,10 +741,10 @@ class HttpTransport extends TransportAdapter {
       return;
     }
 
-    if (kind !== 'call' && kind !== 'publish') {
+    if (kind !== 'call' && kind !== 'publish' && kind !== 'action') {
       return _writeJson(res, 404, {
         ok: false,
-        error: `unsupported kind over HTTP: ${kind} (use WebSocket for action)`,
+        error: `unsupported kind over HTTP: ${kind}`,
         code: 'unsupported_kind',
       });
     }
@@ -590,7 +764,10 @@ class HttpTransport extends TransportAdapter {
         const status = code === 'payload_too_large' ? 413 : 400;
         return _writeJson(res, status, { ok: false, error: err.message, code });
       }
-      const conn = new HttpRequestConnection(req, res, kind, name, payload);
+      const conn =
+        kind === 'action'
+          ? new HttpActionConnection(req, res, name, payload)
+          : new HttpRequestConnection(req, res, kind, name, payload);
       try {
         this._onConnection(conn);
         conn.begin();

--- a/test/test-runtime.js
+++ b/test/test-runtime.js
@@ -22,22 +22,30 @@ describe('CapabilityRegistry (unit)', function () {
       call: { '/add': 'example_interfaces/srv/AddTwoInts' },
       publish: { '/chatter': { type: 'std_msgs/msg/String' } },
       subscribe: { '/scan': 'sensor_msgs/msg/LaserScan' },
+      action: { '/fibonacci': 'example_interfaces/action/Fibonacci' },
     });
     assert.deepStrictEqual(reg.list(), {
       call: { '/add': 'example_interfaces/srv/AddTwoInts' },
       publish: { '/chatter': 'std_msgs/msg/String' },
       subscribe: { '/scan': 'sensor_msgs/msg/LaserScan' },
+      action: { '/fibonacci': 'example_interfaces/action/Fibonacci' },
     });
   });
 
   it('resolve() returns the matching capability or null', function () {
     const reg = new CapabilityRegistry().expose({
       call: { '/add': 'example_interfaces/srv/AddTwoInts' },
+      action: { '/fibonacci': 'example_interfaces/action/Fibonacci' },
     });
     assert.deepStrictEqual(reg.resolve('call', '/add'), {
       kind: 'call',
       name: '/add',
       type: 'example_interfaces/srv/AddTwoInts',
+    });
+    assert.deepStrictEqual(reg.resolve('action', '/fibonacci'), {
+      kind: 'action',
+      name: '/fibonacci',
+      type: 'example_interfaces/action/Fibonacci',
     });
     assert.strictEqual(reg.resolve('call', '/missing'), null);
     assert.strictEqual(reg.resolve('publish', '/add'), null);
@@ -140,7 +148,7 @@ describe('Web Runtime end-to-end (WebSocket transport)', function () {
     ws.close();
   });
 
-  it('reserves kind:action with code:not_implemented', async function () {
+  it('rejects an action frame with a missing/unknown op with code:unknown_kind', async function () {
     const ws = new WebSocket(url());
     await waitOpen(ws);
     const replyP = waitFrame(ws, (f) => f.id === 'a1');
@@ -149,7 +157,26 @@ describe('Web Runtime end-to-end (WebSocket transport)', function () {
     );
     const reply = await replyP;
     assert.strictEqual(reply.ok, false);
-    assert.strictEqual(reply.code, 'not_implemented');
+    assert.strictEqual(reply.code, 'unknown_kind');
+    ws.close();
+  });
+
+  it('rejects action send_goal against an unexposed capability with code:not_exposed', async function () {
+    const ws = new WebSocket(url());
+    await waitOpen(ws);
+    const replyP = waitFrame(ws, (f) => f.id === 'a2');
+    ws.send(
+      JSON.stringify({
+        id: 'a2',
+        kind: 'action',
+        op: 'send_goal',
+        capability: '/anything',
+        payload: {},
+      })
+    );
+    const reply = await replyP;
+    assert.strictEqual(reply.ok, false);
+    assert.strictEqual(reply.code, 'not_exposed');
     ws.close();
   });
 

--- a/test/test-web-action.js
+++ b/test/test-web-action.js
@@ -1,0 +1,356 @@
+// Copyright (c) 2026 RobotWebTools Contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Action capability dispatch coverage: raw wire-protocol frames (mirroring
+// test-runtime.js) plus SDK-level (`rclnodejs/web`) round-trips over both
+// the WebSocket and HTTP transports.
+
+import assert from 'assert';
+import http from 'node:http';
+import WebSocket from 'ws';
+import rclnodejs from '../index.js';
+import {
+  createRuntime,
+  WebSocketTransport,
+  HttpTransport,
+} from '../lib/runtime/index.js';
+import * as assertUtils from './utils.js';
+
+// `web/` is ESM; dynamic import() defers loading the browser SDK until the test starts.
+let connect;
+before(async function () {
+  ({ connect } = await import('../web/index.js'));
+});
+
+describe('Action capability dispatch', function () {
+  this.timeout(60 * 1000);
+
+  const fibonacci = 'example_interfaces/action/Fibonacci';
+  let Fibonacci;
+  let node;
+  let runtime;
+  let server;
+  let wsUrl;
+  let httpUrl;
+
+  function waitOpen(ws) {
+    return new Promise((resolve, reject) => {
+      ws.once('open', resolve);
+      ws.once('error', reject);
+    });
+  }
+
+  function waitFrame(ws, predicate) {
+    return new Promise((resolve) => {
+      const onMsg = (data) => {
+        const frame = JSON.parse(data.toString('utf8'));
+        if (predicate(frame)) {
+          ws.off('message', onMsg);
+          resolve(frame);
+        }
+      };
+      ws.on('message', onMsg);
+    });
+  }
+
+  // Long enough to leave a window for feedback/cancel to land before the
+  // goal finishes, short enough to keep the suite fast.
+  async function executeCallback(goalHandle) {
+    const feedback = new Fibonacci.Feedback();
+    feedback.sequence = [1, 1];
+    goalHandle.publishFeedback(feedback);
+    await assertUtils.createDelay(50);
+    if (goalHandle.isCancelRequested) {
+      goalHandle.canceled();
+      return new Fibonacci.Result();
+    }
+    await assertUtils.createDelay(50);
+    goalHandle.succeed();
+    const result = new Fibonacci.Result();
+    result.sequence = [1, 1, 2, 3];
+    return result;
+  }
+
+  function cancelCallback() {
+    return rclnodejs.CancelResponse.ACCEPT;
+  }
+
+  before(async function () {
+    await rclnodejs.init();
+    Fibonacci = rclnodejs.require(fibonacci);
+    node = rclnodejs.createNode('action_dispatch_test_node');
+    rclnodejs.spin(node);
+
+    server = new rclnodejs.ActionServer(
+      node,
+      fibonacci,
+      '/fibonacci',
+      executeCallback,
+      null,
+      null,
+      cancelCallback
+    );
+
+    runtime = createRuntime({
+      node,
+      transports: [
+        new WebSocketTransport({ port: 0, host: '127.0.0.1' }),
+        new HttpTransport({ port: 0, host: '127.0.0.1' }),
+      ],
+    });
+    runtime.expose({ action: { '/fibonacci': fibonacci } });
+    await runtime.start();
+    wsUrl = `ws://127.0.0.1:${runtime.transports[0].port}/capability`;
+    httpUrl = `http://127.0.0.1:${runtime.transports[1].port}`;
+  });
+
+  after(async function () {
+    if (server) server.destroy();
+    if (runtime) await runtime.stop();
+    rclnodejs.shutdown();
+  });
+
+  describe('wire protocol (WebSocket)', function () {
+    it('rejects send_goal against an unexposed action with code:not_exposed', async function () {
+      const ws = new WebSocket(wsUrl);
+      await waitOpen(ws);
+      const replyP = waitFrame(ws, (f) => f.id === 'g1');
+      ws.send(
+        JSON.stringify({
+          id: 'g1',
+          kind: 'action',
+          op: 'send_goal',
+          capability: '/no_such_action',
+          payload: {},
+        })
+      );
+      const reply = await replyP;
+      assert.strictEqual(reply.ok, false);
+      assert.strictEqual(reply.code, 'not_exposed');
+      ws.close();
+    });
+
+    it('accepts a goal, streams feedback, then a terminal result', async function () {
+      const ws = new WebSocket(wsUrl);
+      await waitOpen(ws);
+      const ackP = waitFrame(ws, (f) => f.id === 'g2');
+      const feedbackP = waitFrame(
+        ws,
+        (f) => f.event === 'feedback' && f.goalId === 'g2'
+      );
+      const resultP = waitFrame(
+        ws,
+        (f) => f.event === 'result' && f.goalId === 'g2'
+      );
+      ws.send(
+        JSON.stringify({
+          id: 'g2',
+          kind: 'action',
+          op: 'send_goal',
+          capability: '/fibonacci',
+          payload: { order: 5 },
+        })
+      );
+      const ack = await ackP;
+      assert.strictEqual(ack.ok, true);
+      assert.strictEqual(ack.payload.accepted, true);
+
+      const feedback = await feedbackP;
+      assert.deepStrictEqual(feedback.payload.sequence, [1, 1]);
+
+      const result = await resultP;
+      assert.strictEqual(result.status, 'succeeded');
+      assert.deepStrictEqual(result.payload.sequence, [1, 1, 2, 3]);
+      ws.close();
+    });
+
+    it('cancels an in-flight goal', async function () {
+      const ws = new WebSocket(wsUrl);
+      await waitOpen(ws);
+      const ackP = waitFrame(ws, (f) => f.id === 'g3');
+      ws.send(
+        JSON.stringify({
+          id: 'g3',
+          kind: 'action',
+          op: 'send_goal',
+          capability: '/fibonacci',
+          payload: { order: 5 },
+        })
+      );
+      await ackP;
+
+      const resultP = waitFrame(
+        ws,
+        (f) => f.event === 'result' && f.goalId === 'g3'
+      );
+      const cancelAckP = waitFrame(ws, (f) => f.id === 'c1');
+      ws.send(
+        JSON.stringify({
+          id: 'c1',
+          kind: 'action',
+          op: 'cancel',
+          goalId: 'g3',
+        })
+      );
+      const cancelAck = await cancelAckP;
+      assert.strictEqual(cancelAck.ok, true);
+
+      const result = await resultP;
+      assert.strictEqual(result.status, 'canceled');
+      ws.close();
+    });
+
+    it('rejects cancel of an unknown goal with code:unknown_goal_id', async function () {
+      const ws = new WebSocket(wsUrl);
+      await waitOpen(ws);
+      const replyP = waitFrame(ws, (f) => f.id === 'c2');
+      ws.send(
+        JSON.stringify({
+          id: 'c2',
+          kind: 'action',
+          op: 'cancel',
+          goalId: 'no-such-goal',
+        })
+      );
+      const reply = await replyP;
+      assert.strictEqual(reply.ok, false);
+      assert.strictEqual(reply.code, 'unknown_goal_id');
+      ws.close();
+    });
+
+    it('rejects a duplicate goal id while the first send is pending', async function () {
+      const ws = new WebSocket(wsUrl);
+      await waitOpen(ws);
+      const duplicateP = waitFrame(
+        ws,
+        (f) => f.id === 'duplicate' && f.code === 'duplicate_id'
+      );
+      const frame = JSON.stringify({
+        id: 'duplicate',
+        kind: 'action',
+        op: 'send_goal',
+        capability: '/fibonacci',
+        payload: { order: 5 },
+      });
+      ws.send(frame);
+      ws.send(frame);
+      const duplicate = await duplicateP;
+      assert.strictEqual(duplicate.ok, false);
+      ws.close();
+    });
+
+    it('survives disconnect while send_goal is pending', async function () {
+      const ws = new WebSocket(wsUrl);
+      await waitOpen(ws);
+      ws.send(
+        JSON.stringify({
+          id: 'disconnect',
+          kind: 'action',
+          op: 'send_goal',
+          capability: '/fibonacci',
+          payload: { order: 5 },
+        })
+      );
+      ws.close();
+      await assertUtils.createDelay(200);
+
+      const probe = new WebSocket(wsUrl);
+      await waitOpen(probe);
+      probe.close();
+    });
+  });
+
+  describe('SDK (rclnodejs/web)', function () {
+    it('sends a goal over WebSocket and awaits the result, with feedback', async function () {
+      const ros = await connect(wsUrl);
+      try {
+        const feedbacks = [];
+        const goal = await ros.action(
+          '/fibonacci',
+          { order: 5 },
+          { onFeedback: (fb) => feedbacks.push(fb) }
+        );
+        const result = await goal.result;
+        assert.deepStrictEqual(result.sequence, [1, 1, 2, 3]);
+        assert.strictEqual(feedbacks.length, 1);
+        assert.deepStrictEqual(feedbacks[0].sequence, [1, 1]);
+      } finally {
+        await ros.close();
+      }
+    });
+
+    it('cancels a goal over WebSocket', async function () {
+      const ros = await connect(wsUrl);
+      try {
+        const goal = await ros.action('/fibonacci', { order: 5 });
+        await assertUtils.createDelay(20);
+        await goal.cancel();
+        const result = await goal.result;
+        assert.deepStrictEqual(result, { sequence: [] });
+      } finally {
+        await ros.close();
+      }
+    });
+
+    it('sends a goal over HTTP (SSE) and awaits the result, with feedback', async function () {
+      const ros = await connect(httpUrl);
+      try {
+        const feedbacks = [];
+        const goal = await ros.action(
+          '/fibonacci',
+          { order: 5 },
+          { onFeedback: (fb) => feedbacks.push(fb) }
+        );
+        const result = await goal.result;
+        assert.deepStrictEqual(result.sequence, [1, 1, 2, 3]);
+        assert.strictEqual(feedbacks.length, 1);
+        assert.deepStrictEqual(feedbacks[0].sequence, [1, 1]);
+      } finally {
+        await ros.close();
+      }
+    });
+
+    it('rejects cancel over HTTP with code:unsupported_kind', async function () {
+      const ros = await connect(httpUrl);
+      try {
+        const goal = await ros.action('/fibonacci', { order: 5 });
+        await assert.rejects(goal.cancel(), (err) => {
+          assert.strictEqual(err.code, 'unsupported_kind');
+          return true;
+        });
+        await goal.result;
+      } finally {
+        await ros.close();
+      }
+    });
+
+    it('rejects when an HTTP action stream ends without a result', async function () {
+      const truncatedServer = http.createServer((req, res) => {
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        res.end('event: accepted\ndata: {}\n\n');
+      });
+      await new Promise((resolve) =>
+        truncatedServer.listen(0, '127.0.0.1', resolve)
+      );
+      const address = truncatedServer.address();
+      const ros = await connect(`http://127.0.0.1:${address.port}`);
+      try {
+        const goal = await ros.action('/fibonacci', { order: 5 });
+        await assert.rejects(goal.result, (err) => {
+          assert.strictEqual(err.code, 'connection_lost');
+          return true;
+        });
+      } finally {
+        await ros.close();
+        await new Promise((resolve, reject) =>
+          truncatedServer.close((err) => (err ? reject(err) : resolve()))
+        );
+      }
+    });
+  });
+});

--- a/web/client.js
+++ b/web/client.js
@@ -97,6 +97,7 @@ class _WsLink {
     this._ws = null;
     this._pending = new Map();
     this._subs = new Map();
+    this._goals = new Map(); // goal id -> { onFeedback, resolveResult, rejectResult }
     this._closed = false;
     this._isUserClosed = false;
     this._isReconnecting = false;
@@ -218,6 +219,48 @@ class _WsLink {
   publish(capability, payload) {
     return this._request({ kind: 'publish', capability, payload });
   }
+  action(capability, payload, { onFeedback } = {}) {
+    if (this._isReconnecting) {
+      return Promise.reject(_connectionLostError());
+    }
+    const id = _genId();
+    // Registered synchronously, before the frame is even sent: feedback is
+    // delivered over a separate topic subscription from the goal-accept
+    // service response, so a feedback frame can race ahead of the accept
+    // ack. If _goals isn't populated yet when that happens, the feedback
+    // is silently dropped (no id to route it to).
+    let resolveResult, rejectResult;
+    const result = new Promise((res, rej) => {
+      resolveResult = res;
+      rejectResult = rej;
+    });
+    this._goals.set(id, { onFeedback, resolveResult, rejectResult });
+    return new Promise((resolve, reject) => {
+      this._pending.set(id, {
+        resolve: () => {
+          resolve({
+            goalId: id,
+            result,
+            cancel: () => this._cancelGoal(id),
+          });
+        },
+        reject: (err) => {
+          this._goals.delete(id); // goal was never accepted; nothing to route to
+          reject(err);
+        },
+      });
+      this._sendRaw({
+        id,
+        kind: 'action',
+        op: 'send_goal',
+        capability,
+        payload,
+      });
+    });
+  }
+  _cancelGoal(goalId) {
+    return this._request({ kind: 'action', op: 'cancel', goalId });
+  }
   subscribe(capability, callback) {
     if (this._isReconnecting) {
       return Promise.reject(_connectionLostError());
@@ -333,6 +376,33 @@ class _WsLink {
       }
       return;
     }
+    if (frame.event === 'feedback') {
+      const goal = this._goals.get(frame.goalId);
+      if (goal && goal.onFeedback) {
+        try {
+          goal.onFeedback(frame.payload);
+        } catch (_) {
+          // user callback errors don't break the dispatch loop
+        }
+      }
+      return;
+    }
+    if (frame.event === 'result') {
+      const goal = this._goals.get(frame.goalId);
+      this._goals.delete(frame.goalId);
+      if (goal) {
+        if (frame.ok === false) {
+          goal.rejectResult(
+            Object.assign(new Error(frame.error || 'action failed'), {
+              code: frame.code,
+            })
+          );
+        } else {
+          goal.resolveResult(frame.payload);
+        }
+      }
+      return;
+    }
     const pend = this._pending.get(frame.id);
     if (!pend) return;
     this._pending.delete(frame.id);
@@ -351,6 +421,10 @@ class _WsLink {
       p.reject(cause);
     }
     this._pending.clear();
+    for (const goal of this._goals.values()) {
+      goal.rejectResult(cause);
+    }
+    this._goals.clear();
   }
 }
 
@@ -390,6 +464,59 @@ class _HttpLink {
 
   publish(capability, payload) {
     return this._fetch('publish', capability, payload, /* expectBody */ false);
+  }
+
+  /**
+   * Send an action goal over HTTP. The response streams `feedback`
+   * events (relayed to `onFeedback`) and one terminal `result` event.
+   * No cancellation support over HTTP — the returned handle's `cancel()`
+   * always rejects with `code: 'unsupported_kind'`. Use the WebSocket
+   * transport for cancelable actions.
+   */
+  async action(capability, payload, { onFeedback } = {}) {
+    const url = this.baseUrl + '/action/' + _encodeRosName(capability);
+    let res;
+    try {
+      res = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload ?? {}),
+      });
+    } catch (e) {
+      throw Object.assign(new Error(`HTTP request failed: ${e.message}`), {
+        code: 'network_error',
+      });
+    }
+
+    if (!res.ok || !res.body) {
+      let err = {};
+      try {
+        err = await res.json();
+      } catch (_) {
+        // non-JSON error body; fall back to the generic message below
+      }
+      throw Object.assign(new Error(err.error || `HTTP ${res.status}`), {
+        code: err.code || 'http_' + res.status,
+        status: res.status,
+      });
+    }
+
+    let resolveResult, rejectResult;
+    const result = new Promise((res2, rej2) => {
+      resolveResult = res2;
+      rejectResult = rej2;
+    });
+    _pumpActionStream(res.body, onFeedback, resolveResult, rejectResult);
+    return {
+      goalId: 'http-action',
+      result,
+      cancel: () =>
+        Promise.reject(
+          Object.assign(new Error('action cancel is not supported over HTTP'), {
+            code: 'unsupported_kind',
+          })
+        ),
+    };
   }
 
   async _fetch(kind, capability, payload, expectBody) {
@@ -444,6 +571,85 @@ function _connectionLostError(reconnecting = true) {
     ),
     { code: 'connection_lost' }
   );
+}
+
+/**
+ * Read an SSE response body (from an action `fetch()`), relaying
+ * `feedback` events to `onFeedback` and settling `result`/`error` events
+ * against the goal's result promise. Runs detached from the caller’s
+ * await chain — the returned handle's `result` promise is what the
+ * caller actually awaits.
+ */
+async function _pumpActionStream(
+  body,
+  onFeedback,
+  resolveResult,
+  rejectResult
+) {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let idx;
+      while ((idx = buffer.indexOf('\n\n')) !== -1) {
+        const chunk = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 2);
+        const { event, data } = _parseSseChunk(chunk);
+        if (event === 'feedback' && onFeedback) {
+          try {
+            onFeedback(data);
+          } catch (_) {
+            // user callback errors don't break the stream
+          }
+        } else if (event === 'result') {
+          resolveResult(
+            data && data.payload !== undefined ? data.payload : data
+          );
+          return;
+        } else if (event === 'error') {
+          rejectResult(
+            Object.assign(new Error((data && data.error) || 'action failed'), {
+              code: data && data.code,
+            })
+          );
+          return;
+        }
+      }
+    }
+    rejectResult(
+      Object.assign(new Error('action stream ended before a terminal result'), {
+        code: 'connection_lost',
+      })
+    );
+  } catch (e) {
+    rejectResult(
+      Object.assign(new Error(`action stream read failed: ${e.message}`), {
+        code: 'network_error',
+      })
+    );
+  }
+}
+
+/** Parse one `event:`/`data:` SSE block into `{event, data}`. */
+function _parseSseChunk(chunk) {
+  let event = 'message';
+  const dataLines = [];
+  for (const line of chunk.split('\n')) {
+    if (line.startsWith('event:')) event = line.slice(6).trim();
+    else if (line.startsWith('data:'))
+      dataLines.push(line.slice(5).replace(/^ /, ''));
+  }
+  let data;
+  try {
+    data = JSON.parse(dataLines.join('\n'));
+  } catch (_) {
+    data = undefined;
+  }
+  return { event, data };
 }
 
 // ROS names always start with `/`. Encode each path segment so that
@@ -640,6 +846,22 @@ export class RosClient {
     }
     const ws = await this._ensureWs();
     return ws.subscribe(capability, callback);
+  }
+
+  /**
+   * Send an action goal. Returns `{ goalId, result, cancel() }` where
+   * `result` is a Promise resolving with the action result, and `cancel()`
+   * requests cancellation — WebSocket only; over an HTTP-only connection
+   * `cancel()` rejects with `code: 'unsupported_kind'`.
+   * @param {string} capability
+   * @param {*} payload The goal.
+   * @param {object} [options]
+   * @param {(feedback: *) => void} [options.onFeedback]
+   */
+  async action(capability, payload, options) {
+    if (this._http) return this._http.action(capability, payload, options);
+    const ws = await this._ensureWs();
+    return ws.action(capability, payload, options);
   }
 }
 

--- a/web/index.d.ts
+++ b/web/index.d.ts
@@ -98,6 +98,24 @@ declare module 'rclnodejs/web' {
     InstanceType<_SvcCtor<TName>['Response']>
   >;
 
+  /** ROS 2 action type names available in the sourced environment. */
+  export type ActionName = keyof import('rclnodejs').ActionsMap;
+
+  /** Wire shape of the named action's goal request. */
+  export type ActionGoal<TName extends ActionName> = WireType<
+    import('rclnodejs').ActionGoal<TName>
+  >;
+
+  /** Wire shape of the named action's feedback message. */
+  export type ActionFeedback<TName extends ActionName> = WireType<
+    import('rclnodejs').ActionFeedback<TName>
+  >;
+
+  /** Wire shape of the named action's result. */
+  export type ActionResult<TName extends ActionName> = WireType<
+    import('rclnodejs').ActionResult<TName>
+  >;
+
   // -------- SDK ------------------------------------------------------
 
   /**
@@ -107,6 +125,21 @@ declare module 'rclnodejs/web' {
   export interface Subscription {
     readonly subId: string;
     close(): Promise<void>;
+  }
+
+  /**
+   * Handle for an in-flight action goal, returned by {@link RosClient.action}.
+   *
+   * `cancel()` requests cancellation of the goal — WebSocket transport
+   * only. Over an HTTP-only connection (no WebSocket sibling), `cancel()`
+   * rejects with `code: 'unsupported_kind'`: HTTP has no back-channel once
+   * the goal request is sent, so a goal sent over HTTP always runs to
+   * completion server-side even if the caller gives up on it.
+   */
+  export interface ActionHandle<TResult = unknown> {
+    readonly goalId: string;
+    readonly result: Promise<TResult>;
+    cancel(): Promise<void>;
   }
 
   export interface ConnectOptions {
@@ -228,6 +261,30 @@ declare module 'rclnodejs/web' {
       capability: string,
       callback: (msg: unknown) => void
     ): Promise<Subscription>;
+
+    /**
+     * Send an action goal.
+     *
+     * @example Typed via the ROS action type name (preferred)
+     *   const goal = await ros.action<'example_interfaces/action/Fibonacci'>(
+     *     '/fibonacci', { order: 5 }, { onFeedback: (fb) => console.log(fb) }
+     *   );
+     *   const result = await goal.result;
+     *
+     * @example Untyped (capability with a custom type not in the
+     *          generated maps, or quick prototyping)
+     *   const goal = await ros.action('/whatever', { foo: 1 });
+     */
+    action<TName extends ActionName>(
+      capability: string,
+      goal: ActionGoal<TName>,
+      options?: { onFeedback?: (feedback: ActionFeedback<TName>) => void }
+    ): Promise<ActionHandle<ActionResult<TName>>>;
+    action(
+      capability: string,
+      goal: unknown,
+      options?: { onFeedback?: (feedback: unknown) => void }
+    ): Promise<ActionHandle>;
   }
 
   /**


### PR DESCRIPTION
- Add allow-listed action capabilities with goal, feedback, result, and cancellation support.
- Support actions over WebSocket and HTTP/SSE in the browser SDK, including typed action APIs.
- Add `--action` support to the `rclnodejs-web` CLI and runtime declarations.
- Safely manage pending goals, duplicate IDs, disconnects, and action-client cleanup.
- Handle truncated and CRLF-framed SSE streams.
- Add WebSocket, HTTP, CLI, cancellation, lifecycle, and error-path tests.

Fix: #1579