### PR TITLE
[Web runtime] Add WebSocket action support (2/3)

### DIFF
--- a/test/test-web-action.js
+++ b/test/test-web-action.js
@@ -275,6 +275,19 @@ describe('Action capability dispatch', function () {
       }
     });
 
+    it('treats null and undefined action options as omitted', async function () {
+      const ros = await connect(wsUrl);
+      try {
+        for (const options of [null, undefined]) {
+          const goal = await ros.action('/fibonacci', { order: 5 }, options);
+          assert.deepStrictEqual(await goal.result, { sequence: [1, 1, 2, 3] });
+          assert.strictEqual(goal.status, 'succeeded');
+        }
+      } finally {
+        await ros.close();
+      }
+    });
+
     it('rejects actions during and after WebSocket close without tracking goals', async function () {
       const ros = await connect(wsUrl);
       const closing = ros.close();
@@ -300,10 +313,14 @@ describe('Action capability dispatch', function () {
       try {
         const goal = await ros.action('/fibonacci', { order: 5 });
         await assertUtils.createDelay(20);
-        await goal.cancel();
+        assert.strictEqual(await goal.cancel(), undefined);
         const result = await goal.result;
         assert.deepStrictEqual(result, { sequence: [] });
         assert.strictEqual(goal.status, 'canceled');
+        await assert.rejects(
+          goal.cancel(),
+          (error) => error.code === 'unknown_goal_id'
+        );
       } finally {
         await ros.close();
       }

--- a/test/test-web-action.js
+++ b/test/test-web-action.js
@@ -10,7 +10,8 @@
 // test-runtime.js) plus SDK-level (`rclnodejs/web`) WebSocket round-trips.
 
 import assert from 'assert';
-import WebSocket from 'ws';
+import { once } from 'node:events';
+import WebSocket, { WebSocketServer } from 'ws';
 import rclnodejs from '../index.js';
 import { createRuntime, WebSocketTransport } from '../lib/runtime/index.js';
 import * as assertUtils from './utils.js';
@@ -266,10 +267,31 @@ describe('Action capability dispatch', function () {
         );
         const result = await goal.result;
         assert.deepStrictEqual(result.sequence, [1, 1, 2, 3]);
+        assert.strictEqual(goal.status, 'succeeded');
         assert.strictEqual(feedbacks.length, 1);
         assert.deepStrictEqual(feedbacks[0].sequence, [1, 1]);
       } finally {
         await ros.close();
+      }
+    });
+
+    it('rejects actions during and after WebSocket close without tracking goals', async function () {
+      const ros = await connect(wsUrl);
+      const closing = ros.close();
+      try {
+        await assert.rejects(
+          ros.action('/fibonacci', { order: 5 }),
+          /connection closed/
+        );
+        await closing;
+        await assert.rejects(
+          ros.action('/fibonacci', { order: 5 }),
+          /connection closed/
+        );
+        assert.strictEqual(ros._ws._pending.size, 0);
+        assert.strictEqual(ros._ws._goals.size, 0);
+      } finally {
+        await closing;
       }
     });
 
@@ -281,8 +303,103 @@ describe('Action capability dispatch', function () {
         await goal.cancel();
         const result = await goal.result;
         assert.deepStrictEqual(result, { sequence: [] });
+        assert.strictEqual(goal.status, 'canceled');
       } finally {
         await ros.close();
+      }
+    });
+
+    for (const { name, terminal, errorCode } of [
+      { name: 'missing status', terminal: { payload: {} } },
+      { name: 'unknown status', terminal: { status: 'unknown', payload: {} } },
+      {
+        name: 'invalid status',
+        terminal: { status: 'executing', payload: {} },
+      },
+      {
+        name: 'result error',
+        terminal: { ok: false, code: 'action_failed', error: 'result failed' },
+        errorCode: 'action_failed',
+      },
+      {
+        name: 'connection loss before a result',
+        terminal: null,
+        errorCode: 'connection_lost',
+      },
+    ]) {
+      it(`does not infer a terminal status from ${name}`, async function () {
+        const wireServer = new WebSocketServer({ port: 0, host: '127.0.0.1' });
+        wireServer.on('connection', (socket) => {
+          socket.on('message', (data) => {
+            const { id } = JSON.parse(data.toString());
+            socket.send(
+              JSON.stringify({ id, ok: true, payload: { accepted: true } })
+            );
+            if (terminal === null) {
+              socket.close();
+            } else {
+              socket.send(
+                JSON.stringify({ event: 'result', goalId: id, ...terminal })
+              );
+            }
+          });
+        });
+        await once(wireServer, 'listening');
+        let ros;
+        try {
+          ros = await connect(
+            `ws://127.0.0.1:${wireServer.address().port}/capability`
+          );
+          const goal = await ros.action('/fibonacci', { order: 5 });
+          if (errorCode) {
+            await assert.rejects(
+              goal.result,
+              (error) => error.code === errorCode
+            );
+          } else {
+            assert.deepStrictEqual(await goal.result, {});
+          }
+          assert.strictEqual(
+            goal.status,
+            terminal === null ? undefined : 'unknown'
+          );
+          assert.strictEqual(ros._ws._goals.size, 0);
+        } finally {
+          if (ros) await ros.close();
+          await new Promise((resolve) => wireServer.close(resolve));
+        }
+      });
+    }
+
+    it('exposes an aborted status without changing the result payload', async function () {
+      const capability = '/fibonacci_abort';
+      let finishExecution;
+      const execution = new Promise((resolve) => (finishExecution = resolve));
+      const actionServer = new rclnodejs.ActionServer(
+        node,
+        fibonacci,
+        capability,
+        async (goalHandle) => {
+          await execution;
+          goalHandle.abort();
+          return new Fibonacci.Result();
+        }
+      );
+      runtime.expose({ action: { [capability]: fibonacci } });
+      const ros = await connect(wsUrl);
+      try {
+        const goal = await ros.action(capability, { order: 5 });
+        assert.strictEqual(goal.status, undefined);
+        finishExecution();
+        assert.deepStrictEqual(await goal.result, { sequence: [] });
+        assert.strictEqual(goal.status, 'aborted');
+        assert.throws(() => {
+          goal.status = 'succeeded';
+        }, TypeError);
+      } finally {
+        finishExecution();
+        await ros.close();
+        actionServer.destroy();
       }
     });
   });

