### PR TITLE
[Web runtime] Add core action capability dispatch (1/3)

### DIFF
--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -52,6 +52,12 @@ jobs:
             docker_image: ubuntu:resolute
             ros_distribution: rolling
             ros_tar_url: "https://github.com/ros2/ros2/releases/download/release-rolling-nightlies/ros2-rolling-nightly-linux-amd64.tar.bz2"
+          - node-version: 26.X
+            architecture: x64
+            docker_image: ubuntu:resolute
+            ros_distribution: rolling
+            ros_tar_url: "https://github.com/ros2/ros2/releases/download/release-rolling-nightlies/ros2-rolling-nightly-linux-amd64.tar.bz2"
+            test_suite: idl
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
       uses: actions/setup-node@v7
@@ -101,6 +107,7 @@ jobs:
         sudo apt install -y ros-${{ matrix.ros_distribution }}-test-msgs ros-${{ matrix.ros_distribution }}-mrpt-msgs
 
     - name: Install Electron test dependencies
+      if: ${{ matrix.test_suite != 'idl' }}
       run: |
         # Adjust dependencies based on Ubuntu version.
         # 22.04 (jammy) uses libasound2; 24.04 (noble) and 26.04 (resolute) use the
@@ -117,6 +124,7 @@ jobs:
     # not fail the whole matrix leg. Keep max_attempts conservative so real
     # regressions still surface quickly.
     - name: Build and test rclnodejs
+      if: ${{ matrix.test_suite != 'idl' }}
       uses: nick-fields/retry@v4
       with:
         shell: bash
@@ -136,12 +144,10 @@ jobs:
           else
             npm test
           fi
-          if [ "${{ matrix.ros_distribution }}" != "rolling" ]; then
-            npm run clean
-          fi
+          npm run clean
 
     - name: Test with IDL ROS messages (rolling)
-      if: ${{ matrix.ros_distribution == 'rolling' }}
+      if: ${{ matrix.ros_distribution == 'rolling' && matrix.test_suite == 'idl' }}
       uses: nick-fields/retry@v4
       with:
         shell: bash
@@ -150,6 +156,7 @@ jobs:
         timeout_minutes: 60
         command: |
           source /opt/ros/${{ matrix.ros_distribution }}/setup.bash
+          npm i
           npm run test-idl
           npm run clean
 

--- a/bin/rclnodejs-web.js
+++ b/bin/rclnodejs-web.js
@@ -139,7 +139,8 @@ if (SUBCOMMANDS.has(argv[0])) {
       const totals =
         Object.keys(list.call).length +
         Object.keys(list.publish).length +
-        Object.keys(list.subscribe).length;
+        Object.keys(list.subscribe).length +
+        Object.keys(list.action).length;
       const noun = totals === 1 ? 'capability' : 'capabilities';
       process.stdout.write(
         `rclnodejs/web listening on ws://${displayHost(cfg.host)}:${wsTransport.port}${cfg.path} (${totals} ${noun})\n`

--- a/lib/action/client.js
+++ b/lib/action/client.js
@@ -460,15 +460,17 @@ class ActionClient extends Entity {
     });
     deferred.setDoneCallback(() => {
       this._removePendingResultRequest(sequenceNumber);
-      this._feedbackCallbacks.delete(
-        ActionUuid.fromMessage(goalHandle.goalId).toString()
-      );
+      this._removeFeedbackCallback(goalHandle.goalId);
       this._feedbackSubFilterRemoveGoalId(goalHandle.goalId);
     });
 
     this._pendingResultRequests.set(sequenceNumber, deferred);
 
     return deferred.promise;
+  }
+
+  _removeFeedbackCallback(goalId) {
+    this._feedbackCallbacks.delete(ActionUuid.fromMessage(goalId).toString());
   }
 
   _removePendingGoalRequest(sequenceNumber) {

--- a/lib/action/client.js
+++ b/lib/action/client.js
@@ -460,6 +460,9 @@ class ActionClient extends Entity {
     });
     deferred.setDoneCallback(() => {
       this._removePendingResultRequest(sequenceNumber);
+      this._feedbackCallbacks.delete(
+        ActionUuid.fromMessage(goalHandle.goalId).toString()
+      );
       this._feedbackSubFilterRemoveGoalId(goalHandle.goalId);
     });
 
@@ -527,6 +530,12 @@ class ActionClient extends Entity {
     }
 
     this._goalHandles.clear();
+    this._feedbackCallbacks.clear();
+    this._sequenceNumberGoalIdMap.clear();
+    this._pendingGoalRequests.clear();
+    this._pendingResultRequests.clear();
+    this._pendingCancelRequests.clear();
+    this._enableFeedbackMsgOptimization = false;
 
     this._node._destroyEntity(this, this._node._actionClients);
   }

--- a/lib/runtime/capability_registry.js
+++ b/lib/runtime/capability_registry.js
@@ -15,8 +15,8 @@
  * touched.
  *
  * Each capability is a tuple `(kind, name, type)` where:
- *   - `kind` is one of `'call' | 'publish' | 'subscribe'`
- *   - `name` is the ROS 2 service or topic name (e.g. `'/cmd_vel'`)
+ *   - `kind` is one of `'call' | 'publish' | 'subscribe' | 'action'`
+ *   - `name` is the ROS 2 service, topic, or action name (e.g. `'/cmd_vel'`)
  *   - `type` is the ROS 2 interface name (e.g. `'std_msgs/msg/String'`)
  */
 class CapabilityRegistry {
@@ -28,6 +28,7 @@ class CapabilityRegistry {
     this._call = new Map(); //      ROS service name -> srv type
     this._publish = new Map(); //   ROS topic name   -> msg type
     this._subscribe = new Map(); // ROS topic name   -> msg type
+    this._action = new Map(); //    ROS action name  -> action type
   }
 
   /**
@@ -57,6 +58,7 @@ class CapabilityRegistry {
    *   call?:      Object<string, string | {type:string}>,
    *   publish?:   Object<string, string | {type:string}>,
    *   subscribe?: Object<string, string | {type:string}>,
+   *   action?:    Object<string, string | {type:string}>,
    * }} spec
    * @returns {CapabilityRegistry} this (chainable)
    */
@@ -70,12 +72,15 @@ class CapabilityRegistry {
     for (const [name, value] of Object.entries(spec.subscribe || {})) {
       this._subscribe.set(name, _typeOf(value, 'subscribe', name));
     }
+    for (const [name, value] of Object.entries(spec.action || {})) {
+      this._action.set(name, _typeOf(value, 'action', name));
+    }
     return this;
   }
 
   /**
    * Resolve a capability lookup.
-   * @param {'call'|'publish'|'subscribe'} kind
+   * @param {'call'|'publish'|'subscribe'|'action'} kind
    * @param {string} name
    * @returns {{kind:string, name:string, type:string}|null}
    */
@@ -98,6 +103,7 @@ class CapabilityRegistry {
       call: Object.fromEntries(this._call),
       publish: Object.fromEntries(this._publish),
       subscribe: Object.fromEntries(this._subscribe),
+      action: Object.fromEntries(this._action),
     };
   }
 
@@ -105,6 +111,7 @@ class CapabilityRegistry {
     if (kind === 'call') return this._call;
     if (kind === 'publish') return this._publish;
     if (kind === 'subscribe') return this._subscribe;
+    if (kind === 'action') return this._action;
     return null;
   }
 }

--- a/lib/runtime/cli-config.js
+++ b/lib/runtime/cli-config.js
@@ -359,7 +359,7 @@ Capabilities:
       --call <name>=<type>    expose a service capability   (repeatable)
       --publish <name>=<type> expose a topic publish        (repeatable)
       --subscribe <n>=<type>  expose a topic subscription   (repeatable)
-        --action <name>=<type>  expose an action capability    (repeatable)
+      --action <name>=<type>  expose an action capability    (repeatable)
 
 Other:
       --node-name <name>      ROS 2 node name          (default rclnodejs_web)

--- a/lib/runtime/cli-config.js
+++ b/lib/runtime/cli-config.js
@@ -37,10 +37,10 @@ const DEFAULTS = Object.freeze({
     sseKeepAliveMs: null,
     cors: false,
   },
-  expose: { call: {}, publish: {}, subscribe: {} },
+  expose: { call: {}, publish: {}, subscribe: {}, action: {} },
 });
 
