### PR TITLE
Optimize CI coverage across Node.js and ROS 2

### DIFF
--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [24.X, 26.X]
+        node-version: [24.X]
         architecture: [x64]
         ros_distribution:
           - humble
@@ -28,6 +28,9 @@ jobs:
           - kilted
           - lyrical
           - rolling
+        exclude:
+          - node-version: 24.X
+            ros_distribution: rolling
         include:
           # Humble Hawksbill (May 2022 - May 2027)
           - docker_image: ubuntu:jammy
@@ -44,7 +47,9 @@ jobs:
           # Rolling Ridley (No End-Of-Life) - migrated to Ubuntu 26.04 (resolute)
           # to follow the Lyrical Luth target platform.
           # See: https://docs.ros.org/en/jazzy/Releases/Release-Lyrical-Luth.html
-          - docker_image: ubuntu:resolute
+          - node-version: 26.X
+            architecture: x64
+            docker_image: ubuntu:resolute
             ros_distribution: rolling
             ros_tar_url: "https://github.com/ros2/ros2/releases/download/release-rolling-nightlies/ros2-rolling-nightly-linux-amd64.tar.bz2"
     steps:
@@ -149,7 +154,7 @@ jobs:
           npm run clean
 
     - name: Coveralls
-      if: ${{ matrix.ros_distribution == 'rolling' && matrix['node-version'] == '24.X' }}
+      if: ${{ matrix.ros_distribution == 'rolling' && matrix['node-version'] == '26.X' }}
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -136,7 +136,9 @@ jobs:
           else
             npm test
           fi
-          npm run clean
+          if [ "${{ matrix.ros_distribution }}" != "rolling" ]; then
+            npm run clean
+          fi
 
     - name: Test with IDL ROS messages (rolling)
       if: ${{ matrix.ros_distribution == 'rolling' }}
@@ -148,7 +150,6 @@ jobs:
         timeout_minutes: 60
         command: |
           source /opt/ros/${{ matrix.ros_distribution }}/setup.bash
-          npm i
           npm run test-idl
           npm run clean
 

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -139,8 +139,8 @@ jobs:
           fi
           npm run clean
 
-    - name: Test with IDL ROS messages (rolling / lyrical)
-      if: ${{ matrix.ros_distribution == 'rolling' || matrix.ros_distribution == 'lyrical' }}
+    - name: Test with IDL ROS messages (rolling)
+      if: ${{ matrix.ros_distribution == 'rolling' }}
       uses: nick-fields/retry@v4
       with:
         shell: bash
@@ -154,7 +154,7 @@ jobs:
           npm run clean
 
     - name: Coveralls
-      if: ${{ matrix.ros_distribution == 'rolling' && matrix['node-version'] == '26.X' }}
+      if: ${{ matrix.ros_distribution == 'lyrical' && matrix['node-version'] == '24.X' }}
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linux-x64-build-and-test.yml
+++ b/.github/workflows/linux-x64-build-and-test.yml
@@ -129,10 +129,9 @@ jobs:
           npm i
           npm run lint
           # c8 (coverage) depends on yargs 17, whose extensionless `yargs/yargs`
-          # entry fails to load under `require()` on Node 26. Coverage is only
-          # uploaded from the Node 24.X leg, so wrap with c8 there and run the
-          # plain suite everywhere else to keep the Node 26 lane green.
-          if [ "${{ matrix.node-version }}" = "24.X" ]; then
+          # entry fails to load under `require()` on Node 26. Generate coverage
+          # only in the Lyrical Node 24.X leg that uploads it below.
+          if [ "${{ matrix.ros_distribution }}" = "lyrical" ] && [ "${{ matrix.node-version }}" = "24.X" ]; then
             npm run test:coverage
           else
             npm test

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [24.X]
+        node-version: [22.X]
         ros_distribution:
           - humble
           - jazzy

--- a/test/test-message-generation-bin.js
+++ b/test/test-message-generation-bin.js
@@ -69,7 +69,7 @@ describe('rclnodejs generate-messages binary-script tests', function () {
   let tmpPkg;
   const args = process.argv.find((arg) => arg === '--idl') ? ['--idl'] : [];
 
-  this.timeout(90 * 1000); // 90 seconds to run this test suite
+  this.timeout(10 * 60 * 1000);
 
   // Create a test pkg wtih rclnodejs dependency
   //   create test package folder

--- a/test/test-message-generation-bin.js
+++ b/test/test-message-generation-bin.js
@@ -69,7 +69,7 @@ describe('rclnodejs generate-messages binary-script tests', function () {
   let tmpPkg;
   const args = process.argv.find((arg) => arg === '--idl') ? ['--idl'] : [];
 
-  this.timeout(10 * 60 * 1000);
+  this.timeout(15 * 60 * 1000);
 
   // Create a test pkg wtih rclnodejs dependency
   //   create test package folder
@@ -117,7 +117,7 @@ describe('rclnodejs generate-messages binary-script tests', function () {
       // stdio: 'inherit',
       shell: true,
       cwd: this.tmpPkg,
-      timeout: 300 * 1000,
+      timeout: 10 * 60 * 1000,
     });
 
     let generatedFolderPath = createGeneratedFolderPath(this.tmpPkg);


### PR DESCRIPTION
- Run fixed ROS 2 releases on Linux x64 with Node.js 24
- Run ROS 2 Rolling exclusively with Node.js 26
- Use Node.js 22 for Windows build and test coverage
- Run the expensive custom IDL tests only with Rolling
- Upload Coveralls results from Lyrical with Node.js 24
- Increase the message-generation test timeout to 10 minutes for slower ARM64 builds

Fix: #1591 