### PR TITLE
Pump checkout and setup-node actions to v7

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,13 +26,13 @@ jobs:
     if: github.repository == 'RobotWebTools/rclnodejs'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
 

--- a/.github/workflows/linux-arm64-build-and-test.yml
+++ b/.github/workflows/linux-arm64-build-and-test.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         architecture: ${{ matrix.architecture }}
@@ -88,7 +88,7 @@ jobs:
         fi
         sudo apt install -y xvfb libgtk-3-0 libnss3 $LIBASOUND_PKG libgbm-dev
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Fix permissions
       run: |

--- a/.github/workflows/linux-x64-asan-test.yml
+++ b/.github/workflows/linux-x64-asan-test.yml
@@ -21,12 +21,12 @@ jobs:
       image: ubuntu:26.04
     steps:
     - name: Setup Node.js 24.X
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24.X
         architecture: x64
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Setup ROS2 Lyrical from apt
       # ros-tooling/setup-ros does not support lyrical yet, so the shared

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -49,14 +49,14 @@ jobs:
             ros_tar_url: "https://github.com/ros2/ros2/releases/download/release-rolling-nightlies/ros2-rolling-nightly-linux-amd64.tar.bz2"
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         architecture: ${{ matrix.architecture }}
 
     # Checkout early so the local composite action under .github/actions is
     # available to the rolling / lyrical apt setup step below.
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Setup ROS2
       if: ${{ matrix.ros_distribution != 'rolling' && matrix.ros_distribution != 'lyrical' }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,10 +40,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/prebuild-linux-arm64.yml
+++ b/.github/workflows/prebuild-linux-arm64.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         architecture: ${{ matrix.architecture }}
@@ -68,7 +68,7 @@ jobs:
       run: |
         apt-get install -y ros-lyrical-desktop
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/prebuild-linux-x64.yml
+++ b/.github/workflows/prebuild-linux-x64.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Setup Node.js ${{ matrix.node-version }} on ${{ matrix.architecture }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         architecture: ${{ matrix.architecture }}
@@ -68,7 +68,7 @@ jobs:
       run: |
         apt-get install -y ros-lyrical-desktop
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -42,7 +42,7 @@ jobs:
             run_tests: false
     steps:
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -83,7 +83,7 @@ jobs:
     - name: Prebuild - Setup VS Dev Environment
       uses: seanmiddleditch/gha-setup-vsdevenv@v4
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Build rclnodejs
       shell: cmd


### PR DESCRIPTION
- Update `actions/checkout` from v6 to v7.
- Update `actions/setup-node` from v6 to v7.
- Apply the upgrades across build, test, prebuild, deployment, and npm publishing workflows.

Fix: #1587 