-const KINDS = ['call', 'publish', 'subscribe'];
+const KINDS = ['call', 'publish', 'subscribe', 'action'];
 
 /**
  * Parse command-line argv (without the leading `node`/script entries)
@@ -52,7 +52,7 @@ const KINDS = ['call', 'publish', 'subscribe'];
  */
 function parseArgv(argv) {
   const partial = {
-    expose: { call: {}, publish: {}, subscribe: {} },
+    expose: { call: {}, publish: {}, subscribe: {}, action: {} },
     http: {},
   };
   const out = { partial };
@@ -106,7 +106,12 @@ function parseArgv(argv) {
         if (!Array.isArray(partial.http.cors)) partial.http.cors = [];
         partial.http.cors.push(v);
       }
-    } else if (a === '--call' || a === '--publish' || a === '--subscribe') {
+    } else if (
+      a === '--call' ||
+      a === '--publish' ||
+      a === '--subscribe' ||
+      a === '--action'
+    ) {
       const kind = a.slice(2);
       const pair = eat(a);
       const eq = pair.indexOf('=');
@@ -354,6 +359,7 @@ Capabilities:
       --call <name>=<type>    expose a service capability   (repeatable)
       --publish <name>=<type> expose a topic publish        (repeatable)
       --subscribe <n>=<type>  expose a topic subscription   (repeatable)
+        --action <name>=<type>  expose an action capability    (repeatable)
 
 Other:
       --node-name <name>      ROS 2 node name          (default rclnodejs_web)
@@ -389,7 +395,8 @@ Config-file shape (every field optional):
     "expose": {
       "call":      { "/add_two_ints": "example_interfaces/srv/AddTwoInts" },
       "publish":   { "/cmd_vel":      "geometry_msgs/msg/Twist" },
-      "subscribe": { "/scan":         "sensor_msgs/msg/LaserScan" }
+      "subscribe": { "/scan":         "sensor_msgs/msg/LaserScan" },
+      "action":    { "/navigate":     "nav2_msgs/action/NavigateToPose" }
     }
   }
 

--- a/lib/runtime/dispatcher.js
+++ b/lib/runtime/dispatcher.js
@@ -8,6 +8,8 @@
 
 import createDebug from 'debug';
 import { toJSONSafe, reviveBigInts } from '../message_serialization.js';
+import ActionClient from '../action/client.js';
+import ActionInterfaces from '../action/interfaces.js';
 
 const debug = createDebug('rclnodejs:runtime');
 