--- a/test/test-web-action.js
+++ b/test/test-web-action.js
@@ -288,6 +288,79 @@ describe('Action capability dispatch', function () {
       }
     });
 
+    it('rejects invalid feedback callbacks before opening the lazy WebSocket', async function () {
+      const httpUrl = new URL(wsUrl);
+      httpUrl.protocol = 'http:';
+      httpUrl.pathname = '/';
+      const ros = await connect(httpUrl.href);
+      try {
+        for (const onFeedback of [null, false, 0, 1, 'feedback', {}, []]) {
+          await assert.rejects(
+            ros.action('/fibonacci', { order: 5 }, { onFeedback }),
+            {
+              name: 'TypeError',
+              message:
+                'action(capability, payload, options): onFeedback must be a function',
+            }
+          );
+          assert.strictEqual(ros._ws, null);
+          assert.strictEqual(ros._wsConnect, null);
+        }
+      } finally {
+        await ros.close();
+      }
+    });
+
+    it('isolates errors thrown by valid feedback callbacks', async function () {
+      const ros = await connect(wsUrl);
+      let feedbackCount = 0;
+      try {
+        const goal = await ros.action(
+          '/fibonacci',
+          { order: 5 },
+          {
+            onFeedback() {
+              feedbackCount++;
+              throw new Error('feedback callback failed');
+            },
+          }
+        );
+        assert.deepStrictEqual(await goal.result, { sequence: [1, 1, 2, 3] });
+        assert.strictEqual(goal.status, 'succeeded');
+        assert.strictEqual(feedbackCount, 1);
+      } finally {
+        await ros.close();
+      }
+    });
+
+    it('does not open the lazy WebSocket during or after client close', async function () {
+      const httpUrl = new URL(wsUrl);
+      httpUrl.protocol = 'http:';
+      httpUrl.pathname = '/';
+      const ros = await connect(httpUrl.href);
+      const closing = ros.close();
+      try {
+        await assert.rejects(
+          ros.action('/fibonacci', { order: 5 }),
+          /connection closed/
+        );
+        await closing;
+        await assert.rejects(
+          ros.action('/fibonacci', { order: 5 }),
+          /connection closed/
+        );
+        await assert.rejects(
+          ros.subscribe('/feedback', () => {}),
+          /connection closed/
+        );
+        await assert.rejects(ros.connect(), /connection closed/);
+        assert.strictEqual(ros._ws, null);
+        assert.strictEqual(ros._wsConnect, null);
+      } finally {
+        await ros.close();
+      }
+    });
+
     it('rejects actions during and after WebSocket close without tracking goals', async function () {
       const ros = await connect(wsUrl);
       const closing = ros.close();

--- a/test/test-web-action.js
+++ b/test/test-web-action.js
@@ -1,0 +1,289 @@
+// Copyright (c) 2026 RobotWebTools Contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Action capability dispatch coverage: raw wire-protocol frames (mirroring
+// test-runtime.js) plus SDK-level (`rclnodejs/web`) WebSocket round-trips.
+
+import assert from 'assert';
+import WebSocket from 'ws';
+import rclnodejs from '../index.js';
+import { createRuntime, WebSocketTransport } from '../lib/runtime/index.js';
+import * as assertUtils from './utils.js';
+
+// `web/` is ESM; dynamic import() defers loading the browser SDK until the test starts.
+let connect;
+before(async function () {
+  ({ connect } = await import('../web/index.js'));
+});
+
+describe('Action capability dispatch', function () {
+  this.timeout(60 * 1000);
+
+  const fibonacci = 'example_interfaces/action/Fibonacci';
+  let Fibonacci;
+  let node;
+  let runtime;
+  let server;
+  let wsUrl;
+
+  function waitOpen(ws) {
+    return new Promise((resolve, reject) => {
+      ws.once('open', resolve);
+      ws.once('error', reject);
+    });
+  }
+
+  function waitFrame(ws, predicate) {
+    return new Promise((resolve) => {
+      const onMsg = (data) => {
+        const frame = JSON.parse(data.toString('utf8'));
+        if (predicate(frame)) {
+          ws.off('message', onMsg);
+          resolve(frame);
+        }
+      };
+      ws.on('message', onMsg);
+    });
+  }
+
+  // Long enough to leave a window for feedback/cancel to land before the
+  // goal finishes, short enough to keep the suite fast.
+  async function executeCallback(goalHandle) {
+    const feedback = new Fibonacci.Feedback();
+    feedback.sequence = [1, 1];
+    goalHandle.publishFeedback(feedback);
+    await assertUtils.createDelay(50);
+    if (goalHandle.isCancelRequested) {
+      goalHandle.canceled();
+      return new Fibonacci.Result();
+    }
+    await assertUtils.createDelay(50);
+    goalHandle.succeed();
+    const result = new Fibonacci.Result();
+    result.sequence = [1, 1, 2, 3];
+    return result;
+  }
+
+  function cancelCallback() {
+    return rclnodejs.CancelResponse.ACCEPT;
+  }
+
+  before(async function () {
+    await rclnodejs.init();
+    Fibonacci = rclnodejs.require(fibonacci);
+    node = rclnodejs.createNode('action_dispatch_test_node');
+    rclnodejs.spin(node);
+
+    server = new rclnodejs.ActionServer(
+      node,
+      fibonacci,
+      '/fibonacci',
+      executeCallback,
+      null,
+      null,
+      cancelCallback
+    );
+
+    runtime = createRuntime({
+      node,
+      transport: new WebSocketTransport({ port: 0, host: '127.0.0.1' }),
+    });
+    runtime.expose({ action: { '/fibonacci': fibonacci } });
+    await runtime.start();
+    wsUrl = `ws://127.0.0.1:${runtime.transports[0].port}/capability`;
+  });
+
+  after(async function () {
+    if (server) server.destroy();
+    if (runtime) await runtime.stop();
+    rclnodejs.shutdown();
+  });
+
+  describe('wire protocol (WebSocket)', function () {
+    it('rejects send_goal against an unexposed action with code:not_exposed', async function () {
+      const ws = new WebSocket(wsUrl);
+      await waitOpen(ws);
+      const replyP = waitFrame(ws, (f) => f.id === 'g1');
+      ws.send(
+        JSON.stringify({
+          id: 'g1',
+          kind: 'action',
+          op: 'send_goal',
+          capability: '/no_such_action',
+          payload: {},
+        })
+      );
+      const reply = await replyP;
+      assert.strictEqual(reply.ok, false);
+      assert.strictEqual(reply.code, 'not_exposed');
+      ws.close();
+    });
+
+    it('accepts a goal, streams feedback, then a terminal result', async function () {
+      const ws = new WebSocket(wsUrl);
+      await waitOpen(ws);
+      const ackP = waitFrame(ws, (f) => f.id === 'g2');
+      const feedbackP = waitFrame(
+        ws,
+        (f) => f.event === 'feedback' && f.goalId === 'g2'
+      );
+      const resultP = waitFrame(
+        ws,
+        (f) => f.event === 'result' && f.goalId === 'g2'
+      );
+      ws.send(
+        JSON.stringify({
+          id: 'g2',
+          kind: 'action',
+          op: 'send_goal',
+          capability: '/fibonacci',
+          payload: { order: 5 },
+        })
+      );
+      const ack = await ackP;
+      assert.strictEqual(ack.ok, true);
+      assert.strictEqual(ack.payload.accepted, true);
+
+      const feedback = await feedbackP;
+      assert.deepStrictEqual(feedback.payload.sequence, [1, 1]);
+
+      const result = await resultP;
+      assert.strictEqual(result.status, 'succeeded');
+      assert.deepStrictEqual(result.payload.sequence, [1, 1, 2, 3]);
+      ws.close();
+    });
+
+    it('cancels an in-flight goal', async function () {
+      const ws = new WebSocket(wsUrl);
+      await waitOpen(ws);
+      const ackP = waitFrame(ws, (f) => f.id === 'g3');
+      ws.send(
+        JSON.stringify({
+          id: 'g3',
+          kind: 'action',
+          op: 'send_goal',
+          capability: '/fibonacci',
+          payload: { order: 5 },
+        })
+      );
+      await ackP;
+
+      const resultP = waitFrame(
+        ws,
+        (f) => f.event === 'result' && f.goalId === 'g3'
+      );
+      const cancelAckP = waitFrame(ws, (f) => f.id === 'c1');
+      ws.send(
+        JSON.stringify({
+          id: 'c1',
+          kind: 'action',
+          op: 'cancel',
+          goalId: 'g3',
+        })
+      );
+      const cancelAck = await cancelAckP;
+      assert.strictEqual(cancelAck.ok, true);
+
+      const result = await resultP;
+      assert.strictEqual(result.status, 'canceled');
+      ws.close();
+    });
+
+    it('rejects cancel of an unknown goal with code:unknown_goal_id', async function () {
+      const ws = new WebSocket(wsUrl);
+      await waitOpen(ws);
+      const replyP = waitFrame(ws, (f) => f.id === 'c2');
+      ws.send(
+        JSON.stringify({
+          id: 'c2',
+          kind: 'action',
+          op: 'cancel',
+          goalId: 'no-such-goal',
+        })
+      );
+      const reply = await replyP;
+      assert.strictEqual(reply.ok, false);
+      assert.strictEqual(reply.code, 'unknown_goal_id');
+      ws.close();
+    });
+
+    it('rejects a duplicate goal id while the first send is pending', async function () {
+      const ws = new WebSocket(wsUrl);
+      await waitOpen(ws);
+      const duplicateP = waitFrame(
+        ws,
+        (f) => f.id === 'duplicate' && f.code === 'duplicate_id'
+      );
+      const frame = JSON.stringify({
+        id: 'duplicate',
+        kind: 'action',
+        op: 'send_goal',
+        capability: '/fibonacci',
+        payload: { order: 5 },
+      });
+      ws.send(frame);
+      ws.send(frame);
+      const duplicate = await duplicateP;
+      assert.strictEqual(duplicate.ok, false);
+      ws.close();
+    });
+
+    it('survives disconnect while send_goal is pending', async function () {
+      const ws = new WebSocket(wsUrl);
+      await waitOpen(ws);
+      ws.send(
+        JSON.stringify({
+          id: 'disconnect',
+          kind: 'action',
+          op: 'send_goal',
+          capability: '/fibonacci',
+          payload: { order: 5 },
+        })
+      );
+      ws.close();
+      await assertUtils.createDelay(200);
+
+      const probe = new WebSocket(wsUrl);
+      await waitOpen(probe);
+      probe.close();
+    });
+  });
+
+  describe('SDK (rclnodejs/web)', function () {
+    it('sends a goal over WebSocket and awaits the result, with feedback', async function () {
+      const ros = await connect(wsUrl);
+      try {
+        const feedbacks = [];
+        const goal = await ros.action(
+          '/fibonacci',
+          { order: 5 },
+          { onFeedback: (fb) => feedbacks.push(fb) }
+        );
+        const result = await goal.result;
+        assert.deepStrictEqual(result.sequence, [1, 1, 2, 3]);
+        assert.strictEqual(feedbacks.length, 1);
+        assert.deepStrictEqual(feedbacks[0].sequence, [1, 1]);
+      } finally {
+        await ros.close();
+      }
+    });
+
+    it('cancels a goal over WebSocket', async function () {
+      const ros = await connect(wsUrl);
+      try {
+        const goal = await ros.action('/fibonacci', { order: 5 });
+        await assertUtils.createDelay(20);
+        await goal.cancel();
+        const result = await goal.result;
+        assert.deepStrictEqual(result, { sequence: [] });
+      } finally {
+        await ros.close();
+      }
+    });
+  });
+});

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,7 +1,9 @@
 /// <reference path='../../types/index.d.ts' />
+/// <reference path='../../web/index.d.ts' />
 
-import { expectType, expectAssignable } from 'tsd';
+import { expectType, expectAssignable, expectError } from 'tsd';
 import * as rclnodejs from 'rclnodejs';
+import type { ActionHandle, ActionStatus } from 'rclnodejs/web';
 import { ChildProcess } from 'child_process';
 import { Observable } from 'rxjs';
 
@@ -12,6 +14,16 @@ const TOPIC = 'topic';
 const SERVICE_NAME = 'service';
 const MSG = rclnodejs.createMessageObject(TYPE_CLASS);
 MSG.data = '';
+
+declare const webAction: ActionHandle<{ sequence: number[] }>;
+expectType<Promise<{ sequence: number[] }>>(webAction.result);
+expectType<ActionStatus | undefined>(webAction.status);
+expectAssignable<ActionStatus>('succeeded');
+expectAssignable<ActionStatus>('canceled');
+expectAssignable<ActionStatus>('aborted');
+expectAssignable<ActionStatus>('unknown');
+expectError((webAction.status = 'succeeded'));
+expectType<Promise<void>>(webAction.cancel());
 
 // ---- rclnodejs -----
 expectType<Promise<void>>(rclnodejs.init());

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -3,7 +3,13 @@
 
 import { expectType, expectAssignable, expectError } from 'tsd';
 import * as rclnodejs from 'rclnodejs';
-import type { ActionHandle, ActionStatus } from 'rclnodejs/web';
+import type {
+  ActionHandle,
+  ActionStatus,
+  Int64Wire,
+  RosClient,
+  WireType,
+} from 'rclnodejs/web';
 import { ChildProcess } from 'child_process';
 import { Observable } from 'rxjs';
 
@@ -24,6 +30,47 @@ expectAssignable<ActionStatus>('aborted');
 expectAssignable<ActionStatus>('unknown');
 expectError((webAction.status = 'succeeded'));
 expectType<Promise<void>>(webAction.cancel());
+
+declare const webClient: RosClient;
+const fibonacciAction = webClient.action<'example_interfaces/action/Fibonacci'>(
+  '/fibonacci',
+  { order: 5 },
+  {
+    onFeedback(feedback) {
+      expectType<{ sequence: number[] }>(feedback);
+    },
+  }
+);
+expectType<Promise<ActionHandle<{ sequence: number[] }>>>(fibonacciAction);
+fibonacciAction.then((goal) => {
+  expectType<Promise<{ sequence: number[] }>>(goal.result);
+  expectType<ActionStatus | undefined>(goal.status);
+  expectType<Promise<void>>(goal.cancel());
+});
+expectError(
+  webClient.action<'example_interfaces/action/Fibonacci'>('/fibonacci', {
+    order: '5',
+  })
+);
+expectError(
+  webClient.action<'example_interfaces/action/Fibonacci'>('/fibonacci', {})
+);
+expectType<Promise<ActionHandle<{ sequence: number[] }>>>(
+  webClient.action<'example_interfaces/action/Fibonacci'>(
+    '/fibonacci',
+    { order: 5 },
+    null
+  )
+);
+expectType<Promise<ActionHandle>>(
+  webClient.action('/custom_action', { custom: true }, null)
+);
+
+declare const wireArrays: WireType<{
+  values: Uint8Array | Float64Array;
+  ids: BigInt64Array | BigUint64Array;
+}>;
+expectType<{ values: number[]; ids: Int64Wire[] }>(wireArrays);
 
 // ---- rclnodejs -----
 expectType<Promise<void>>(rclnodejs.init());

--- a/web/client.js
+++ b/web/client.js
@@ -97,6 +97,7 @@ class _WsLink {
     this._ws = null;
     this._pending = new Map();
     this._subs = new Map();
+    this._goals = new Map(); // goal id -> { onFeedback, resolveResult, rejectResult }
     this._closed = false;
     this._isUserClosed = false;
     this._isReconnecting = false;
@@ -218,6 +219,48 @@ class _WsLink {
   publish(capability, payload) {
     return this._request({ kind: 'publish', capability, payload });
   }
+  action(capability, payload, { onFeedback } = {}) {
+    if (this._isReconnecting) {
+      return Promise.reject(_connectionLostError());
+    }
+    const id = _genId();
+    // Registered synchronously, before the frame is even sent: feedback is
+    // delivered over a separate topic subscription from the goal-accept
+    // service response, so a feedback frame can race ahead of the accept
+    // ack. If _goals isn't populated yet when that happens, the feedback
+    // is silently dropped (no id to route it to).
+    let resolveResult, rejectResult;
+    const result = new Promise((res, rej) => {
+      resolveResult = res;
+      rejectResult = rej;
+    });
+    this._goals.set(id, { onFeedback, resolveResult, rejectResult });
+    return new Promise((resolve, reject) => {
+      this._pending.set(id, {
+        resolve: () => {
+          resolve({
+            goalId: id,
+            result,
+            cancel: () => this._cancelGoal(id),
+          });
+        },
+        reject: (err) => {
+          this._goals.delete(id); // goal was never accepted; nothing to route to
+          reject(err);
+        },
+      });
+      this._sendRaw({
+        id,
+        kind: 'action',
+        op: 'send_goal',
+        capability,
+        payload,
+      });
+    });
+  }
+  _cancelGoal(goalId) {
+    return this._request({ kind: 'action', op: 'cancel', goalId });
+  }
   subscribe(capability, callback) {
     if (this._isReconnecting) {
       return Promise.reject(_connectionLostError());
@@ -333,6 +376,33 @@ class _WsLink {
       }
       return;
     }
+    if (frame.event === 'feedback') {
+      const goal = this._goals.get(frame.goalId);
+      if (goal && goal.onFeedback) {
+        try {
+          goal.onFeedback(frame.payload);
+        } catch (_) {
+          // user callback errors don't break the dispatch loop
+        }
+      }
+      return;
+    }
+    if (frame.event === 'result') {
+      const goal = this._goals.get(frame.goalId);
+      this._goals.delete(frame.goalId);
+      if (goal) {
+        if (frame.ok === false) {
+          goal.rejectResult(
+            Object.assign(new Error(frame.error || 'action failed'), {
+              code: frame.code,
+            })
+          );
+        } else {
+          goal.resolveResult(frame.payload);
+        }
+      }
+      return;
+    }
     const pend = this._pending.get(frame.id);
     if (!pend) return;
     this._pending.delete(frame.id);
@@ -351,6 +421,10 @@ class _WsLink {
       p.reject(cause);
     }
     this._pending.clear();
+    for (const goal of this._goals.values()) {
+      goal.rejectResult(cause);
+    }
+    this._goals.clear();
   }
 }
 
@@ -640,6 +714,20 @@ export class RosClient {
     }
     const ws = await this._ensureWs();
     return ws.subscribe(capability, callback);
+  }
+
+  /**
+   * Send an action goal. Returns `{ goalId, result, cancel() }` where
+   * `result` is a Promise resolving with the action result, and `cancel()`
+   * requests cancellation over WebSocket.
+   * @param {string} capability
+   * @param {*} payload The goal.
+   * @param {object} [options]
+   * @param {(feedback: *) => void} [options.onFeedback]
+   */
+  async action(capability, payload, options) {
+    const ws = await this._ensureWs();
+    return ws.action(capability, payload, options);
   }
 }
 

--- a/web/client.js
+++ b/web/client.js
@@ -220,6 +220,9 @@ class _WsLink {
     return this._request({ kind: 'publish', capability, payload });
   }
   action(capability, payload, { onFeedback } = {}) {
+    if (this._closed || this._isUserClosed) {
+      return Promise.reject(new Error('connection closed'));
+    }
     if (this._isReconnecting) {
       return Promise.reject(_connectionLostError());
     }
@@ -234,13 +237,24 @@ class _WsLink {
       resolveResult = res;
       rejectResult = rej;
     });
-    this._goals.set(id, { onFeedback, resolveResult, rejectResult });
+    let status;
+    this._goals.set(id, {
+      onFeedback,
+      resolveResult,
+      rejectResult,
+      setStatus(value) {
+        status = value;
+      },
+    });
     return new Promise((resolve, reject) => {
       this._pending.set(id, {
         resolve: () => {
           resolve({
             goalId: id,
             result,
+            get status() {
+              return status;
+            },
             cancel: () => this._cancelGoal(id),
           });
         },
@@ -391,6 +405,11 @@ class _WsLink {
       const goal = this._goals.get(frame.goalId);
       this._goals.delete(frame.goalId);
       if (goal) {
+        goal.setStatus(
+          ['succeeded', 'canceled', 'aborted'].includes(frame.status)
+            ? frame.status
+            : 'unknown'
+        );
         if (frame.ok === false) {
           goal.rejectResult(
             Object.assign(new Error(frame.error || 'action failed'), {
@@ -717,9 +736,11 @@ export class RosClient {
   }
 
   /**
-   * Send an action goal. Returns `{ goalId, result, cancel() }` where
+   * Send an action goal. Returns `{ goalId, result, status, cancel() }` where
    * `result` is a Promise resolving with the action result, and `cancel()`
    * requests cancellation over WebSocket.
+   * Read `status` after awaiting `result` to distinguish success, cancellation,
+   * and abortion without changing the result payload.
    * @param {string} capability
    * @param {*} payload The goal.
    * @param {object} [options]

--- a/web/client.js
+++ b/web/client.js
@@ -230,11 +230,8 @@ class _WsLink {
     }
     const { onFeedback } = options ?? {};
     const id = _genId();
-    // Registered synchronously, before the frame is even sent: feedback is
-    // delivered over a separate topic subscription from the goal-accept
-    // service response, so a feedback frame can race ahead of the accept
-    // ack. If _goals isn't populated yet when that happens, the feedback
-    // is silently dropped (no id to route it to).
+    // Register the goal before sending to avoid dropping feedback that
+    // arrives before the acknowledgement.
     let resolveResult, rejectResult;
     const result = new Promise((res, rej) => {
       resolveResult = res;

--- a/web/client.js
+++ b/web/client.js
@@ -23,9 +23,9 @@
 //
 // Two transports are supported, picked from the URL scheme:
 //
-//   - ws:// / wss://       → WebSocket only (call/publish/subscribe).
-//   - http:// / https://   → HTTP for call/publish; subscribe lazily
-//                            falls through to a sibling WebSocket.
+//   - ws:// / wss://       → WebSocket only (call/publish/subscribe/action).
+//   - http:// / https://   → HTTP for call/publish; subscribe and action
+//                            lazily use a sibling WebSocket.
 //   - { http, ws }         → explicit endpoint pair.
 
 let WS = globalThis.WebSocket;
@@ -76,7 +76,7 @@ function _backoffDelay(attempt, { baseMs = 500, maxMs = 30000 } = {}) {
 /**
  * WebSocket link. Speaks the capability frame protocol used by
  * `WebSocketTransport` on the server. Long-lived; supports `call`,
- * `publish`, `subscribe`, `unsubscribe` (and reserved `action`).
+ * `publish`, `subscribe`, `unsubscribe`, and `action`.
  *
  * With `options.reconnect`, a drop after a successful open reopens with
  * backoff and replays subscriptions under the same `subId`. The *first*
@@ -216,9 +216,11 @@ class _WsLink {
   call(capability, payload) {
     return this._request({ kind: 'call', capability, payload });
   }
+
   publish(capability, payload) {
     return this._request({ kind: 'publish', capability, payload });
   }
+
   action(capability, payload, options) {
     if (this._closed || this._isUserClosed) {
       return Promise.reject(new Error('connection closed'));
@@ -260,7 +262,8 @@ class _WsLink {
           });
         },
         reject: (err) => {
-          this._goals.delete(id); // goal was never accepted; nothing to route to
+          // Acceptance was not confirmed; stop local tracking.
+          this._goals.delete(id);
           reject(err);
         },
       });
@@ -273,9 +276,11 @@ class _WsLink {
       });
     });
   }
+
   async _cancelGoal(goalId) {
     await this._request({ kind: 'action', op: 'cancel', goalId });
   }
+
   subscribe(capability, callback) {
     if (this._isReconnecting) {
       return Promise.reject(_connectionLostError());
@@ -295,6 +300,7 @@ class _WsLink {
       this._sendRaw({ id, kind: 'subscribe', capability });
     });
   }
+
   _unsubscribe(subId) {
     this._subs.delete(subId);
     return this._request({ kind: 'unsubscribe', subId });
@@ -451,8 +457,8 @@ class _WsLink {
 /**
  * HTTP link. Speaks the L2 HTTP capability protocol used by
  * `HttpTransport` on the server. Stateless — every `call`/`publish`
- * is a one-shot `fetch()`. Does not support subscribe; the public
- * client falls through to the WebSocket link for streaming verbs.
+ * is a one-shot `fetch()`. Does not support subscribe or actions;
+ * the public client uses the WebSocket link for those verbs.
  */
 class _HttpLink {
   constructor(baseUrl) {
@@ -556,9 +562,9 @@ function _encodeRosName(name) {
  *
  * Picks a transport from the URL scheme:
  *
- *   - `ws://`, `wss://`      → WebSocket only (call/publish/subscribe).
- *   - `http://`, `https://`  → HTTP for `call`/`publish`; `subscribe`
- *     lazily falls through to a sibling WebSocket endpoint at the
+ *   - `ws://`, `wss://`      → WebSocket only (call/publish/subscribe/action).
+ *   - `http://`, `https://`  → HTTP for `call`/`publish`; `subscribe` and
+ *     `action` lazily use a sibling WebSocket endpoint at the
  *     same host with `/capability` appended.
  *   - object `{http, ws}`    → both URLs spelled out explicitly.
  *
@@ -575,7 +581,7 @@ function _encodeRosName(name) {
  *   // WebSocket-only (path defaults to /capability)
  *   const ros = await connect('ws://robot.local:9000');
  *
- *   // HTTP for call/publish, automatic WS sibling for subscribe
+ *   // HTTP for call/publish, WS sibling for subscribe/action
  *   const ros = await connect('http://robot.local:9001');
  *
  *   // Split endpoints (e.g. WS behind a different proxy)
@@ -608,9 +614,8 @@ export class RosClient {
     this._http = httpUrl ? new _HttpLink(httpUrl) : null;
     this._wsUrl = wsUrl;
     // Eagerly construct (but don't yet open) the WS link when the user
-    // explicitly asked for it. When the WS URL was *derived* from an
-    // HTTP base, leave construction lazy — most HTTP-only callers
-    // never subscribe and never need the WS sibling at all.
+    // explicitly asked for it. When the WS URL was derived from an
+    // HTTP base, leave construction lazy until subscribe() or action().
     this._ws = wsExplicit && wsUrl ? new _WsLink(wsUrl, this._wsOptions) : null;
     this._wsEager = !!wsExplicit;
     this._wsConnect = null; // memoised connect promise (in-flight or settled)
@@ -654,10 +659,9 @@ export class RosClient {
   /** Open the link(s). */
   async connect() {
     if (this._closed) throw new Error('connection closed');
-    // Open HTTP eagerly (it's a no-op anyway). Defer the WebSocket
-    // open until the user actually calls subscribe() — that way an
-    // HTTP-only deployment with no WS sibling works for call/publish
-    // without blowing up here.
+    // Open HTTP eagerly (it's a no-op anyway). Defer a derived WebSocket
+    // until subscribe() or action(), allowing HTTP-only deployments to
+    // use call/publish without a WebSocket endpoint.
     if (this._http) await this._http.connect();
     if (this._wsEager) await this._ensureWs();
     return this;
@@ -706,7 +710,7 @@ export class RosClient {
     this._wsConnect = link.connect().then(
       () => link,
       (err) => {
-        this._wsConnect = null; // allow a retry on next subscribe()
+        this._wsConnect = null; // allow retry on the next WebSocket operation
         throw Object.assign(
           new Error(
             `failed to open WebSocket sibling at ${this._wsUrl}: ${err && err.message ? err.message : String(err)}`
@@ -793,8 +797,8 @@ function _resolveUrls(url) {
     return { httpUrl: null, wsUrl: _normaliseWsPath(url), wsExplicit: true };
   }
   if (/^https?:\/\//i.test(url)) {
-    // HTTP base URL: derive a sibling WS URL lazily — we don't open
-    // it until the user actually calls subscribe().
+    // HTTP base URL: derive a sibling WS URL, but open it only for
+    // subscribe() or action().
     return { httpUrl: url, wsUrl: _deriveWsSibling(url), wsExplicit: false };
   }
   throw new TypeError(

--- a/web/client.js
+++ b/web/client.js
@@ -219,13 +219,14 @@ class _WsLink {
   publish(capability, payload) {
     return this._request({ kind: 'publish', capability, payload });
   }
-  action(capability, payload, { onFeedback } = {}) {
+  action(capability, payload, options) {
     if (this._closed || this._isUserClosed) {
       return Promise.reject(new Error('connection closed'));
     }
     if (this._isReconnecting) {
       return Promise.reject(_connectionLostError());
     }
+    const { onFeedback } = options ?? {};
     const id = _genId();
     // Registered synchronously, before the frame is even sent: feedback is
     // delivered over a separate topic subscription from the goal-accept
@@ -272,8 +273,8 @@ class _WsLink {
       });
     });
   }
-  _cancelGoal(goalId) {
-    return this._request({ kind: 'action', op: 'cancel', goalId });
+  async _cancelGoal(goalId) {
+    await this._request({ kind: 'action', op: 'cancel', goalId });
   }
   subscribe(capability, callback) {
     if (this._isReconnecting) {
@@ -743,7 +744,7 @@ export class RosClient {
    * and abortion without changing the result payload.
    * @param {string} capability
    * @param {*} payload The goal.
-   * @param {object} [options]
+   * @param {object|null} [options]
    * @param {(feedback: *) => void} [options.onFeedback]
    */
   async action(capability, payload, options) {

--- a/web/client.js
+++ b/web/client.js
@@ -596,6 +596,7 @@ export class RosClient {
    */
   constructor(url, options = {}) {
     this.options = options;
+    this._closed = false;
     this._listeners = new Map(); // event name -> Set<handler>
     const { httpUrl, wsUrl, wsExplicit } = _resolveUrls(url);
     this.url = httpUrl || wsUrl;
@@ -652,6 +653,7 @@ export class RosClient {
 
   /** Open the link(s). */
   async connect() {
+    if (this._closed) throw new Error('connection closed');
     // Open HTTP eagerly (it's a no-op anyway). Defer the WebSocket
     // open until the user actually calls subscribe() — that way an
     // HTTP-only deployment with no WS sibling works for call/publish
@@ -663,6 +665,7 @@ export class RosClient {
 
   /** Close the underlying link(s). */
   async close() {
+    this._closed = true;
     const tasks = [];
     if (this._http) tasks.push(this._http.close());
     if (this._wsConnect) {
@@ -686,6 +689,7 @@ export class RosClient {
    * structured error if no WS URL is available or the open fails.
    */
   async _ensureWs() {
+    if (this._closed) throw new Error('connection closed');
     if (!this._wsUrl) {
       throw Object.assign(
         new Error(
@@ -748,8 +752,14 @@ export class RosClient {
    * @param {(feedback: *) => void} [options.onFeedback]
    */
   async action(capability, payload, options) {
+    const { onFeedback } = options ?? {};
+    if (onFeedback !== undefined && typeof onFeedback !== 'function') {
+      throw new TypeError(
+        'action(capability, payload, options): onFeedback must be a function'
+      );
+    }
     const ws = await this._ensureWs();
-    return ws.action(capability, payload, options);
+    return ws.action(capability, payload, { onFeedback });
   }
 }
 

--- a/web/index.d.ts
+++ b/web/index.d.ts
@@ -127,14 +127,20 @@ declare module 'rclnodejs/web' {
     close(): Promise<void>;
   }
 
+  export type ActionStatus = 'succeeded' | 'canceled' | 'aborted' | 'unknown';
+
   /**
    * Handle for an in-flight action goal, returned by {@link RosClient.action}.
    *
    * `cancel()` requests cancellation of the goal over WebSocket.
+   * `result` resolves with the ROS payload even when canceled or aborted;
+   * inspect `status` after awaiting it to determine the outcome.
    */
   export interface ActionHandle<TResult = unknown> {
     readonly goalId: string;
     readonly result: Promise<TResult>;
+    /** Undefined until a terminal response; missing/unrecognized status is 'unknown'. */
+    readonly status: ActionStatus | undefined;
     cancel(): Promise<void>;
   }
 

--- a/web/index.d.ts
+++ b/web/index.d.ts
@@ -32,14 +32,14 @@ declare module 'rclnodejs/web' {
   /**
    * Map an in-process rclnodejs message shape to its on-wire JSON shape.
    *
-   * The Web Runtime serialises messages as JSON with one transformation:
-   * 64-bit integer fields (`bigint` in the generated types) become the
-   * string `"<n>n"` so they survive `JSON.stringify`. Everything else
-   * passes through unchanged.
+   * The Web Runtime serialises typed arrays as regular JSON arrays.
+   * 64-bit integer fields (`bigint` in the generated types) become
+   * `"<n>n"` strings so they survive `JSON.stringify`.
    *
    * Cases (checked in order):
    *   - `bigint`            → {@link Int64Wire} (the `"<n>n"` string)
    *   - `ReadonlyArray<U>`  → `WireType<U>[]`   (recurse per element)
+   *   - typed arrays        → `WireType<Element>[]`
    *   - `Date`              → `string`          (ISO string on the wire)
    *   - `object`            → field-wise recursion
    *   - everything else     → passes through unchanged
@@ -56,14 +56,15 @@ declare module 'rclnodejs/web' {
   export type WireType<T> = [T] extends [bigint] ? Int64Wire : _WireRecurse<T>;
 
   /** Recursion step for {@link WireType}; pulled out to keep the cascade flat. */
-  type _WireRecurse<T> =
-    T extends ReadonlyArray<infer U>
-      ? WireType<U>[]
-      : T extends Date
-        ? string
-        : T extends object
-          ? { [K in keyof T]: WireType<T[K]> }
-          : T;
+  type _WireRecurse<T> = T extends
+    | ReadonlyArray<infer Element>
+    | (ArrayBufferView & { readonly [index: number]: infer Element })
+    ? WireType<Element>[]
+    : T extends Date
+      ? string
+      : T extends object
+        ? { [K in keyof T]: WireType<T[K]> }
+        : T;
 
   // -------- Type-name lookup helpers ----------------------------------
 
@@ -280,12 +281,14 @@ declare module 'rclnodejs/web' {
     action<TName extends ActionName>(
       capability: string,
       goal: ActionGoal<TName>,
-      options?: { onFeedback?: (feedback: ActionFeedback<TName>) => void }
+      options?: {
+        onFeedback?: (feedback: ActionFeedback<TName>) => void;
+      } | null
     ): Promise<ActionHandle<ActionResult<TName>>>;
     action(
       capability: string,
       goal: unknown,
-      options?: { onFeedback?: (feedback: unknown) => void }
+      options?: { onFeedback?: (feedback: unknown) => void } | null
     ): Promise<ActionHandle>;
   }
 

--- a/web/index.d.ts
+++ b/web/index.d.ts
@@ -98,6 +98,24 @@ declare module 'rclnodejs/web' {
     InstanceType<_SvcCtor<TName>['Response']>
   >;
 
+  /** ROS 2 action type names available in the sourced environment. */
+  export type ActionName = keyof import('rclnodejs').ActionsMap;
+
+  /** Wire shape of the named action's goal request. */
+  export type ActionGoal<TName extends ActionName> = WireType<
+    import('rclnodejs').ActionGoal<TName>
+  >;
+
+  /** Wire shape of the named action's feedback message. */
+  export type ActionFeedback<TName extends ActionName> = WireType<
+    import('rclnodejs').ActionFeedback<TName>
+  >;
+
+  /** Wire shape of the named action's result. */
+  export type ActionResult<TName extends ActionName> = WireType<
+    import('rclnodejs').ActionResult<TName>
+  >;
+
   // -------- SDK ------------------------------------------------------
 
   /**
@@ -107,6 +125,17 @@ declare module 'rclnodejs/web' {
   export interface Subscription {
     readonly subId: string;
     close(): Promise<void>;
+  }
+
+  /**
+   * Handle for an in-flight action goal, returned by {@link RosClient.action}.
+   *
+   * `cancel()` requests cancellation of the goal over WebSocket.
+   */
+  export interface ActionHandle<TResult = unknown> {
+    readonly goalId: string;
+    readonly result: Promise<TResult>;
+    cancel(): Promise<void>;
   }
 
   export interface ConnectOptions {
@@ -228,6 +257,30 @@ declare module 'rclnodejs/web' {
       capability: string,
       callback: (msg: unknown) => void
     ): Promise<Subscription>;
+
+    /**
+     * Send an action goal.
+     *
+     * @example Typed via the ROS action type name (preferred)
+     *   const goal = await ros.action<'example_interfaces/action/Fibonacci'>(
+     *     '/fibonacci', { order: 5 }, { onFeedback: (fb) => console.log(fb) }
+     *   );
+     *   const result = await goal.result;
+     *
+     * @example Untyped (capability with a custom type not in the
+     *          generated maps, or quick prototyping)
+     *   const goal = await ros.action('/whatever', { foo: 1 });
+     */
+    action<TName extends ActionName>(
+      capability: string,
+      goal: ActionGoal<TName>,
+      options?: { onFeedback?: (feedback: ActionFeedback<TName>) => void }
+    ): Promise<ActionHandle<ActionResult<TName>>>;
+    action(
+      capability: string,
+      goal: unknown,
+      options?: { onFeedback?: (feedback: unknown) => void }
+    ): Promise<ActionHandle>;
   }
 
   /**


### PR DESCRIPTION
This PR adds ROS 2 **action** support to the `rclnodejs/web` WebSocket SDK and its type surface, enabling browser/runtime clients to send goals, receive feedback, await results, and request cancellation via the runtime’s action capability dispatch.

**Changes:**
- Support typed goal submission through `RosClient.action()`, deliver feedback through `onFeedback`, and return an action handle after goal acceptance with a result promise and per-goal cancellation.
- Expose read-only terminal status so callers can distinguish `succeeded`, `canceled`, `aborted`, and `unknown` outcomes without changing result payloads. Status remains undefined until a terminal response arrives.
- Support cancellation requests through `cancel()`, resolving to `undefined` when accepted and propagating rejection errors to match the `Promise<void>` contract.
- Accept null and undefined action options, reject invalid feedback callbacks before networking, and isolate exceptions thrown by valid callbacks so result delivery continues.
- Reject actions during and after client closure, including clients whose lazy WebSocket has not opened. Clear pending action state on connection loss and avoid resubmitting goals after reconnection.
- Map native numeric typed arrays to JSON number arrays and BigInt typed arrays to encoded string arrays in the public wire types.
- Add runtime and TypeScript regression coverage for goal submission, feedback, cancellation, terminal status, connection lifecycle, invalid options, and typed goal validation.

Fix: #1579