@@ -41,12 +43,17 @@ class Dispatcher {
    */
   handle(conn) {
     const state = {
-      publishers: new Map(), //    capability name -> Publisher
-      subscriptions: new Map(), // subId           -> { name, Subscription }
-      clients: new Map(), //       capability name -> Client
+      publishers: new Map(), //     capability name -> Publisher
+      subscriptions: new Map(), //  subId           -> { name, Subscription }
+      clients: new Map(), //        capability name -> Client
+      actionClients: new Map(), //  capability name -> ActionClient
+      pendingGoals: new Map(), //   goal id         -> capability name
+      goals: new Map(), //          goal id         -> { name, goalHandle }
+      closed: false,
     };
 
     const cleanup = () => {
+      state.closed = true;
       for (const { subscription } of state.subscriptions.values()) {
         try {
           this.node.destroySubscription(subscription);
@@ -71,6 +78,23 @@ class Dispatcher {
         }
       }
       state.clients.clear();
+      // Deliberately not cancelling in-flight goals here: cancelGoal() is
+      // itself async, and destroying the ActionClient synchronously right
+      // after firing it (without awaiting the response) races the pending
+      // rcl reply — same "client will not receive response" native crash
+      // documented on HttpRequestConnection above. A goal already in flight
+      // when the connection drops just runs to completion server-side;
+      // conn.send() on a closed connection is already a documented no-op.
+      // Deferred one tick: even a goal whose result already arrived can
+      // still have rmw-internal bookkeeping for that exchange settling
+      // asynchronously under the hood: destroying the ActionClient in the
+      // very same tick reproduced this crash. Deferring by one event-loop
+      // turn is enough for that to quiesce.
+      setImmediate(() => {
+        for (const name of state.actionClients.keys()) {
+          _releaseActionClientIfIdle(state, name);
+        }
+      });
     };
 
     conn.on('close', cleanup);
@@ -104,13 +128,7 @@ class Dispatcher {
         case 'unsubscribe':
           return this._handleUnsubscribe(conn, id, frame.subId, state);
         case 'action':
-          conn.send({
-            id,
-            ok: false,
-            error: 'action capabilities are not yet supported',
-            code: 'not_implemented',
-          });
-          return;
+          return this._handleAction(conn, id, capability, frame, state);
         default:
           conn.send({
             id,
@@ -237,6 +255,189 @@ class Dispatcher {
       error: `capability not exposed: ${kind} ${name}`,
       code: 'not_exposed',
     });
+  }
+
+  _handleAction(conn, id, name, frame, state) {
+    const op = frame.op;
+    if (op === 'send_goal') {
+      return this._handleActionSendGoal(conn, id, name, frame.payload, state);
+    }
+    if (op === 'cancel') {
+      return this._handleActionCancel(conn, id, frame.goalId, state);
+    }
+    conn.send({
+      id,
+      ok: false,
+      error: `unknown action op: ${op}`,
+      code: 'unknown_op',
+    });
+  }
+
+  _handleActionSendGoal(conn, id, name, payload, state) {
+    const { actionClients, pendingGoals, goals } = state;
+    const cap = this.registry.resolve('action', name);
+    if (!cap) return this._notExposed(conn, id, 'action', name);
+    if (id === undefined || id === null) {
+      conn.send({
+        ok: false,
+        error: 'action send_goal requires an id',
+        code: 'missing_id',
+      });
+      return;
+    }
+    if (pendingGoals.has(id) || goals.has(id)) {
+      conn.send({
+        id,
+        ok: false,
+        error: `id already in use: ${id}`,
+        code: 'duplicate_id',
+      });
+      return;
+    }
+    let actionClient = actionClients.get(name);
+    if (!actionClient) {
+      actionClient = new ActionClient(this.node, cap.type, name);
+      actionClients.set(name, actionClient);
+    }
+    const goal = reviveBigInts(payload);
+    const feedbackCallback = (feedback) => {
+      conn.send({
+        event: 'feedback',
+        goalId: id,
+        payload: toJSONSafe(feedback),
+      });
+    };
+    let goalHandle;
+    pendingGoals.set(id, name);
+    let sendGoal;
+    try {
+      sendGoal = actionClient.sendGoal(goal, feedbackCallback);
+    } catch (e) {
+      pendingGoals.delete(id);
+      _releaseActionClientIfIdle(state, name);
+      conn.send({
+        id,
+        ok: false,
+        error: `send_goal failed: ${e.message}`,
+        code: 'action_failed',
+      });
+      return;
+    }
+    sendGoal.then(
+      (handle) => {
+        pendingGoals.delete(id);
+        goalHandle = handle;
+        if (!goalHandle.isAccepted()) {
+          conn.send({
+            id,
+            ok: false,
+            error: 'goal rejected',
+            code: 'goal_rejected',
+          });
+          _releaseActionClientIfIdle(state, name);
+          return;
+        }
+        goals.set(id, { name, goalHandle });
+        conn.send({ id, ok: true, payload: { accepted: true } });
+        goalHandle.getResult().then(
+          (result) => {
+            goals.delete(id);
+            conn.send({
+              event: 'result',
+              goalId: id,
+              payload: toJSONSafe(result),
+              status: _goalStatusName(goalHandle.status),
+            });
+            _releaseActionClientIfIdle(state, name);
+          },
+          (e) => {
+            goals.delete(id);
+            conn.send({
+              event: 'result',
+              goalId: id,
+              ok: false,
+              error: `get result failed: ${e.message}`,
+              code: 'action_failed',
+            });
+            _releaseActionClientIfIdle(state, name);
+          }
+        );
+      },
+      (e) => {
+        pendingGoals.delete(id);
+        conn.send({
+          id,
+          ok: false,
+          error: `send_goal failed: ${e.message}`,
+          code: 'action_failed',
+        });
+        _releaseActionClientIfIdle(state, name);
+      }
+    );
+  }
+
+  _handleActionCancel(conn, id, goalId, { goals }) {
+    if (goalId === undefined || goalId === null) {
+      conn.send({
+        id,
+        ok: false,
+        error: 'action cancel requires goalId',
+        code: 'missing_goal_id',
+      });
+      return;
+    }
+    const entry = goals.get(goalId);
+    if (!entry) {
+      conn.send({
+        id,
+        ok: false,
+        error: `unknown goal: ${goalId}`,
+        code: 'unknown_goal_id',
+      });
+      return;
+    }
+    entry.goalHandle.cancelGoal().then(
+      () => conn.send({ id, ok: true }),
+      (e) =>
+        conn.send({
+          id,
+          ok: false,
+          error: `cancel failed: ${e.message}`,
+          code: 'action_failed',
+        })
+    );
+  }
+}
+
+function _releaseActionClientIfIdle(state, name) {
+  if (!state.closed) return;
+  if ([...state.pendingGoals.values()].includes(name)) return;
+  for (const goal of state.goals.values()) {
+    if (goal.name === name) return;
+  }
+  const actionClient = state.actionClients.get(name);
+  if (!actionClient) return;
+  state.actionClients.delete(name);
+  setImmediate(() => {
+    try {
+      actionClient.destroy();
+    } catch {
+      /* destroy is best-effort during connection teardown */
+    }
+  });
+}
+
+/** Map a numeric `GoalStatus` constant to the wire's lowercase status name. */
+function _goalStatusName(status) {
+  switch (status) {
+    case ActionInterfaces.GoalStatus.STATUS_SUCCEEDED:
+      return 'succeeded';
+    case ActionInterfaces.GoalStatus.STATUS_CANCELED:
+      return 'canceled';
+    case ActionInterfaces.GoalStatus.STATUS_ABORTED:
+      return 'aborted';
+    default:
+      return 'unknown';
   }
 }
 

--- a/lib/runtime/dispatcher.js
+++ b/lib/runtime/dispatcher.js
@@ -48,6 +48,7 @@ class Dispatcher {
       clients: new Map(), //        capability name -> Client
       actionClients: new Map(), //  capability name -> ActionClient
       pendingGoals: new Map(), //   goal id         -> capability name
+      pendingCancels: new Map(), // token           -> capability name
       goals: new Map(), //          goal id         -> { name, goalHandle }
       closed: false,
     };
@@ -299,6 +300,15 @@ class Dispatcher {
       actionClient = new ActionClient(this.node, cap.type, name);
       actionClients.set(name, actionClient);
     }
+    if (!actionClient.isActionServerAvailable()) {
+      conn.send({
+        id,
+        ok: false,
+        error: `action server unavailable: ${name}`,
+        code: 'action_unavailable',
+      });
+      return;
+    }
     const goal = reviveBigInts(payload);
     const feedbackCallback = (feedback) => {
       conn.send({
@@ -339,7 +349,22 @@ class Dispatcher {
         }
         goals.set(id, { name, goalHandle });
         conn.send({ id, ok: true, payload: { accepted: true } });
-        goalHandle.getResult().then(
+        let getResult;
+        try {
+          getResult = goalHandle.getResult();
+        } catch (e) {
+          goals.delete(id);
+          conn.send({
+            event: 'result',
+            goalId: id,
+            ok: false,
+            error: `get result failed: ${e.message}`,
+            code: 'action_failed',
+          });
+          _releaseActionClientIfIdle(state, name);
+          return;
+        }
+        getResult.then(
           (result) => {
             goals.delete(id);
             conn.send({
@@ -376,7 +401,8 @@ class Dispatcher {
     );
   }
 
-  _handleActionCancel(conn, id, goalId, { goals }) {
+  _handleActionCancel(conn, id, goalId, state) {
+    const { goals, pendingCancels } = state;
     if (goalId === undefined || goalId === null) {
       conn.send({
         id,
@@ -396,15 +422,48 @@ class Dispatcher {
       });
       return;
     }
-    entry.goalHandle.cancelGoal().then(
-      () => conn.send({ id, ok: true }),
-      (e) =>
+    const token = Symbol('cancel');
+    pendingCancels.set(token, entry.name);
+    let cancelGoal;
+    try {
+      cancelGoal = entry.goalHandle.cancelGoal();
+    } catch (e) {
+      pendingCancels.delete(token);
+      conn.send({
+        id,
+        ok: false,
+        error: `cancel failed: ${e.message}`,
+        code: 'action_failed',
+      });
+      _releaseActionClientIfIdle(state, entry.name);
+      return;
+    }
+    cancelGoal.then(
+      (response) => {
+        pendingCancels.delete(token);
+        if (!response.goals_canceling?.length) {
+          conn.send({
+            id,
+            ok: false,
+            error: `cancel rejected: ${goalId}`,
+            code: 'cancel_rejected',
+            payload: toJSONSafe(response),
+          });
+        } else {
+          conn.send({ id, ok: true, payload: toJSONSafe(response) });
+        }
+        _releaseActionClientIfIdle(state, entry.name);
+      },
+      (e) => {
+        pendingCancels.delete(token);
         conn.send({
           id,
           ok: false,
           error: `cancel failed: ${e.message}`,
           code: 'action_failed',
-        })
+        });
+        _releaseActionClientIfIdle(state, entry.name);
+      }
     );
   }
 }
@@ -412,6 +471,7 @@ class Dispatcher {
 function _releaseActionClientIfIdle(state, name) {
   if (!state.closed) return;
   if ([...state.pendingGoals.values()].includes(name)) return;
+  if ([...state.pendingCancels.values()].includes(name)) return;
   for (const goal of state.goals.values()) {
     if (goal.name === name) return;
   }

--- a/lib/runtime/dispatcher.js
+++ b/lib/runtime/dispatcher.js
@@ -13,6 +13,8 @@ import ActionInterfaces from '../action/interfaces.js';
 
 const debug = createDebug('rclnodejs:runtime');
 
+const ACTION_DISCONNECT_GRACE_MS = 30 * 1000;
+
 /**
  * Per-connection request handler. Statelessly routes inbound capability
  * frames to the registered ROS 2 endpoints, lazily creating publishers,
@@ -51,9 +53,12 @@ class Dispatcher {
       pendingCancels: new Map(), // token           -> capability name
       goals: new Map(), //          goal id         -> { name, goalHandle }
       closed: false,
+      expired: false,
+      cleanupTimer: null,
     };
 
     const cleanup = () => {
+      if (state.closed) return;
       state.closed = true;
       for (const { subscription } of state.subscriptions.values()) {
         try {
@@ -79,18 +84,18 @@ class Dispatcher {
         }
       }
       state.clients.clear();
-      // Deliberately not cancelling in-flight goals here: cancelGoal() is
-      // itself async, and destroying the ActionClient synchronously right
-      // after firing it (without awaiting the response) races the pending
-      // rcl reply — same "client will not receive response" native crash
-      // documented on HttpRequestConnection above. A goal already in flight
-      // when the connection drops just runs to completion server-side;
-      // conn.send() on a closed connection is already a documented no-op.
-      // Deferred one tick: even a goal whose result already arrived can
-      // still have rmw-internal bookkeeping for that exchange settling
-      // asynchronously under the hood: destroying the ActionClient in the
-      // very same tick reproduced this crash. Deferring by one event-loop
-      // turn is enough for that to quiesce.
+      if (state.actionClients.size > 0) {
+        state.cleanupTimer = setTimeout(() => {
+          state.expired = true;
+          state.pendingGoals.clear();
+          state.pendingCancels.clear();
+          state.goals.clear();
+          for (const name of state.actionClients.keys()) {
+            _releaseActionClientIfIdle(state, name);
+          }
+        }, ACTION_DISCONNECT_GRACE_MS);
+        state.cleanupTimer.unref();
+      }
       setImmediate(() => {
         for (const name of state.actionClients.keys()) {
           _releaseActionClientIfIdle(state, name);
@@ -103,6 +108,7 @@ class Dispatcher {
   }
 
   _dispatchFrame(conn, frame, state) {
+    if (state.closed) return;
     if (!frame || typeof frame !== 'object') {
       conn.send({
         ok: false,
@@ -310,7 +316,9 @@ class Dispatcher {
       return;
     }
     const goal = reviveBigInts(payload);
+    let feedbackActive = true;
     const feedbackCallback = (feedback) => {
+      if (!feedbackActive || state.closed) return;
       conn.send({
         event: 'feedback',
         goalId: id,
@@ -323,6 +331,7 @@ class Dispatcher {
     try {
       sendGoal = actionClient.sendGoal(goal, feedbackCallback);
     } catch (e) {
+      feedbackActive = false;
       pendingGoals.delete(id);
       _releaseActionClientIfIdle(state, name);
       conn.send({
@@ -336,8 +345,13 @@ class Dispatcher {
     sendGoal.then(
       (handle) => {
         pendingGoals.delete(id);
+        if (state.expired || actionClient.isDestroyed()) {
+          feedbackActive = false;
+          return;
+        }
         goalHandle = handle;
         if (!goalHandle.isAccepted()) {
+          feedbackActive = false;
           conn.send({
             id,
             ok: false,
@@ -353,6 +367,7 @@ class Dispatcher {
         try {
           getResult = goalHandle.getResult();
         } catch (e) {
+          feedbackActive = false;
           goals.delete(id);
           conn.send({
             event: 'result',
@@ -366,6 +381,7 @@ class Dispatcher {
         }
         getResult.then(
           (result) => {
+            feedbackActive = false;
             goals.delete(id);
             conn.send({
               event: 'result',
@@ -376,6 +392,7 @@ class Dispatcher {
             _releaseActionClientIfIdle(state, name);
           },
           (e) => {
+            feedbackActive = false;
             goals.delete(id);
             conn.send({
               event: 'result',
@@ -389,6 +406,7 @@ class Dispatcher {
         );
       },
       (e) => {
+        feedbackActive = false;
         pendingGoals.delete(id);
         conn.send({
           id,
@@ -478,6 +496,10 @@ function _releaseActionClientIfIdle(state, name) {
   const actionClient = state.actionClients.get(name);
   if (!actionClient) return;
   state.actionClients.delete(name);
+  if (state.actionClients.size === 0) {
+    clearTimeout(state.cleanupTimer);
+    state.cleanupTimer = null;
+  }
   setImmediate(() => {
     try {
       actionClient.destroy();

--- a/lib/runtime/dispatcher.js
+++ b/lib/runtime/dispatcher.js
@@ -10,6 +10,7 @@ import createDebug from 'debug';
 import { toJSONSafe, reviveBigInts } from '../message_serialization.js';
 import ActionClient from '../action/client.js';
 import ActionInterfaces from '../action/interfaces.js';
+import ActionUuid from '../action/uuid.js';
 
 const debug = createDebug('rclnodejs:runtime');
 
@@ -316,107 +317,100 @@ class Dispatcher {
       return;
     }
     const goal = reviveBigInts(payload);
-    let feedbackActive = true;
+    const actionGoal = {
+      id,
+      name,
+      actionClient,
+      goalUuid: ActionUuid.randomMessage(),
+      goalHandle: null,
+      finished: false,
+    };
     const feedbackCallback = (feedback) => {
-      if (!feedbackActive || state.closed) return;
+      if (actionGoal.finished || state.closed) return;
       conn.send({
         event: 'feedback',
         goalId: id,
         payload: toJSONSafe(feedback),
       });
     };
-    let goalHandle;
-    pendingGoals.set(id, name);
-    let sendGoal;
-    try {
-      sendGoal = actionClient.sendGoal(goal, feedbackCallback);
-    } catch (e) {
-      feedbackActive = false;
-      pendingGoals.delete(id);
-      _releaseActionClientIfIdle(state, name);
-      conn.send({
+    const onError = (error) =>
+      this._finishActionGoal(conn, state, actionGoal, {
         id,
         ok: false,
-        error: `send_goal failed: ${e.message}`,
+        error: `send_goal failed: ${error.message}`,
         code: 'action_failed',
+      });
+    pendingGoals.set(id, name);
+    try {
+      actionClient
+        .sendGoal(goal, feedbackCallback, actionGoal.goalUuid)
+        .then(
+          (handle) =>
+            this._handleActionGoalResponse(conn, state, actionGoal, handle),
+          onError
+        );
+    } catch (error) {
+      onError(error);
+    }
+  }
+
+  _handleActionGoalResponse(conn, state, actionGoal, handle) {
+    const { id, actionClient } = actionGoal;
+    state.pendingGoals.delete(id);
+    if (state.expired || actionClient.isDestroyed()) {
+      this._finishActionGoal(conn, state, actionGoal);
+      return;
+    }
+    actionGoal.goalHandle = handle;
+    if (!handle.isAccepted()) {
+      this._finishActionGoal(conn, state, actionGoal, {
+        id,
+        ok: false,
+        error: 'goal rejected',
+        code: 'goal_rejected',
       });
       return;
     }
-    sendGoal.then(
-      (handle) => {
-        pendingGoals.delete(id);
-        if (state.expired || actionClient.isDestroyed()) {
-          feedbackActive = false;
-          return;
-        }
-        goalHandle = handle;
-        if (!goalHandle.isAccepted()) {
-          feedbackActive = false;
-          conn.send({
-            id,
-            ok: false,
-            error: 'goal rejected',
-            code: 'goal_rejected',
-          });
-          _releaseActionClientIfIdle(state, name);
-          return;
-        }
-        goals.set(id, { name, goalHandle });
-        conn.send({ id, ok: true, payload: { accepted: true } });
-        let getResult;
-        try {
-          getResult = goalHandle.getResult();
-        } catch (e) {
-          feedbackActive = false;
-          goals.delete(id);
-          conn.send({
-            event: 'result',
-            goalId: id,
-            ok: false,
-            error: `get result failed: ${e.message}`,
-            code: 'action_failed',
-          });
-          _releaseActionClientIfIdle(state, name);
-          return;
-        }
-        getResult.then(
-          (result) => {
-            feedbackActive = false;
-            goals.delete(id);
-            conn.send({
-              event: 'result',
-              goalId: id,
-              payload: toJSONSafe(result),
-              status: _goalStatusName(goalHandle.status),
-            });
-            _releaseActionClientIfIdle(state, name);
-          },
-          (e) => {
-            feedbackActive = false;
-            goals.delete(id);
-            conn.send({
-              event: 'result',
-              goalId: id,
-              ok: false,
-              error: `get result failed: ${e.message}`,
-              code: 'action_failed',
-            });
-            _releaseActionClientIfIdle(state, name);
-          }
-        );
-      },
-      (e) => {
-        feedbackActive = false;
-        pendingGoals.delete(id);
-        conn.send({
-          id,
-          ok: false,
-          error: `send_goal failed: ${e.message}`,
-          code: 'action_failed',
-        });
-        _releaseActionClientIfIdle(state, name);
-      }
-    );
+    state.goals.set(id, actionGoal);
+    conn.send({ id, ok: true, payload: { accepted: true } });
+    return this._watchActionResult(conn, state, actionGoal);
+  }
+
+  async _watchActionResult(conn, state, actionGoal) {
+    const { id, goalHandle } = actionGoal;
+    let response;
+    try {
+      const result = await goalHandle.getResult();
+      response = {
+        payload: toJSONSafe(result),
+        status: _goalStatusName(goalHandle.status),
+      };
+    } catch (error) {
+      response = {
+        ok: false,
+        error: `get result failed: ${error.message}`,
+        code: 'action_failed',
+      };
+    }
+    this._finishActionGoal(conn, state, actionGoal, {
+      event: 'result',
+      goalId: id,
+      ...response,
+    });
+  }
+
+  _finishActionGoal(conn, state, actionGoal, response) {
+    if (actionGoal.finished) return;
+    actionGoal.finished = true;
+    const { id, name, actionClient, goalUuid } = actionGoal;
+    actionClient._removeFeedbackCallback(goalUuid);
+    state.pendingGoals.delete(id);
+    state.goals.delete(id);
+    try {
+      if (response) conn.send(response);
+    } finally {
+      _releaseActionClientIfIdle(state, name);
+    }
   }
 
   _handleActionCancel(conn, id, goalId, state) {

--- a/lib/runtime/dispatcher.js
+++ b/lib/runtime/dispatcher.js
@@ -334,7 +334,7 @@ class Dispatcher {
       });
     };
     const onError = (error) =>
-      this._finishActionGoal(conn, state, actionGoal, {
+      this._finalizeActionGoal(conn, state, actionGoal, {
         id,
         ok: false,
         error: `send_goal failed: ${error.message}`,
@@ -358,12 +358,12 @@ class Dispatcher {
     const { id, actionClient } = actionGoal;
     state.pendingGoals.delete(id);
     if (state.expired || actionClient.isDestroyed()) {
-      this._finishActionGoal(conn, state, actionGoal);
+      this._finalizeActionGoal(conn, state, actionGoal);
       return;
     }
     actionGoal.goalHandle = handle;
     if (!handle.isAccepted()) {
-      this._finishActionGoal(conn, state, actionGoal, {
+      this._finalizeActionGoal(conn, state, actionGoal, {
         id,
         ok: false,
         error: 'goal rejected',
@@ -392,14 +392,14 @@ class Dispatcher {
         code: 'action_failed',
       };
     }
-    this._finishActionGoal(conn, state, actionGoal, {
+    this._finalizeActionGoal(conn, state, actionGoal, {
       event: 'result',
       goalId: id,
       ...response,
     });
   }
 
-  _finishActionGoal(conn, state, actionGoal, response) {
+  _finalizeActionGoal(conn, state, actionGoal, response) {
     if (actionGoal.finished) return;
     actionGoal.finished = true;
     const { id, name, actionClient, goalUuid } = actionGoal;
@@ -434,49 +434,49 @@ class Dispatcher {
       });
       return;
     }
-    const token = Symbol('cancel');
-    pendingCancels.set(token, entry.name);
-    let cancelGoal;
+    const actionCancel = {
+      id,
+      goalId,
+      name: entry.name,
+      goalHandle: entry.goalHandle,
+      token: Symbol('cancel'),
+    };
+    pendingCancels.set(actionCancel.token, actionCancel.name);
+    return this._watchActionCancel(conn, state, actionCancel);
+  }
+
+  async _watchActionCancel(conn, state, actionCancel) {
+    const { goalId, goalHandle } = actionCancel;
+    let response;
     try {
-      cancelGoal = entry.goalHandle.cancelGoal();
-    } catch (e) {
-      pendingCancels.delete(token);
-      conn.send({
-        id,
-        ok: false,
-        error: `cancel failed: ${e.message}`,
-        code: 'action_failed',
-      });
-      _releaseActionClientIfIdle(state, entry.name);
-      return;
-    }
-    cancelGoal.then(
-      (response) => {
-        pendingCancels.delete(token);
-        if (!response.goals_canceling?.length) {
-          conn.send({
-            id,
+      const cancelResponse = await goalHandle.cancelGoal();
+      const payload = toJSONSafe(cancelResponse);
+      response = cancelResponse.goals_canceling?.length
+        ? { ok: true, payload }
+        : {
             ok: false,
             error: `cancel rejected: ${goalId}`,
             code: 'cancel_rejected',
-            payload: toJSONSafe(response),
-          });
-        } else {
-          conn.send({ id, ok: true, payload: toJSONSafe(response) });
-        }
-        _releaseActionClientIfIdle(state, entry.name);
-      },
-      (e) => {
-        pendingCancels.delete(token);
-        conn.send({
-          id,
-          ok: false,
-          error: `cancel failed: ${e.message}`,
-          code: 'action_failed',
-        });
-        _releaseActionClientIfIdle(state, entry.name);
-      }
-    );
+            payload,
+          };
+    } catch (error) {
+      response = {
+        ok: false,
+        error: `cancel failed: ${error.message}`,
+        code: 'action_failed',
+      };
+    }
+    this._finalizeActionCancel(conn, state, actionCancel, response);
+  }
+
+  _finalizeActionCancel(conn, state, actionCancel, response) {
+    const { id, name, token } = actionCancel;
+    state.pendingCancels.delete(token);
+    try {
+      conn.send({ id, ...response });
+    } finally {
+      _releaseActionClientIfIdle(state, name);
+    }
   }
 }
 

--- a/lib/runtime/index.d.ts
+++ b/lib/runtime/index.d.ts
@@ -15,7 +15,7 @@
 
 import type { Node } from 'rclnodejs';
 
-export type CapabilityKind = 'call' | 'publish' | 'subscribe';
+export type CapabilityKind = 'call' | 'publish' | 'subscribe' | 'action';
 
 /** A single capability entry as resolved from the registry. */
 export interface Capability {
@@ -34,6 +34,7 @@ export interface ExposeSpec {
   call?: CapabilityMap;
   publish?: CapabilityMap;
   subscribe?: CapabilityMap;
+  action?: CapabilityMap;
 }
 
 /** Snapshot returned by `CapabilityRegistry.list()`. */
@@ -41,6 +42,7 @@ export interface RegistrySnapshot {
   call: Record<string, string>;
   publish: Record<string, string>;
   subscribe: Record<string, string>;
+  action: Record<string, string>;
 }
 
 /**
@@ -66,6 +68,9 @@ export interface CapabilityFrame {
   capability?: string;
   payload?: unknown;
   subId?: string | number;
+  op?: 'send_goal' | 'cancel';
+  goalId?: string | number;
+  status?: 'succeeded' | 'canceled' | 'aborted' | 'unknown';
   ok?: boolean;
   event?: string;
   error?: string;

--- a/test/test-action-client.js
+++ b/test/test-action-client.js
@@ -192,6 +192,45 @@ describe('rclnodejs action client', function () {
     client.destroy();
   });
 
+  it('releases feedback callbacks after results on a reused client', async function () {
+    const client = new rclnodejs.ActionClient(node, fibonacci, 'fibonacci');
+    try {
+      assert.ok(await client.waitForServer(2000));
+      for (let index = 0; index < 3; index++) {
+        const feedback = sinon.spy();
+        const goalHandle = await client.sendGoal(
+          new Fibonacci.Goal(),
+          feedback
+        );
+        await goalHandle.getResult();
+        assert.strictEqual(client._feedbackCallbacks.size, 0);
+        client.processFeedbackMessage({
+          goal_id: goalHandle.goalId,
+          toPlainObject: () => ({ feedback: {} }),
+        });
+        assert.ok(feedback.notCalled);
+      }
+    } finally {
+      client.destroy();
+    }
+  });
+
+  it('clears pending requests and feedback when destroyed', function () {
+    const client = new rclnodejs.ActionClient(node, fibonacci, 'fibonacci');
+    const maps = [
+      client._goalHandles,
+      client._feedbackCallbacks,
+      client._sequenceNumberGoalIdMap,
+      client._pendingGoalRequests,
+      client._pendingResultRequests,
+      client._pendingCancelRequests,
+    ];
+    for (const entries of maps) entries.set('pending', {});
+    client.destroy();
+    for (const entries of maps) assert.strictEqual(entries.size, 0);
+    assert.ok(client.isDestroyed());
+  });
+
   it('Test send goal with feedback for another goal', async function () {
     let client = new rclnodejs.ActionClient(node, fibonacci, 'fibonacci');
 

--- a/test/test-runtime.js
+++ b/test/test-runtime.js
@@ -7,13 +7,17 @@
 //     http://www.apache.org/licenses/LICENSE-2.0
 
 import assert from 'assert';
+import sinon from 'sinon';
 import WebSocket from 'ws';
 import rclnodejs from '../index.js';
+import ActionClient from '../lib/action/client.js';
+import ClientGoalHandle from '../lib/action/client_goal_handle.js';
 import {
   createRuntime,
   CapabilityRegistry,
   WebSocketTransport,
 } from '../lib/runtime/index.js';
+import * as assertUtils from './utils.js';
 
 describe('CapabilityRegistry (unit)', function () {
   it('expose() registers shorthand and rich forms', function () {
@@ -72,11 +76,44 @@ describe('Web Runtime end-to-end (WebSocket transport)', function () {
 
   let node;
   let runtime;
+  let Fibonacci;
+  let actionServer;
+  let acceptCancellation = true;
+
+  const fibonacci = 'example_interfaces/action/Fibonacci';
+
+  async function executeAction(goalHandle) {
+    const feedback = new Fibonacci.Feedback();
+    feedback.sequence = [1, 1];
+    goalHandle.publishFeedback(feedback);
+    await assertUtils.createDelay(100);
+    const result = new Fibonacci.Result();
+    if (goalHandle.isCancelRequested) {
+      goalHandle.canceled();
+      return result;
+    }
+    goalHandle.succeed();
+    result.sequence = [1, 1, 2, 3];
+    return result;
+  }
 
   before(async function () {
     await rclnodejs.init();
+    Fibonacci = rclnodejs.require(fibonacci);
     node = rclnodejs.createNode('runtime_test_node');
     rclnodejs.spin(node);
+    actionServer = new rclnodejs.ActionServer(
+      node,
+      fibonacci,
+      '/wb_fibonacci',
+      executeAction,
+      null,
+      null,
+      () =>
+        acceptCancellation
+          ? rclnodejs.CancelResponse.ACCEPT
+          : rclnodejs.CancelResponse.REJECT
+    );
     runtime = createRuntime({
       node,
       transports: [new WebSocketTransport({ port: 0 })],
@@ -85,13 +122,22 @@ describe('Web Runtime end-to-end (WebSocket transport)', function () {
       call: { '/wb_add': 'example_interfaces/srv/AddTwoInts' },
       publish: { '/wb_pub_in': 'std_msgs/msg/String' },
       subscribe: { '/wb_chatter': 'std_msgs/msg/String' },
+      action: {
+        '/wb_fibonacci': fibonacci,
+        '/wb_offline': fibonacci,
+      },
     });
     await runtime.start();
   });
 
   after(async function () {
+    if (actionServer) actionServer.destroy();
     if (runtime) await runtime.stop();
     rclnodejs.shutdown();
+  });
+
+  afterEach(function () {
+    acceptCancellation = true;
   });
 
   function url() {
@@ -117,6 +163,18 @@ describe('Web Runtime end-to-end (WebSocket transport)', function () {
       };
       ws.on('message', onMsg);
     });
+  }
+
+  function sendGoal(ws, id, capability = '/wb_fibonacci') {
+    ws.send(
+      JSON.stringify({
+        id,
+        kind: 'action',
+        op: 'send_goal',
+        capability,
+        payload: { order: 5 },
+      })
+    );
   }
 
   it('rejects capabilities not in the allow-list with code:not_exposed', async function () {
@@ -178,6 +236,163 @@ describe('Web Runtime end-to-end (WebSocket transport)', function () {
     assert.strictEqual(reply.ok, false);
     assert.strictEqual(reply.code, 'not_exposed');
     ws.close();
+  });
+
+  it('rejects an exposed action whose server is unavailable', async function () {
+    const ws = new WebSocket(url());
+    await waitOpen(ws);
+    const replyP = waitFrame(ws, (f) => f.id === 'offline');
+    sendGoal(ws, 'offline', '/wb_offline');
+    const reply = await replyP;
+    assert.strictEqual(reply.ok, false);
+    assert.strictEqual(reply.code, 'action_unavailable');
+    ws.close();
+  });
+
+  it('streams action feedback and a successful result', async function () {
+    const ws = new WebSocket(url());
+    await waitOpen(ws);
+    const ackP = waitFrame(ws, (f) => f.id === 'goal-success');
+    const feedbackP = waitFrame(
+      ws,
+      (f) => f.event === 'feedback' && f.goalId === 'goal-success'
+    );
+    const resultP = waitFrame(
+      ws,
+      (f) => f.event === 'result' && f.goalId === 'goal-success'
+    );
+    sendGoal(ws, 'goal-success');
+    const ack = await ackP;
+    assert.strictEqual(ack.ok, true);
+    assert.deepStrictEqual((await feedbackP).payload.sequence, [1, 1]);
+    const result = await resultP;
+    assert.strictEqual(result.status, 'succeeded');
+    assert.deepStrictEqual(result.payload.sequence, [1, 1, 2, 3]);
+    ws.close();
+  });
+
+  it('reports accepted action cancellation', async function () {
+    acceptCancellation = true;
+    const ws = new WebSocket(url());
+    await waitOpen(ws);
+    const ackP = waitFrame(ws, (f) => f.id === 'goal-cancel');
+    const resultP = waitFrame(
+      ws,
+      (f) => f.event === 'result' && f.goalId === 'goal-cancel'
+    );
+    sendGoal(ws, 'goal-cancel');
+    await ackP;
+    const cancelP = waitFrame(ws, (f) => f.id === 'cancel-accepted');
+    ws.send(
+      JSON.stringify({
+        id: 'cancel-accepted',
+        kind: 'action',
+        op: 'cancel',
+        goalId: 'goal-cancel',
+      })
+    );
+    const cancel = await cancelP;
+    assert.strictEqual(cancel.ok, true);
+    assert.strictEqual(cancel.payload.goals_canceling.length, 1);
+    assert.strictEqual((await resultP).status, 'canceled');
+    ws.close();
+  });
+
+  it('reports rejected action cancellation', async function () {
+    acceptCancellation = false;
+    const ws = new WebSocket(url());
+    await waitOpen(ws);
+    const ackP = waitFrame(ws, (f) => f.id === 'goal-reject-cancel');
+    const resultP = waitFrame(
+      ws,
+      (f) => f.event === 'result' && f.goalId === 'goal-reject-cancel'
+    );
+    sendGoal(ws, 'goal-reject-cancel');
+    await ackP;
+    const cancelP = waitFrame(ws, (f) => f.id === 'cancel-rejected');
+    ws.send(
+      JSON.stringify({
+        id: 'cancel-rejected',
+        kind: 'action',
+        op: 'cancel',
+        goalId: 'goal-reject-cancel',
+      })
+    );
+    const cancel = await cancelP;
+    assert.strictEqual(cancel.ok, false);
+    assert.strictEqual(cancel.code, 'cancel_rejected');
+    assert.strictEqual(cancel.payload.goals_canceling.length, 0);
+    assert.strictEqual((await resultP).status, 'succeeded');
+    ws.close();
+  });
+
+  it('reports a synchronous getResult failure', async function () {
+    const getResult = sinon
+      .stub(ClientGoalHandle.prototype, 'getResult')
+      .throws(new Error('result setup failed'));
+    try {
+      const ws = new WebSocket(url());
+      await waitOpen(ws);
+      const resultP = waitFrame(
+        ws,
+        (f) => f.event === 'result' && f.goalId === 'goal-result-error'
+      );
+      sendGoal(ws, 'goal-result-error');
+      const result = await resultP;
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.code, 'action_failed');
+      assert.match(result.error, /result setup failed/);
+      ws.close();
+    } finally {
+      getResult.restore();
+    }
+  });
+
+  it('keeps the action client alive until a pending cancel settles', async function () {
+    let resolveResult;
+    let resolveCancel;
+    let actionClient;
+    const getResult = sinon
+      .stub(ClientGoalHandle.prototype, 'getResult')
+      .returns(new Promise((resolve) => (resolveResult = resolve)));
+    const cancelGoal = sinon
+      .stub(ClientGoalHandle.prototype, 'cancelGoal')
+      .callsFake(function () {
+        actionClient = this._actionClient;
+        return new Promise((resolve) => (resolveCancel = resolve));
+      });
+    const destroy = sinon.spy(ActionClient.prototype, 'destroy');
+    try {
+      const ws = new WebSocket(url());
+      await waitOpen(ws);
+      const ackP = waitFrame(ws, (f) => f.id === 'goal-pending-cancel');
+      sendGoal(ws, 'goal-pending-cancel');
+      await ackP;
+      ws.send(
+        JSON.stringify({
+          id: 'pending-cancel',
+          kind: 'action',
+          op: 'cancel',
+          goalId: 'goal-pending-cancel',
+        })
+      );
+      while (!cancelGoal.called) {
+        await assertUtils.createDelay(5);
+      }
+      const closed = new Promise((resolve) => ws.once('close', resolve));
+      ws.close();
+      await closed;
+      resolveResult(new Fibonacci.Result());
+      await assertUtils.createDelay(20);
+      assert.strictEqual(destroy.calledOn(actionClient), false);
+      resolveCancel({ return_code: 0, goals_canceling: [{}] });
+      await assertUtils.createDelay(20);
+      assert.strictEqual(destroy.calledOn(actionClient), true);
+    } finally {
+      getResult.restore();
+      cancelGoal.restore();
+      destroy.restore();
+    }
   });
 
   it('rejects non-JSON frames with code:invalid_json', async function () {

--- a/test/test-runtime.js
+++ b/test/test-runtime.js
@@ -22,22 +22,30 @@ describe('CapabilityRegistry (unit)', function () {
       call: { '/add': 'example_interfaces/srv/AddTwoInts' },
       publish: { '/chatter': { type: 'std_msgs/msg/String' } },
       subscribe: { '/scan': 'sensor_msgs/msg/LaserScan' },
+      action: { '/fibonacci': 'example_interfaces/action/Fibonacci' },
     });
     assert.deepStrictEqual(reg.list(), {
       call: { '/add': 'example_interfaces/srv/AddTwoInts' },
       publish: { '/chatter': 'std_msgs/msg/String' },
       subscribe: { '/scan': 'sensor_msgs/msg/LaserScan' },
+      action: { '/fibonacci': 'example_interfaces/action/Fibonacci' },
     });
   });
 
   it('resolve() returns the matching capability or null', function () {
     const reg = new CapabilityRegistry().expose({
       call: { '/add': 'example_interfaces/srv/AddTwoInts' },
+      action: { '/fibonacci': 'example_interfaces/action/Fibonacci' },
     });
     assert.deepStrictEqual(reg.resolve('call', '/add'), {
       kind: 'call',
       name: '/add',
       type: 'example_interfaces/srv/AddTwoInts',
+    });
+    assert.deepStrictEqual(reg.resolve('action', '/fibonacci'), {
+      kind: 'action',
+      name: '/fibonacci',
+      type: 'example_interfaces/action/Fibonacci',
     });
     assert.strictEqual(reg.resolve('call', '/missing'), null);
     assert.strictEqual(reg.resolve('publish', '/add'), null);
@@ -140,7 +148,7 @@ describe('Web Runtime end-to-end (WebSocket transport)', function () {
     ws.close();
   });
 
-  it('reserves kind:action with code:not_implemented', async function () {
+  it('rejects an action frame with a missing/unknown op with code:unknown_op', async function () {
     const ws = new WebSocket(url());
     await waitOpen(ws);
     const replyP = waitFrame(ws, (f) => f.id === 'a1');
@@ -149,7 +157,26 @@ describe('Web Runtime end-to-end (WebSocket transport)', function () {
     );
     const reply = await replyP;
     assert.strictEqual(reply.ok, false);
-    assert.strictEqual(reply.code, 'not_implemented');
+    assert.strictEqual(reply.code, 'unknown_op');
+    ws.close();
+  });
+
+  it('rejects action send_goal against an unexposed capability with code:not_exposed', async function () {
+    const ws = new WebSocket(url());
+    await waitOpen(ws);
+    const replyP = waitFrame(ws, (f) => f.id === 'a2');
+    ws.send(
+      JSON.stringify({
+        id: 'a2',
+        kind: 'action',
+        op: 'send_goal',
+        capability: '/anything',
+        payload: {},
+      })
+    );
+    const reply = await replyP;
+    assert.strictEqual(reply.ok, false);
+    assert.strictEqual(reply.code, 'not_exposed');
     ws.close();
   });
 

--- a/test/test-runtime.js
+++ b/test/test-runtime.js
@@ -7,6 +7,7 @@
 //     http://www.apache.org/licenses/LICENSE-2.0
 
 import assert from 'assert';
+import { setImmediate as nextTurn } from 'node:timers/promises';
 import sinon from 'sinon';
 import WebSocket from 'ws';
 import rclnodejs from '../index.js';
@@ -15,6 +16,8 @@ import ClientGoalHandle from '../lib/action/client_goal_handle.js';
 import {
   createRuntime,
   CapabilityRegistry,
+  Connection,
+  Dispatcher,
   WebSocketTransport,
 } from '../lib/runtime/index.js';
 import * as assertUtils from './utils.js';
@@ -68,6 +71,265 @@ describe('CapabilityRegistry (unit)', function () {
       () => reg.expose({ call: { '/x': null } }),
       /string or { type: string }/
     );
+  });
+});
+
+describe('Dispatcher action cleanup', function () {
+  let node;
+  let sandbox;
+  let clock;
+  let connection;
+  let sendGoal;
+  let destroy;
+  const capability = '/cleanup_fibonacci';
+
+  before(async function () {
+    await rclnodejs.init();
+  });
+
+  after(function () {
+    rclnodejs.shutdown();
+  });
+
+  beforeEach(function () {
+    node = rclnodejs.createNode('runtime_cleanup_test_node');
+    sandbox = sinon.createSandbox();
+    clock = sandbox.useFakeTimers({
+      toFake: ['setTimeout', 'clearTimeout'],
+    });
+    sandbox
+      .stub(ActionClient.prototype, 'isActionServerAvailable')
+      .returns(true);
+    sendGoal = sandbox.stub(ActionClient.prototype, 'sendGoal');
+    destroy = sandbox.spy(ActionClient.prototype, 'destroy');
+    connection = new Connection();
+    connection.send = sandbox.spy();
+    const registry = new CapabilityRegistry().expose({
+      action: { [capability]: 'example_interfaces/action/Fibonacci' },
+    });
+    new Dispatcher({ node, registry }).handle(connection);
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+    node.destroy();
+  });
+
+  for (const phase of ['goal', 'result', 'cancel']) {
+    it(`bounds disconnected clients with a missing ${phase} response`, async function () {
+      let resolveGoal;
+      let resolveResult;
+      let resolveCancel;
+      const goalResponse = new Promise((resolve) => (resolveGoal = resolve));
+      const resultResponse = new Promise(
+        (resolve) => (resolveResult = resolve)
+      );
+      const cancelResponse = new Promise(
+        (resolve) => (resolveCancel = resolve)
+      );
+      const handle = {
+        isAccepted: () => true,
+        getResult: sandbox.stub().returns(resultResponse),
+        cancelGoal: sandbox.stub().returns(cancelResponse),
+        status: 4,
+      };
+      sendGoal.returns(goalResponse);
+      connection.emit('message', {
+        id: 'goal',
+        kind: 'action',
+        op: 'send_goal',
+        capability,
+        payload: {},
+      });
+      if (phase !== 'goal') {
+        resolveGoal(handle);
+        await nextTurn();
+      }
+      if (phase === 'cancel') {
+        connection.emit('message', {
+          id: 'cancel',
+          kind: 'action',
+          op: 'cancel',
+          goalId: 'goal',
+        });
+        resolveResult({});
+        await nextTurn();
+      }
+      connection.emit('close');
+      await clock.tickAsync(29999);
+      assert.strictEqual(node._actionClients.length, 1);
+      assert.ok(destroy.notCalled);
+      connection.emit('close');
+      connection.emit('message', {
+        id: 'after-close',
+        kind: 'action',
+        op: 'send_goal',
+        capability,
+        payload: {},
+      });
+      assert.ok(sendGoal.calledOnce);
+      await clock.tickAsync(1);
+      await nextTurn();
+      assert.strictEqual(node._actionClients.length, 0);
+      assert.ok(destroy.calledOnce);
+      resolveGoal(handle);
+      resolveResult({});
+      resolveCancel({ goals_canceling: [{}] });
+      await nextTurn();
+      await nextTurn();
+      if (phase === 'goal') assert.ok(handle.getResult.notCalled);
+      assert.strictEqual(node._actionClients.length, 0);
+      assert.ok(destroy.calledOnce);
+      assert.strictEqual(clock.countTimers(), 0);
+    });
+  }
+
+  it('ignores feedback from completed goals when their wire ID is reused', async function () {
+    const feedbackCallbacks = [];
+    const results = [];
+    sendGoal.callsFake((goal, feedback) => {
+      feedbackCallbacks.push(feedback);
+      return Promise.resolve({
+        isAccepted: () => true,
+        status: 4,
+        getResult: () => new Promise((resolve) => results.push(resolve)),
+      });
+    });
+    const frame = {
+      id: 'reused',
+      kind: 'action',
+      op: 'send_goal',
+      capability,
+      payload: {},
+    };
+    connection.emit('message', frame);
+    await nextTurn();
+    results[0]({});
+    await nextTurn();
+    connection.emit('message', frame);
+    await nextTurn();
+    connection.send.resetHistory();
+    feedbackCallbacks[0]({ sequence: [99] });
+    assert.ok(connection.send.notCalled);
+    feedbackCallbacks[1]({ sequence: [2] });
+    assert.deepStrictEqual(connection.send.lastCall.args[0], {
+      event: 'feedback',
+      goalId: 'reused',
+      payload: { sequence: [2] },
+    });
+    results[1]({});
+    await nextTurn();
+    connection.send.resetHistory();
+    feedbackCallbacks[1]({ sequence: [99] });
+    assert.ok(connection.send.notCalled);
+    connection.emit('close');
+    await nextTurn();
+    await nextTurn();
+  });
+
+  it('suppresses feedback after a synchronous result-setup failure', async function () {
+    sendGoal.resolves({
+      isAccepted: () => true,
+      getResult: sandbox.stub().throws(new Error('result setup failed')),
+    });
+    connection.emit('message', {
+      id: 'failed',
+      kind: 'action',
+      op: 'send_goal',
+      capability,
+      payload: {},
+    });
+    await nextTurn();
+    assert.strictEqual(connection.send.lastCall.args[0].code, 'action_failed');
+    connection.send.resetHistory();
+    sendGoal.firstCall.args[1]({ sequence: [99] });
+    assert.ok(connection.send.notCalled);
+    connection.emit('close');
+    await nextTurn();
+    await nextTurn();
+  });
+
+  it('handles a real result after the disconnected client expires', async function () {
+    sendGoal.callThrough();
+    const actionType = 'example_interfaces/action/Fibonacci';
+    const Fibonacci = rclnodejs.require(actionType);
+    let finishExecution;
+    const execution = new Promise((resolve) => (finishExecution = resolve));
+    const server = new rclnodejs.ActionServer(
+      node,
+      actionType,
+      capability,
+      async (goalHandle) => {
+        await execution;
+        goalHandle.succeed();
+        return new Fibonacci.Result();
+      }
+    );
+    let requestTaken;
+    const requested = new Promise((resolve) => (requestTaken = resolve));
+    const executeRequest = server._executeGetResultRequest;
+    sandbox.stub(server, '_executeGetResultRequest').callsFake(function (
+      ...args
+    ) {
+      executeRequest.apply(this, args);
+      requestTaken();
+    });
+    let replySent;
+    let replyFailed;
+    const responded = new Promise((resolve, reject) => {
+      replySent = resolve;
+      replyFailed = reject;
+    });
+    const sendResponse = server._sendResultResponse;
+    sandbox.stub(server, '_sendResultResponse').callsFake(function (...args) {
+      try {
+        sendResponse.apply(this, args);
+        replySent();
+      } catch (error) {
+        replyFailed(error);
+      }
+    });
+    rclnodejs.spin(node);
+    try {
+      connection.emit('message', {
+        id: 'late-result',
+        kind: 'action',
+        op: 'send_goal',
+        capability,
+        payload: { order: 1 },
+      });
+      await requested;
+      connection.emit('close');
+      await clock.tickAsync(30000);
+      await nextTurn();
+      assert.strictEqual(node._actionClients.length, 0);
+      finishExecution();
+      await responded;
+      assert.ok(destroy.calledOnce);
+    } finally {
+      server.destroy();
+    }
+  });
+
+  it('clears the drain timer when the pending goal finishes normally', async function () {
+    let resolveGoal;
+    sendGoal.returns(new Promise((resolve) => (resolveGoal = resolve)));
+    connection.emit('message', {
+      id: 'goal',
+      kind: 'action',
+      op: 'send_goal',
+      capability,
+      payload: {},
+    });
+    connection.emit('close');
+    await clock.tickAsync(1000);
+    assert.ok(destroy.notCalled);
+    resolveGoal({ isAccepted: () => false });
+    await nextTurn();
+    await nextTurn();
+    assert.ok(destroy.calledOnce);
+    assert.strictEqual(node._actionClients.length, 0);
+    assert.strictEqual(clock.countTimers(), 0);
   });
 });
 

--- a/test/test-runtime.js
+++ b/test/test-runtime.js
@@ -227,27 +227,56 @@ describe('Dispatcher action cleanup', function () {
     await nextTurn();
   });
 
-  it('suppresses feedback after a synchronous result-setup failure', async function () {
-    sendGoal.resolves({
-      isAccepted: () => true,
-      getResult: sandbox.stub().throws(new Error('result setup failed')),
+  for (const failureMode of ['throws', 'rejects']) {
+    it(`releases feedback callbacks when getResult ${failureMode}`, async function () {
+      sendGoal.callThrough();
+      sandbox
+        .stub(ClientGoalHandle.prototype, 'getResult')
+        [failureMode](new Error('result setup failed'));
+      const actionType = 'example_interfaces/action/Fibonacci';
+      const Fibonacci = rclnodejs.require(actionType);
+      const server = new rclnodejs.ActionServer(
+        node,
+        actionType,
+        capability,
+        (goalHandle) => {
+          goalHandle.succeed();
+          return new Fibonacci.Result();
+        }
+      );
+      rclnodejs.spin(node);
+      try {
+        for (let index = 0; index < 3; index++) {
+          connection.emit('message', {
+            id: 'failed',
+            kind: 'action',
+            op: 'send_goal',
+            capability,
+            payload: { order: 1 },
+          });
+          await sendGoal.lastCall.returnValue;
+          await nextTurn();
+          assert.deepStrictEqual(connection.send.lastCall.args[0], {
+            event: 'result',
+            goalId: 'failed',
+            ok: false,
+            error: 'get result failed: result setup failed',
+            code: 'action_failed',
+          });
+          assert.strictEqual(node._actionClients.length, 1);
+          assert.strictEqual(node._actionClients[0]._feedbackCallbacks.size, 0);
+          connection.send.resetHistory();
+          sendGoal.lastCall.args[1]({ sequence: [99] });
+          assert.ok(connection.send.notCalled);
+        }
+      } finally {
+        connection.emit('close');
+        await nextTurn();
+        await nextTurn();
+        server.destroy();
+      }
     });
-    connection.emit('message', {
-      id: 'failed',
-      kind: 'action',
-      op: 'send_goal',
-      capability,
-      payload: {},
-    });
-    await nextTurn();
-    assert.strictEqual(connection.send.lastCall.args[0].code, 'action_failed');
-    connection.send.resetHistory();
-    sendGoal.firstCall.args[1]({ sequence: [99] });
-    assert.ok(connection.send.notCalled);
-    connection.emit('close');
-    await nextTurn();
-    await nextTurn();
-  });
+  }
 
   it('handles a real result after the disconnected client expires', async function () {
     sendGoal.callThrough();

--- a/test/test-runtime.js
+++ b/test/test-runtime.js
@@ -184,6 +184,126 @@ describe('Dispatcher action cleanup', function () {
     });
   }
 
+  for (const failureMode of ['throws', 'rejects']) {
+    it(`cleans up a cancel request when cancelGoal ${failureMode}`, async function () {
+      let resolveResult;
+      const handle = {
+        isAccepted: () => true,
+        getResult: () => new Promise((resolve) => (resolveResult = resolve)),
+        cancelGoal: sandbox.stub()[failureMode](new Error('cancel failed')),
+        status: 4,
+      };
+      sendGoal.resolves(handle);
+      connection.emit('message', {
+        id: 'goal',
+        kind: 'action',
+        op: 'send_goal',
+        capability,
+        payload: {},
+      });
+      await nextTurn();
+      connection.emit('message', {
+        id: 'cancel',
+        kind: 'action',
+        op: 'cancel',
+        goalId: 'goal',
+      });
+      await nextTurn();
+      assert.deepStrictEqual(connection.send.lastCall.args[0], {
+        id: 'cancel',
+        ok: false,
+        error: 'cancel failed: cancel failed',
+        code: 'action_failed',
+      });
+      assert.ok(destroy.notCalled);
+      sendGoal.firstCall.args[1]({ sequence: [1] });
+      assert.deepStrictEqual(connection.send.lastCall.args[0], {
+        event: 'feedback',
+        goalId: 'goal',
+        payload: { sequence: [1] },
+      });
+      resolveResult({ sequence: [1, 1] });
+      await nextTurn();
+      assert.deepStrictEqual(connection.send.lastCall.args[0], {
+        event: 'result',
+        goalId: 'goal',
+        payload: { sequence: [1, 1] },
+        status: 'succeeded',
+      });
+      connection.emit('close');
+      await nextTurn();
+      await nextTurn();
+      assert.strictEqual(node._actionClients.length, 0);
+      assert.ok(destroy.calledOnce);
+      assert.strictEqual(clock.countTimers(), 0);
+    });
+  }
+
+  it('keeps the client alive until all concurrent cancel requests settle', async function () {
+    let resolveResult;
+    let resolveFirstCancel;
+    let resolveSecondCancel;
+    const cancelGoal = sandbox.stub();
+    cancelGoal
+      .onFirstCall()
+      .returns(new Promise((resolve) => (resolveFirstCancel = resolve)));
+    cancelGoal
+      .onSecondCall()
+      .returns(new Promise((resolve) => (resolveSecondCancel = resolve)));
+    sendGoal.resolves({
+      isAccepted: () => true,
+      getResult: () => new Promise((resolve) => (resolveResult = resolve)),
+      cancelGoal,
+      status: 4,
+    });
+    connection.emit('message', {
+      id: 'goal',
+      kind: 'action',
+      op: 'send_goal',
+      capability,
+      payload: {},
+    });
+    await nextTurn();
+    for (const id of ['first-cancel', 'second-cancel']) {
+      connection.emit('message', {
+        id,
+        kind: 'action',
+        op: 'cancel',
+        goalId: 'goal',
+      });
+    }
+    assert.ok(cancelGoal.calledTwice);
+    connection.emit('close');
+    resolveResult({});
+    await nextTurn();
+    assert.ok(destroy.notCalled);
+    const rejected = { return_code: 1, goals_canceling: [] };
+    resolveSecondCancel(rejected);
+    await nextTurn();
+    await nextTurn();
+    assert.deepStrictEqual(connection.send.lastCall.args[0], {
+      id: 'second-cancel',
+      ok: false,
+      error: 'cancel rejected: goal',
+      code: 'cancel_rejected',
+      payload: rejected,
+    });
+    assert.strictEqual(node._actionClients.length, 1);
+    assert.ok(destroy.notCalled);
+    const accepted = { return_code: 0, goals_canceling: [{}] };
+    resolveFirstCancel(accepted);
+    await nextTurn();
+    await nextTurn();
+    assert.deepStrictEqual(connection.send.lastCall.args[0], {
+      id: 'first-cancel',
+      ok: true,
+      payload: accepted,
+    });
+    assert.strictEqual(node._actionClients.length, 0);
+    assert.ok(destroy.calledOnce);
+    assert.strictEqual(clock.countTimers(), 0);
+  });
+
   it('ignores feedback from completed goals when their wire ID is reused', async function () {
     const feedbackCallbacks = [];
     const results = [];

--- a/test/test-web-cli.js
+++ b/test/test-web-cli.js
@@ -62,6 +62,7 @@ describe('rclnodejs-web CLI', function () {
         call: {},
         publish: {},
         subscribe: {},
+        action: {},
       });
     });
 
@@ -90,6 +91,8 @@ describe('rclnodejs-web CLI', function () {
         '/cmd_vel=geometry_msgs/msg/Twist',
         '--subscribe',
         '/scan=sensor_msgs/msg/LaserScan',
+        '--action',
+        '/fibonacci=example_interfaces/action/Fibonacci',
       ]);
       assert.deepStrictEqual(partial.expose.call, {
         '/add': 'example_interfaces/srv/AddTwoInts',
@@ -99,6 +102,9 @@ describe('rclnodejs-web CLI', function () {
       });
       assert.deepStrictEqual(partial.expose.subscribe, {
         '/scan': 'sensor_msgs/msg/LaserScan',
+      });
+      assert.deepStrictEqual(partial.expose.action, {
+        '/fibonacci': 'example_interfaces/action/Fibonacci',
       });
     });
 


### PR DESCRIPTION
- Add action capabilities to the registry, CLI configuration, and runtime types
- Support goal submission, feedback, results, and per-goal cancellation
- Report unavailable servers, rejected goals, and action failures
- Bound disconnected-client cleanup with a 30-second drain period
- Release feedback callbacks on completion or failure and clear pending state on teardown
- Add regression coverage for callback cleanup, reused IDs, late replies, and concurrent cancellation
- Run regular and IDL tests in separate Node.js 26 matrix jobs (43.3% reduction)

Fix: #1579